### PR TITLE
LFXV2-526: Update committee member event payload to include old member data

### DIFF
--- a/charts/lfx-v2-committee-service/Chart.yaml
+++ b/charts/lfx-v2-committee-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-committee-service
 description: LFX Platform V2 Committee Service chart
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "latest"

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -643,41 +643,55 @@ func TestCommitteeWriterOrchestrator_publishMemberMessages(t *testing.T) {
 	tests := []struct {
 		name   string
 		action model.MessageAction
-		data   any
+		data   *model.CommitteeMemberMessageData
 	}{
 		{
 			name:   "publish create message with member data",
 			action: model.ActionCreated,
-			data: &model.CommitteeMember{
-				CommitteeMemberBase: model.CommitteeMemberBase{
-					UID:          "member-123",
-					CommitteeUID: "committee-123",
-					Email:        "test@example.com",
-					Username:     "testuser",
+			data: &model.CommitteeMemberMessageData{
+				Member: &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-123",
+						CommitteeUID: "committee-123",
+						Email:        "test@example.com",
+						Username:     "testuser",
+					},
 				},
 			},
 		},
 		{
 			name:   "publish update message with member data",
 			action: model.ActionUpdated,
-			data: &model.CommitteeMember{
-				CommitteeMemberBase: model.CommitteeMemberBase{
-					UID:          "member-456",
-					CommitteeUID: "committee-123",
-					Email:        "updated@example.com",
-					Username:     "updateduser",
+			data: &model.CommitteeMemberMessageData{
+				Member: &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-456",
+						CommitteeUID: "committee-123",
+						Email:        "updated@example.com",
+						Username:     "updateduser",
+					},
+				},
+				OldMember: &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-456",
+						CommitteeUID: "committee-123",
+						Email:        "old@example.com",
+						Username:     "olduser",
+					},
 				},
 			},
 		},
 		{
 			name:   "publish delete message with member data",
 			action: model.ActionDeleted,
-			data: &model.CommitteeMember{
-				CommitteeMemberBase: model.CommitteeMemberBase{
-					UID:          "member-789",
-					CommitteeUID: "committee-123",
-					Email:        "deleted@example.com",
-					Username:     "deleteduser",
+			data: &model.CommitteeMemberMessageData{
+				Member: &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-789",
+						CommitteeUID: "committee-123",
+						Email:        "deleted@example.com",
+						Username:     "deleteduser",
+					},
 				},
 			},
 		},
@@ -688,8 +702,7 @@ func TestCommitteeWriterOrchestrator_publishMemberMessages(t *testing.T) {
 			orchestrator, _, _ := setupMemberWriterTest()
 
 			ctx := context.Background()
-			member := tt.data.(*model.CommitteeMember)
-			err := orchestrator.publishMemberMessages(ctx, tt.action, member)
+			err := orchestrator.publishMemberMessages(ctx, tt.action, tt.data)
 
 			// Should succeed with mock publisher
 			assert.NoError(t, err)


### PR DESCRIPTION
## Summary
Updates the committee member event payload structure to include both old and new member data when a committee member is updated.

## Changes
- Add `CommitteeMemberUpdateEventData` struct with `member_uid`, `old_member`, and `member` fields
- Create `CommitteeMemberMessageData` wrapper for passing old and new member data context
- Modify `buildCommitteeMembers` to handle different input types for update vs create/delete actions  
- Update `publishMemberMessages` to accept new data structure and build appropriate event payload
- Update all call sites to use new `CommitteeMemberMessageData` structure
- Fix test coverage to match new function signatures
- Bump chart version to 0.2.7

## Test plan
- [x] All existing tests pass (20+ test cases)
- [x] New test coverage for update event payload structure
- [x] Backward compatibility maintained for create and delete operations
- [x] Clean compilation with no errors
- [x] Type safety with proper input validation

## Ticket
https://linuxfoundation.atlassian.net/browse/LFXV2-526

## Impact
The event message now includes both old and new member data when a committee member is updated, enabling consumers to track what changed during member updates while maintaining existing behavior for create and delete operations.

🤖 Generated with [Claude Code](https://claude.ai/code)