### PR TITLE
add heimdall middleware

### DIFF
--- a/charts/lfx-v2-committee-service/Chart.yaml
+++ b/charts/lfx-v2-committee-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-committee-service
 description: LFX Platform V2 Committee Service chart
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "latest"

--- a/charts/lfx-v2-committee-service/templates/heimdall-middleware.yaml
+++ b/charts/lfx-v2-committee-service/templates/heimdall-middleware.yaml
@@ -1,0 +1,35 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+{{ if .Values.heimdall.add_middleware }}
+---
+# Heimdall middleware with body forwarding capability
+# This is the default middleware that should be used in most cases, particularly
+# when parentRef requiring authentication is in the request body.
+# Note: For routes handling very large payloads (like file uploads), consider using
+# the lighter-weight middleware below to reduce overhead.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: heimdall-forward-body
+  namespace: {{ .Release.Namespace }}
+spec:
+  forwardAuth:
+    address: "{{ .Values.heimdall.url }}"
+    authResponseHeaders:
+      - Authorization
+    forwardBody: true
+---
+# Alternative Heimdall middleware without body forwarding
+# Use this middleware only for routes where body inspection isn't required for authentication
+# and when dealing with large payloads where forwarding the entire body would be inefficient.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: heimdall
+  namespace: {{ .Release.Namespace }}
+spec:
+  forwardAuth:
+    address: "{{ .Values.heimdall.url }}"
+    authResponseHeaders:
+      - Authorization
+{{- end }}

--- a/charts/lfx-v2-committee-service/values.yaml
+++ b/charts/lfx-v2-committee-service/values.yaml
@@ -112,6 +112,9 @@ heimdall:
   url: http://lfx-platform-heimdall.lfx.svc.cluster.local:4456
   # jwksUrl is the URL to the JSON Web Key Set endpoint for JWT validation
   jwksUrl: http://lfx-platform-heimdall.lfx.svc.cluster.local:4457/.well-known/jwks
+  # add_middleware determines whether or not the middleware is installed. If not managed
+  # by another service or helm chart then it is needed.
+  add_middleware: false
 
 # authelia is the configuration for the Authelia server
 authelia:


### PR DESCRIPTION
This is needed if this service is installed in a namespace that doesn't otherwise have the middleware, since there is no current way to reference a middleware in the gateway api spec outside of the current namespace.