### PR TITLE
[LFXV2-593] fix ruleset.yaml with openfga disabled

### DIFF
--- a/charts/lfx-v2-committee-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-committee-service/templates/ruleset.yaml
@@ -48,9 +48,11 @@ spec:
             values:
               relation: writer
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -76,7 +78,7 @@ spec:
             values:
               relation: viewer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -102,7 +104,7 @@ spec:
             values:
               relation: auditor
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -128,7 +130,7 @@ spec:
             values:
               relation: writer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -154,7 +156,7 @@ spec:
             values:
               relation: writer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -180,9 +182,11 @@ spec:
             values:
               relation: owner
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{- else }}
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -208,7 +212,7 @@ spec:
             values:
               relation: writer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -234,7 +238,7 @@ spec:
             values:
               relation: viewer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -260,7 +264,7 @@ spec:
             values:
               relation: writer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -286,7 +290,7 @@ spec:
             values:
               relation: writer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
-        {{- else -}}
+        {{- else }}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-593

When running helm template lfx-v2-committee-service ./charts/lfx-v2-committee-service --namespace lfx, the following error occurs:
```
Error: YAML parse error on lfx-v2-committee-service/templates/ruleset.yaml: error converting YAML to JSON: yaml: line 53: mapping values are not allowed in this context
```

This pull request updates the `ruleset.yaml` Helm template for the committee service to improve the handling of authorization logic when OpenFGA is disabled. The main change is to standardize the use of Helm templating and commenting style for the fallback authorization block, making the template more readable and maintainable.

### Tests

```
mauriciosalomao@Mauricios-MacBook-Pro lfx-v2-committee-service % make helm-templates
==> Printing templates for Helm chart...
...
    - id: "rule:lfx:lfx-v2-committee-service:committees:create"
      ...
        - contextualizer: oidc_contextualizer
        
        - authorizer: allow_all
        - finalizer: create_jwt
          ...
    - id: "rule:lfx:lfx-v2-committee-service:committees:get"
      	...
        - authorizer: allow_all
        - finalizer: create_jwt
          ...
==> Templates printed for Helm chart: lfx-v2-committee-service

```