### PR TITLE
feat: Add NATS event publishing for committee member lifecycle operations

### DIFF
--- a/internal/domain/model/committee_message.go
+++ b/internal/domain/model/committee_message.go
@@ -168,7 +168,6 @@ func (e *CommitteeEvent) buildCommitteeMembers(ctx context.Context, resource Res
 		return nil, fmt.Errorf("unsupported action: %s", action)
 	}
 
-	// For both created and deleted actions, we expect the full CommitteeMember object
 	member, ok := input.(*CommitteeMember)
 	if !ok {
 		slog.ErrorContext(ctx, "invalid input type for CommitteeEvent",

--- a/internal/domain/model/committee_message.go
+++ b/internal/domain/model/committee_message.go
@@ -157,19 +157,16 @@ func (e *CommitteeEvent) buildCommitteeMembers(ctx context.Context, resource Res
 	switch action {
 	case ActionCreated:
 		e.Subject = constants.CommitteeMemberCreatedSubject
-		e.buildEventType(resource, action)
 	case ActionUpdated:
 		e.Subject = constants.CommitteeMemberUpdatedSubject
-		e.buildEventType(resource, action)
 	case ActionDeleted:
 		e.Subject = constants.CommitteeMemberDeletedSubject
-		e.buildEventType(resource, action)
 	default:
 		return nil, fmt.Errorf("unsupported action: %s", action)
 	}
 
 	member, ok := input.(*CommitteeMember)
-	if !ok {
+	if !ok || member == nil {
 		slog.ErrorContext(ctx, "invalid input type for CommitteeEvent",
 			"resource", resource,
 			"action", action,
@@ -178,6 +175,7 @@ func (e *CommitteeEvent) buildCommitteeMembers(ctx context.Context, resource Res
 		)
 		return nil, fmt.Errorf("invalid input type, got %T", input)
 	}
+	e.buildEventType(resource, action)
 	e.Data = member
 
 	return e, nil

--- a/internal/domain/port/committee_publisher.go
+++ b/internal/domain/port/committee_publisher.go
@@ -11,4 +11,5 @@ import (
 type CommitteePublisher interface {
 	Indexer(ctx context.Context, subject string, message any) error
 	Access(ctx context.Context, subject string, message any) error
+	Event(ctx context.Context, subject string, event any) error
 }

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -789,6 +789,15 @@ func (p *MockCommitteePublisher) Access(ctx context.Context, subject string, mes
 	return nil
 }
 
+// Event simulates publishing an event message
+func (p *MockCommitteePublisher) Event(ctx context.Context, subject string, event any) error {
+	slog.InfoContext(ctx, "mock publisher: event message published",
+		"subject", subject,
+		"message_type", "event",
+	)
+	return nil
+}
+
 // NewMockCommitteePublisher creates a mock committee publisher
 func NewMockCommitteePublisher() port.CommitteePublisher {
 	return &MockCommitteePublisher{}

--- a/internal/infrastructure/nats/messaging_publish.go
+++ b/internal/infrastructure/nats/messaging_publish.go
@@ -66,6 +66,10 @@ func (m *messagePublisher) Access(ctx context.Context, subject string, message a
 	return m.publish(ctx, subject, message, "access")
 }
 
+func (m *messagePublisher) Event(ctx context.Context, subject string, event any) error {
+	return m.publish(ctx, subject, event, "event")
+}
+
 // NewMessagePublish creates a new message publish service
 func NewMessagePublisher(client *NATSClient) port.CommitteePublisher {
 	return &messagePublisher{

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -666,6 +666,7 @@ func (uc *committeeWriterOrchestrator) publishMemberMessages(ctx context.Context
 	case model.ActionCreated, model.ActionUpdated:
 		// Add tags for create/update operations (when we have the full member data)
 		indexerMessage.Tags = data.Tags()
+		indexerMessage.Data = data
 	case model.ActionDeleted:
 		// Indexer message only expects the UID for deleted operations
 		indexerMessage.Data = data.UID

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -671,7 +671,7 @@ func (uc *committeeWriterOrchestrator) publishMemberMessages(ctx context.Context
 		indexerMessage.Data = data.UID
 	}
 
-	indexerMessageBuild, errBuildIndexerMessage := indexerMessage.Build(ctx, data)
+	indexerMessageBuild, errBuildIndexerMessage := indexerMessage.Build(ctx, indexerMessage.Data)
 	if errBuildIndexerMessage != nil {
 		slog.ErrorContext(ctx, "failed to build member indexer message",
 			"error", errBuildIndexerMessage,
@@ -681,9 +681,11 @@ func (uc *committeeWriterOrchestrator) publishMemberMessages(ctx context.Context
 	}
 
 	// Build event message for the member
-	eventMessage := model.CommitteeEvent{}
+	eventMessage := model.CommitteeEvent{
+		Data: data,
+	}
 
-	eventMessageBuild, errBuildEventMessage := eventMessage.Build(ctx, model.ResourceCommitteeMember, action, data)
+	eventMessageBuild, errBuildEventMessage := eventMessage.Build(ctx, model.ResourceCommitteeMember, action, eventMessage.Data)
 	if errBuildEventMessage != nil {
 		slog.ErrorContext(ctx, "failed to build member event message",
 			"error", errBuildEventMessage,

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -666,9 +666,16 @@ func TestCommitteeWriterOrchestrator_publishMemberMessages(t *testing.T) {
 			},
 		},
 		{
-			name:   "publish delete message with uid string",
+			name:   "publish delete message with member data",
 			action: model.ActionDeleted,
-			data:   "member-789",
+			data: &model.CommitteeMember{
+				CommitteeMemberBase: model.CommitteeMemberBase{
+					UID:          "member-789",
+					CommitteeUID: "committee-123",
+					Email:        "deleted@example.com",
+					Username:     "deleteduser",
+				},
+			},
 		},
 	}
 
@@ -677,7 +684,8 @@ func TestCommitteeWriterOrchestrator_publishMemberMessages(t *testing.T) {
 			orchestrator, _, _ := setupMemberWriterTest()
 
 			ctx := context.Background()
-			err := orchestrator.publishMemberMessages(ctx, tt.action, tt.data)
+			member := tt.data.(*model.CommitteeMember)
+			err := orchestrator.publishMemberMessages(ctx, tt.action, member)
 
 			// Should succeed with mock publisher
 			assert.NoError(t, err)

--- a/internal/service/committee_writer_test.go
+++ b/internal/service/committee_writer_test.go
@@ -841,6 +841,11 @@ func (p *MockCommitteePublisherWithError) Access(ctx context.Context, subject st
 	return nil
 }
 
+func (p *MockCommitteePublisherWithError) Event(ctx context.Context, subject string, event any) error {
+	// For testing purposes, we don't fail on events
+	return nil
+}
+
 func TestCommitteeWriterOrchestrator_Create_PublishingErrors(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -39,3 +39,18 @@ const (
 	// The subject is of the form: lfx.delete_all_access.committee
 	DeleteAllAccessCommitteeSubject = "lfx.delete_all_access.committee"
 )
+
+// Event subjects emitted by the committee service for general consumption by any service
+const (
+	// CommitteeMemberCreatedSubject is the subject for committee member creation events.
+	// The subject is of the form: lfx.committee-api.member_created
+	CommitteeMemberCreatedSubject = "lfx.committee-api.committee_member.created"
+
+	// CommitteeMemberDeletedSubject is the subject for committee member deletion events.
+	// The subject is of the form: lfx.committee-api.committee_member.deleted
+	CommitteeMemberDeletedSubject = "lfx.committee-api.committee_member.deleted"
+
+	// CommitteeMemberUpdatedSubject is the subject for committee member update events.
+	// The subject is of the form: lfx.committee-api.committee_member.updated
+	CommitteeMemberUpdatedSubject = "lfx.committee-api.committee_member.updated"
+)


### PR DESCRIPTION
## Summary
Implements NATS event publishing for committee member lifecycle operations (create, update, delete) to enable other services to subscribe to member events.

## Changes
- Add `CommitteeEvent` struct and `ResourceType` constants for generic event handling
- Add `Event()` method to `CommitteePublisher` interface and implementations  
- Add NATS subjects for member created, updated, and deleted events:
  - `lfx.committee-api.committee_member.created`
  - `lfx.committee-api.committee_member.updated`
  - `lfx.committee-api.committee_member.deleted`
- Publish events concurrently with indexer messages for all member operations
- Include full member data in all event payloads (create, update, delete)
- Update mock publishers and tests to support new event functionality

## Test plan
- [x] All existing tests continue to pass
- [x] New tests verify event publishing for create, update, delete operations
- [x] Mock publishers correctly simulate event publishing
- [x] Events include complete member data in all scenarios

## Manual testing

### POST committee member

```
{
    "first_name": "John",
    "last_name": "Doe",
    "email": "john.doe@linuxfoundation.org",
    "username": "john.doe",
    "job_title": "Software Engineer",
    "voting": {
        "status": "Voting Rep"
    }
}
```

```
[#1] Received on "lfx.committee-api.committee_member.created"
{"event_type":"committee_member.created","subject":"lfx.committee-api.committee_member.created","timestamp":"2025-09-03T19:38:33.174186Z","version":"1","data":{"uid":"9c41f921-2af5-4970-a5e9-fbda7c27f1c2","username":"john.doe","email":"john.doe@linuxfoundation.org","first_name":"John","last_name":"Doe","job_title":"Software Engineer","role":{"name":""},"appointed_by":"None","status":"Active","voting":{"status":"Voting Rep"},"organization":{"name":""},"committee_uid":"0edfb825-b369-40fd-a309-8cf76728e1e9","committee_name":"Test Committee 5","created_at":"2025-09-03T12:38:33.152275-07:00","updated_at":"2025-09-03T12:38:33.152275-07:00"}}
```

### PUT committee member

```
{
    "uid": "9c41f921-2af5-4970-a5e9-fbda7c27f1c2",
    "committee_uid": "0edfb825-b369-40fd-a309-8cf76728e1e9",
    "committee_name": "Test Committee 5",
    "username": "john.doe",
    "email": "john.doe@linuxfoundation.org",
    "first_name": "John",
    "last_name": "Doe",
    "job_title": "Software Engineer",
    "role": {
        "name": "None"
    },
    "appointed_by": "None",
    "status": "Active",
    "voting": {
        "status": "Voting Rep"
    }
}
```

```
[#3] Received on "lfx.committee-api.committee_member.updated"
{"event_type":"committee_member.updated","subject":"lfx.committee-api.committee_member.updated","timestamp":"2025-09-03T19:41:13.053843Z","version":"1","data":{"uid":"9c41f921-2af5-4970-a5e9-fbda7c27f1c2","username":"john.doe","email":"john.doe@linuxfoundation.org","first_name":"John","last_name":"Doe","job_title":"Software Engineer","role":{"name":"None"},"appointed_by":"None","status":"Active","voting":{"status":"Voting Rep"},"organization":{"name":""},"committee_uid":"0edfb825-b369-40fd-a309-8cf76728e1e9","committee_name":"Test Committee 5","created_at":"2025-09-03T12:38:33.152275-07:00","updated_at":"2025-09-03T12:41:13.049061-07:00"}}
```

### DELETE committee member

```
<no content>
```

```
[#5] Received on "lfx.committee-api.committee_member.deleted"
{"event_type":"committee_member.deleted","subject":"lfx.committee-api.committee_member.deleted","timestamp":"2025-09-03T19:41:40.532446Z","version":"1","data":{"uid":"9c41f921-2af5-4970-a5e9-fbda7c27f1c2","username":"john.doe","email":"john.doe@linuxfoundation.org","first_name":"John","last_name":"Doe","job_title":"Software Engineer","role":{"name":"None"},"appointed_by":"None","status":"Active","voting":{"status":"Voting Rep"},"organization":{"name":""},"committee_uid":"0edfb825-b369-40fd-a309-8cf76728e1e9","committee_name":"Test Committee 5","created_at":"2025-09-03T12:38:33.152275-07:00","updated_at":"2025-09-03T12:41:13.049061-07:00"}}
```

🤖 Generated with [Claude Code](https://claude.ai/code)