### PR TITLE
Update OpenAPI paths to use _committees prefix

### DIFF
--- a/charts/lfx-v2-committee-service/Chart.yaml
+++ b/charts/lfx-v2-committee-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-committee-service
 description: LFX Platform V2 Committee Service chart
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "latest"

--- a/charts/lfx-v2-committee-service/templates/httproute.yaml
+++ b/charts/lfx-v2-committee-service/templates/httproute.yaml
@@ -21,6 +21,9 @@ spec:
     - path:
         type: PathPrefix
         value: /committees/
+    - path:
+        type: PathPrefix
+        value: /_committees/
     {{- if .Values.heimdall.enabled }}
     filters:
     - type: ExtensionRef

--- a/charts/lfx-v2-committee-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-committee-service/templates/ruleset.yaml
@@ -8,6 +8,27 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
+    - id: "rule:lfx:lfx-v2-committee-service:openapi:get"
+      match:
+        methods:
+          - GET
+          - HEAD
+        routes:
+          - path: /_committees/openapi.json
+          - path: /_committees/openapi.yaml
+          - path: /_committees/openapi3.json
+          - path: /_committees/openapi3.yaml
+      execute:
+        - authenticator: oidc
+        - authenticator: anonymous_authenticator
+        {{- if .Values.app.use_oidc_contextualizer }}
+        - contextualizer: oidc_contextualizer
+        {{- end }}
+        - authorizer: allow_all
+        - finalizer: create_jwt
+          config:
+            values:
+              aud: {{ .Values.app.audience }}
     - id: "rule:lfx:lfx-v2-committee-service:committees:create"
       match:
         methods:

--- a/cmd/committee-api/design/committee.go
+++ b/cmd/committee-api/design/committee.go
@@ -449,16 +449,16 @@ var _ = dsl.Service("committee-service", func() {
 	})
 
 	// Serve the file gen/http/openapi3.json for requests sent to /openapi.json.
