### PR TITLE
Update HTTPRoute and RuleSet with missing fields

### DIFF
--- a/charts/lfx-v2-committee-service/Chart.yaml
+++ b/charts/lfx-v2-committee-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-committee-service
 description: LFX Platform V2 Committee Service chart
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "latest"

--- a/charts/lfx-v2-committee-service/Chart.yaml
+++ b/charts/lfx-v2-committee-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-committee-service
 description: LFX Platform V2 Committee Service chart
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "latest"

--- a/charts/lfx-v2-committee-service/templates/httproute.yaml
+++ b/charts/lfx-v2-committee-service/templates/httproute.yaml
@@ -8,7 +8,9 @@ metadata:
   namespace: {{ .Values.lfx.namespace }}
 spec:
   parentRefs:
-  - name: {{ .Values.traefik.gateway.name }}
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.traefik.gateway.name }}
     namespace: {{ .Values.traefik.gateway.namespace }}
   hostnames:
   - "lfx-api.{{ .Values.lfx.domain }}"
@@ -33,5 +35,8 @@ spec:
         name: heimdall-forward-body
     {{- end }}
     backendRefs:
-    - name: {{ .Chart.Name }}
+    - group: ''
+      kind: Service
+      name: {{ .Chart.Name }}
       port: {{ .Values.service.port }}
+      weight: 1

--- a/charts/lfx-v2-committee-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-committee-service/templates/ruleset.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   rules:
     - id: "rule:lfx:lfx-v2-committee-service:openapi:get"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - GET
@@ -30,6 +31,7 @@ spec:
             values:
               aud: {{ .Values.app.audience }}
     - id: "rule:lfx:lfx-v2-committee-service:committees:create"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - POST
@@ -59,6 +61,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committees:get"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - GET
@@ -85,6 +88,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committee_settings:get"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - GET
@@ -111,6 +115,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committees:update"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - PUT
@@ -137,6 +142,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committee_settings:update"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - PUT
@@ -163,6 +169,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committees:delete"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - DELETE
@@ -191,6 +198,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committee_members:create"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - POST
@@ -217,6 +225,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committee_members:get"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - GET
@@ -243,6 +252,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committee_members:update"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - PUT
@@ -269,6 +279,7 @@ spec:
               aud: {{ .Values.app.audience }}
 
     - id: "rule:lfx:lfx-v2-committee-service:committee_members:delete"
+      allow_encoded_slashes: 'off'
       match:
         methods:
           - DELETE


### PR DESCRIPTION
ArgoCD sees the HTTPRoute and RuleSet resources being out of sync as
the templates are missing some default fields.

Issue: LFXV2-511
Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
