### PR TITLE
bump chart version to 0.2.4

### DIFF
--- a/charts/lfx-v2-committee-service/Chart.yaml
+++ b/charts/lfx-v2-committee-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-committee-service
 description: LFX Platform V2 Committee Service chart
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "latest"


### PR DESCRIPTION
## Summary
- Bump Helm chart version from 0.2.3 to 0.2.4

🤖 Generated with [Claude Code](https://claude.ai/code)