-	dsl.Files("/openapi.json", "gen/http/openapi.json", func() {
+	dsl.Files("/_committees/openapi.json", "gen/http/openapi.json", func() {
 		dsl.Meta("swagger:generate", "false")
 	})
-	dsl.Files("/openapi.yaml", "gen/http/openapi.yaml", func() {
+	dsl.Files("/_committees/openapi.yaml", "gen/http/openapi.yaml", func() {
 		dsl.Meta("swagger:generate", "false")
 	})
-	dsl.Files("/openapi3.json", "gen/http/openapi3.json", func() {
+	dsl.Files("/_committees/openapi3.json", "gen/http/openapi3.json", func() {
 		dsl.Meta("swagger:generate", "false")
 	})
-	dsl.Files("/openapi3.yaml", "gen/http/openapi3.yaml", func() {
+	dsl.Files("/_committees/openapi3.yaml", "gen/http/openapi3.yaml", func() {
 		dsl.Meta("swagger:generate", "false")
 	})
 })

--- a/cmd/committee-api/kodata/gen/http/openapi.json
+++ b/cmd/committee-api/kodata/gen/http/openapi.json
@@ -1,0 +1,1 @@
+../../../../../gen/http/openapi.json

--- a/cmd/committee-api/kodata/gen/http/openapi.yaml
+++ b/cmd/committee-api/kodata/gen/http/openapi.yaml
@@ -1,0 +1,1 @@
+../../../../../gen/http/openapi.yaml

--- a/cmd/committee-api/kodata/gen/http/openapi3.json
+++ b/cmd/committee-api/kodata/gen/http/openapi3.json
@@ -1,0 +1,1 @@
+../../../../../gen/http/openapi3.json

--- a/cmd/committee-api/kodata/gen/http/openapi3.yaml
+++ b/cmd/committee-api/kodata/gen/http/openapi3.yaml
@@ -1,0 +1,1 @@
+../../../../../gen/http/openapi3.yaml

--- a/cmd/committee-api/kodata/openapi.json
+++ b/cmd/committee-api/kodata/openapi.json
@@ -1,1 +1,0 @@
-../../../gen/http/openapi.json

--- a/cmd/committee-api/kodata/openapi.yaml
+++ b/cmd/committee-api/kodata/openapi.yaml
@@ -1,1 +1,0 @@
-../../../gen/http/openapi.yaml

--- a/cmd/committee-api/kodata/openapi3.json
+++ b/cmd/committee-api/kodata/openapi3.json
@@ -1,1 +1,0 @@
-../../../gen/http/openapi3.json

--- a/cmd/committee-api/kodata/openapi3.yaml
+++ b/cmd/committee-api/kodata/openapi3.yaml
@@ -1,1 +1,0 @@
-../../../gen/http/openapi3.yaml

--- a/gen/http/committee_service/server/server.go
+++ b/gen/http/committee_service/server/server.go
@@ -98,10 +98,10 @@ func New(
 			{"GetCommitteeMember", "GET", "/committees/{uid}/members/{member_uid}"},
 			{"UpdateCommitteeMember", "PUT", "/committees/{uid}/members/{member_uid}"},
 			{"DeleteCommitteeMember", "DELETE", "/committees/{uid}/members/{member_uid}"},
-			{"Serve gen/http/openapi.json", "GET", "/openapi.json"},
-			{"Serve gen/http/openapi.yaml", "GET", "/openapi.yaml"},
-			{"Serve gen/http/openapi3.json", "GET", "/openapi3.json"},
-			{"Serve gen/http/openapi3.yaml", "GET", "/openapi3.yaml"},
+			{"Serve gen/http/openapi.json", "GET", "/_committees/openapi.json"},
+			{"Serve gen/http/openapi.yaml", "GET", "/_committees/openapi.yaml"},
+			{"Serve gen/http/openapi3.json", "GET", "/_committees/openapi3.json"},
+			{"Serve gen/http/openapi3.yaml", "GET", "/_committees/openapi3.yaml"},
 		},
 		CreateCommittee:         NewCreateCommitteeHandler(e.CreateCommittee, mux, decoder, encoder, errhandler, formatter),
 		GetCommitteeBase:        NewGetCommitteeBaseHandler(e.GetCommitteeBase, mux, decoder, encoder, errhandler, formatter),
@@ -158,10 +158,10 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountGetCommitteeMemberHandler(mux, h.GetCommitteeMember)
 	MountUpdateCommitteeMemberHandler(mux, h.UpdateCommitteeMember)
 	MountDeleteCommitteeMemberHandler(mux, h.DeleteCommitteeMember)
-	MountGenHTTPOpenapiJSON(mux, h.GenHTTPOpenapiJSON)
-	MountGenHTTPOpenapiYaml(mux, h.GenHTTPOpenapiYaml)
-	MountGenHTTPOpenapi3JSON(mux, h.GenHTTPOpenapi3JSON)
-	MountGenHTTPOpenapi3Yaml(mux, h.GenHTTPOpenapi3Yaml)
+	MountGenHTTPOpenapiJSON(mux, http.StripPrefix("/_committees", h.GenHTTPOpenapiJSON))
+	MountGenHTTPOpenapiYaml(mux, http.StripPrefix("/_committees", h.GenHTTPOpenapiYaml))
+	MountGenHTTPOpenapi3JSON(mux, http.StripPrefix("/_committees", h.GenHTTPOpenapi3JSON))
+	MountGenHTTPOpenapi3Yaml(mux, http.StripPrefix("/_committees", h.GenHTTPOpenapi3Yaml))
 }
 
 // Mount configures the mux to serve the committee-service endpoints.
@@ -823,25 +823,25 @@ func appendPrefix(fsys http.FileSystem, prefix string) http.FileSystem {
 }
 
 // MountGenHTTPOpenapiJSON configures the mux to serve GET request made to
-// "/openapi.json".
+// "/_committees/openapi.json".
 func MountGenHTTPOpenapiJSON(mux goahttp.Muxer, h http.Handler) {
-	mux.Handle("GET", "/openapi.json", h.ServeHTTP)
+	mux.Handle("GET", "/_committees/openapi.json", h.ServeHTTP)
 }
 
 // MountGenHTTPOpenapiYaml configures the mux to serve GET request made to
-// "/openapi.yaml".
+// "/_committees/openapi.yaml".
 func MountGenHTTPOpenapiYaml(mux goahttp.Muxer, h http.Handler) {
-	mux.Handle("GET", "/openapi.yaml", h.ServeHTTP)
+	mux.Handle("GET", "/_committees/openapi.yaml", h.ServeHTTP)
 }
 
 // MountGenHTTPOpenapi3JSON configures the mux to serve GET request made to
-// "/openapi3.json".
+// "/_committees/openapi3.json".
 func MountGenHTTPOpenapi3JSON(mux goahttp.Muxer, h http.Handler) {
-	mux.Handle("GET", "/openapi3.json", h.ServeHTTP)
+	mux.Handle("GET", "/_committees/openapi3.json", h.ServeHTTP)
 }
 
 // MountGenHTTPOpenapi3Yaml configures the mux to serve GET request made to
-// "/openapi3.yaml".
+// "/_committees/openapi3.yaml".
 func MountGenHTTPOpenapi3Yaml(mux goahttp.Muxer, h http.Handler) {
-	mux.Handle("GET", "/openapi3.yaml", h.ServeHTTP)
+	mux.Handle("GET", "/_committees/openapi3.yaml", h.ServeHTTP)
 }


### PR DESCRIPTION
- Move OpenAPI endpoints from root paths to /_committees/ prefix
- Update HTTP route configuration to handle new paths
- Reorganize kodata symlinks to match new structure
- Add Heimdall ruleset for OpenAPI endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)