### PR TITLE
[LFXV2-130] Committee Service - health checkers

### DIFF
--- a/cmd/committee-api/main.go
+++ b/cmd/committee-api/main.go
@@ -64,6 +64,7 @@ func main() {
 	projectRetriever := service.ProjectRetrieverImpl(ctx)
 	committeePublisher := service.CommitteePublisherImpl(ctx)
 	authService := service.AuthServiceImpl(ctx)
+	storage := service.CommitteeReaderWriterImpl(ctx)
 
 	// Initialize the service with use cases
 	createCommitteeUseCase := usecaseSvc.NewCommitteeWriterOrchestrator(
@@ -77,7 +78,7 @@ func main() {
 		usecaseSvc.WithCommitteeReader(committeeRetriever),
 	)
 
-	committeeServiceSvc := service.NewCommitteeService(createCommitteeUseCase, readCommitteeUseCase, authService)
+	committeeServiceSvc := service.NewCommitteeService(createCommitteeUseCase, readCommitteeUseCase, authService, storage)
 
 	// Wrap the services in endpoints that can be invoked from other services
 	// potentially running in different processes.

--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -243,3 +243,33 @@ func CommitteePublisherImpl(ctx context.Context) port.CommitteePublisher {
 
 	return committeePublisher
 }
+
+// CommitteeReaderWriterImpl initializes the committee reader/writer implementation based on the repository source
+func CommitteeReaderWriterImpl(ctx context.Context) port.CommitteeReaderWriter {
+	var storage port.CommitteeReaderWriter
+
+	// Repository implementation configuration
+	repoSource := os.Getenv("REPOSITORY_SOURCE")
+	if repoSource == "" {
+		repoSource = "nats"
+	}
+
+	switch repoSource {
+	case "mock":
+		slog.InfoContext(ctx, "initializing mock committee storage")
+		storage = infrastructure.NewMockCommitteeReaderWriter(infrastructure.NewMockRepository())
+
+	case "nats":
+		slog.InfoContext(ctx, "initializing NATS committee storage")
+		natsClient := natsStorageImpl(ctx)
+		if natsClient == nil {
+			log.Fatalf("failed to initialize NATS client")
+		}
+		storage = natsClient
+
+	default:
+		log.Fatalf("unsupported committee storage implementation: %s", repoSource)
+	}
+
+	return storage
+}

--- a/internal/domain/port/committee.go
+++ b/internal/domain/port/committee.go
@@ -3,8 +3,12 @@
 
 package port
 
+import "context"
+
 // CommitteeReaderWriter provides access to committee reading and writing operations
 type CommitteeReaderWriter interface {
 	CommitteeReader
 	CommitteeWriter
+
+	IsReady(ctx context.Context) error
 }

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -399,6 +399,12 @@ type MockCommitteeReaderWriter struct {
 	port.CommitteeWriter
 }
 
+// IsReady checks if the committee reader writer is ready
+func (m *MockCommitteeReaderWriter) IsReady(ctx context.Context) error {
+	// Mock implementation - always return nil (ready)
+	return nil
+}
+
 // NewMockProjectRetriever creates a mock project retriever
 func NewMockProjectRetriever(mock *MockRepository) port.ProjectReader {
 	return &MockProjectRetriever{mock: mock}

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -227,6 +227,10 @@ func (s *storage) Delete(ctx context.Context, uid string, revision uint64) error
 	return nil
 }
 
+func (s *storage) IsReady(ctx context.Context) error {
+	return s.client.IsReady(ctx)
+}
+
 func NewStorage(client *NATSClient) port.CommitteeReaderWriter {
 	return &storage{
 		client: client,


### PR DESCRIPTION
## Overview

* https://linuxfoundation.atlassian.net/browse/LFXV2-130

This pull request enhances the committee API service by introducing a readiness check for the underlying committee storage and refactoring service initialization to support pluggable storage backends. The main changes ensure the service can report its readiness based on the availability of its storage layer, improving reliability and observability for deployments.

### Validation

#### ✅ Health Check Implementation Verified

**Evidence from Kubernetes Pod Status:**

##### Pod Readiness Status
```
Status:           Running
Ready:            True
ContainersReady:  True
```

##### Active Health Check Configuration
- **Readiness**: `http-get http://:web/readyz` (10s interval, 1s timeout)
- **Startup**: `http-get http://:web/readyz` (1s interval, 30 failure threshold)  
- **Liveness**: `http-get http://:web/livez` (15s interval, 3 failure threshold)

##### Implementation Details
- `/readyz` endpoint performs NATS connectivity validation via `storage.IsReady()`
- `/livez` endpoint provides simple service availability check
- Both endpoints return `200 OK` with "OK\n" response body on success
- Readiness probe returns `503 Service Unavailable` if NATS connection fails

##### Runtime Verification
- Pod successfully started and maintained `Ready: True` status for 75+ seconds
- No probe failure events in Kubernetes events log
- All health check endpoints responding successfully

**✅ Readiness probes are working correctly and validating service dependencies (NATS) before marking pod as ready for traffic.**