### PR TITLE
[LFXV2-412] Add NATS message handler for listing committee members

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The LFX v2 Committee Service is a RESTful API service that manages committees an
 ## Key Features
 
 - **RESTful API**: Full CRUD operations for committee and committee member management
+- **NATS Messaging**: Inter-service communication for committee data retrieval via NATS subjects
 - **Committee Hierarchies**: Support for parent-child committee relationships
 - **Member Management**: Comprehensive committee member operations including roles, voting status, and organization details
 - **Project Integration**: Committees are associated with projects for organizational structure

--- a/cmd/committee-api/README.md
+++ b/cmd/committee-api/README.md
@@ -28,6 +28,44 @@ This service contains the following API endpoints:
   - `PUT /{member_uid}`: replace an existing committee member (requires complete resource with all fields)
   - `DELETE /{member_uid}`: remove a member from a committee
 
+## NATS Messaging Interface
+
+In addition to HTTP endpoints, this service provides NATS messaging capabilities for inter-service communication. Other LFX services can send requests via NATS subjects to retrieve committee data.
+
+### Supported NATS Subjects
+
+| Subject | Purpose | Request Format | Response Format |
+|---------|---------|----------------|----------------|
+| `lfx.committee-api.get_name` | Get committee name by UID | Committee UID (string) | Committee name (string) |
+| `lfx.committee-api.list_members` | List all members of a committee | Committee UID (string) | JSON array of committee members |
+
+### Usage Examples
+
+#### Get Committee Name
+```bash
+# Send request with committee UID as message data
+nats request lfx.committee-api.get_name "061a110a-7c38-4cd3-bfcf-fc8511a37f35"
+# Response: "Technical Steering Committee"
+```
+
+#### List Committee Members
+```bash
+# Send request with committee UID as message data
+nats request lfx.committee-api.list_members "061a110a-7c38-4cd3-bfcf-fc8511a37f35"
+# Response: JSON array of CommitteeMember objects
+```
+
+### Error Handling
+
+NATS message responses follow this format:
+- **Success**: Direct data response (string for name, JSON for members)
+- **Error**: JSON object with error message: `{"error": "error description"}`
+
+Common error scenarios:
+- Invalid UUID format: `{"error": "invalid UUID format"}`
+- Committee not found: `{"error": "committee with UID <uid> not found"}`
+- Committee has no members: `[]` (empty array for list_members)
+
 ## File Structure
 
 ```bash

--- a/cmd/committee-api/service/committee_handler.go
+++ b/cmd/committee-api/service/committee_handler.go
@@ -26,7 +26,8 @@ func (mhs *MessageHandlerService) HandleMessage(ctx context.Context, msg port.Tr
 	slog.DebugContext(ctx, "handling NATS message")
 
 	handlers := map[string]func(ctx context.Context, msg port.TransportMessenger) ([]byte, error){
-		constants.CommitteeGetNameSubject: mhs.handleCommitteeGetName,
+		constants.CommitteeGetNameSubject:     mhs.handleCommitteeGetName,
+		constants.CommitteeListMembersSubject: mhs.handleCommitteeListMembers,
 	}
 
 	handler, ok := handlers[subject]
@@ -57,6 +58,10 @@ func (mhs *MessageHandlerService) HandleMessage(ctx context.Context, msg port.Tr
 
 func (mhs *MessageHandlerService) handleCommitteeGetName(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 	return mhs.messageHandler.HandleCommitteeGetAttribute(ctx, msg, "name")
+}
+
+func (mhs *MessageHandlerService) handleCommitteeListMembers(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
+	return mhs.messageHandler.HandleCommitteeListMembers(ctx, msg)
 }
 
 func (mhs *MessageHandlerService) respondWithError(ctx context.Context, msg port.TransportMessenger, errorMsg string) {

--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -308,7 +308,8 @@ func QueueSubscriptions(ctx context.Context, committeeReader port.CommitteeReade
 
 	// Start subscriptions for each subject
 	subjects := map[string]func(context.Context, port.TransportMessenger){
-		constants.CommitteeGetNameSubject: messageHandlerService.HandleMessage,
+		constants.CommitteeGetNameSubject:     messageHandlerService.HandleMessage,
+		constants.CommitteeListMembersSubject: messageHandlerService.HandleMessage,
 		// Add more subjects here as needed
 	}
 

--- a/internal/domain/port/committee_member_reader.go
+++ b/internal/domain/port/committee_member_reader.go
@@ -15,4 +15,6 @@ type CommitteeMemberReader interface {
 	GetMember(ctx context.Context, uid string) (*model.CommitteeMember, uint64, error)
 	// GetMemberRevision retrieves the revision number for a committee member
 	GetMemberRevision(ctx context.Context, uid string) (uint64, error)
+	// ListMembers retrieves all members for a given committee UID
+	ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
 }

--- a/internal/domain/port/message_handler.go
+++ b/internal/domain/port/message_handler.go
@@ -9,4 +9,6 @@ import "context"
 type MessageHandler interface {
 	// HandleCommitteeGetAttribute handles committee get attribute messages
 	HandleCommitteeGetAttribute(ctx context.Context, msg TransportMessenger, attribute string) ([]byte, error)
+	// HandleCommitteeListMembers handles committee list members messages
+	HandleCommitteeListMembers(ctx context.Context, msg TransportMessenger) ([]byte, error)
 }

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -192,6 +192,10 @@ func (r *TestMockCommitteeReader) GetMemberRevision(ctx context.Context, uid str
 	return 0, errs.NewNotFound("member not found")
 }
 
+func (r *TestMockCommitteeReader) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
+	return []*model.CommitteeMember{}, errs.NewNotFound("not implemented for this test")
+}
+
 func TestCommitteeWriterOrchestrator_CreateMember(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -174,16 +174,6 @@ func (rc *committeeReaderOrchestrator) ListMembers(ctx context.Context, committe
 		"committee_uid", committeeUID,
 	)
 
-	// First, verify that the committee exists
-	_, _, err := rc.committeeReader.GetBase(ctx, committeeUID)
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee base - committee does not exist",
-			"error", err,
-			"committee_uid", committeeUID,
-		)
-		return nil, err
-	}
-
 	// Get all committee members from storage
 	members, err := rc.committeeReader.ListMembers(ctx, committeeUID)
 	if err != nil {

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -12,6 +12,10 @@ const (
 	// The subject is of the form: lfx.committee-api.get_name
 	CommitteeGetNameSubject = "lfx.committee-api.get_name"
 
+	// CommitteeListMembersSubject is the subject for listing committee members.
+	// The subject is of the form: lfx.committee-api.list_members
+	CommitteeListMembersSubject = "lfx.committee-api.list_members"
+
 	// ProjectGetNameSubject is the subject for the project get name.
 	// The subject is of the form: lfx.projects-api.get_name
 	ProjectGetNameSubject = "lfx.projects-api.get_name"


### PR DESCRIPTION
## Summary

Implements a new NATS message handler to support listing committee members via the `lfx.committee-api.list_members` subject. This enables the meeting service to retrieve committee member lists for automatic meeting registration.

## Changes

### Core Implementation
- **New NATS subject**: `lfx.committee-api.list_members`
- **Interface extensions**: Added `ListMembers` method to `CommitteeMemberReader` and service interfaces
- **Storage implementation**: NATS key-value store implementation with key iteration and committee UID filtering
- **Message handler**: Complete request processing with JSON response and proper error handling
- **Service routing**: Wired up new handler in committee service routing and NATS subscriptions

### Documentation
- **NATS Messaging Interface**: Added comprehensive documentation with usage examples
- **Updated README**: Added NATS messaging to key features list

### Development Tools
- **Makefile enhancements**: Added new recipes for formatting (`fmt`), license checking (`license-check`), and comprehensive validation (`check`)

## Usage

Other services can now send NATS requests to list committee members:

```bash
nats request lfx.committee-api.list_members "061a110a-7c38-4cd3-bfcf-fc8511a37f35"
# Returns: JSON array of CommitteeMember objects
```

## Test Plan

- [x] All existing tests pass
- [x] Added mock implementations for new interface methods
- [x] Code builds successfully
- [x] NATS message handler follows existing patterns

## Manual Testing

NATS message request to list members for a committee that has two members:

```
nats request lfx.committee-api.list_members 0edfb825-b369-40fd-a309-8cf76728e1e9
16:28:25 Sending request on "lfx.committee-api.list_members"
16:28:26 Received with rtt 33.245666ms
[{"uid":"2bb7aedd-4864-4425-ba38-a2ffad94036a","username":"andrest50dev","email":"atobon@linuxfoundation.org","first_name":"Andres","last_name":"Tobon","job_title":"Software Engineer","role":{"name":""},"appointed_by":"None","status":"Active","voting":{"status":"Voting Rep"},"organization":{"name":""},"committee_uid":"0edfb825-b369-40fd-a309-8cf76728e1e9","committee_name":"Test Committee 5","created_at":"2025-09-03T11:51:07.42868-07:00","updated_at":"2025-09-03T11:51:07.42868-07:00"},{"uid":"a7308249-30f5-4e71-b4f7-bf6b08adae8c","username":"andrest50dev","email":"atobon2@linuxfoundation.org","first_name":"Andres","last_name":"Tobon","job_title":"Software Engineer","role":{"name":""},"appointed_by":"None","status":"Active","voting":{"status":"Voting Rep"},"organization":{"name":""},"committee_uid":"0edfb825-b369-40fd-a309-8cf76728e1e9","committee_name":"Test Committee 5","created_at":"2025-09-03T11:51:58.839702-07:00","updated_at":"2025-09-03T11:51:58.839702-07:00"}]
```

NATS message request to list members for a committee that doesn't exist:

```
nats request lfx.committee-api.list_members 0edfb825-b369-40fd-a309-8cf76728e1e8
16:30:12 Sending request on "lfx.committee-api.list_members"
16:30:12 Received with rtt 24.64075ms
{"error":"committee not found: committee UID: 0edfb825-b369-40fd-a309-8cf76728e1e8"}
```

## Related

- **Jira**: https://linuxfoundation.atlassian.net/browse/LFXV2-412

🤖 Generated with [Claude Code](https://claude.ai/code)