### PR TITLE
[LFXV2-920] Committee member visibility - Conditional Relation

### DIFF
--- a/charts/lfx-v2-committee-service/Chart.yaml
+++ b/charts/lfx-v2-committee-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-committee-service
 description: LFX Platform V2 Committee Service chart
 type: application
-version: 0.2.19
+version: 0.2.20
 appVersion: "latest"

--- a/charts/lfx-v2-committee-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-committee-service/templates/ruleset.yaml
@@ -245,7 +245,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: viewer
+              relation: basic_profile_viewer
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
         {{- else }}
         - authorizer: allow_all

--- a/internal/domain/model/committee_base.go
+++ b/internal/domain/model/committee_base.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	categoryGovernmentAdvisoryCouncil = "Government Advisory Council"
+
+	memberVisibilityBasicProfileSetting = "basic_profile"
 )
 
 // Committee represents the core committee business entity
@@ -154,4 +156,13 @@ func (c *Committee) Tags() []string {
 // IsGovernmentAdvisoryCouncil returns true if the committee is a Government Advisory Council
 func (c *Committee) IsGovernmentAdvisoryCouncil() bool {
 	return c.Category == categoryGovernmentAdvisoryCouncil
+}
+
+// IsMemberVisibilityBasicProfile returns true if the committee's member visibility setting is "basic_profile"
+func (c *Committee) IsMemberVisibilityBasicProfile() bool {
+	if c.CommitteeSettings == nil {
+		return false
+	}
+
+	return c.CommitteeSettings.MemberVisibility == memberVisibilityBasicProfileSetting
 }

--- a/internal/domain/model/committee_base.go
+++ b/internal/domain/model/committee_base.go
@@ -164,5 +164,5 @@ func (c *Committee) IsMemberVisibilityBasicProfile() bool {
 		return false
 	}
 
-	return c.CommitteeSettings.MemberVisibility == memberVisibilityBasicProfileSetting
+	return c.MemberVisibility == memberVisibilityBasicProfileSetting
 }

--- a/internal/domain/model/committee_base_test.go
+++ b/internal/domain/model/committee_base_test.go
@@ -593,9 +593,9 @@ func BenchmarkCommitteeTags_Parallel(b *testing.B) {
 
 func TestCommitteeIsMemberVisibilityBasicProfile(t *testing.T) {
 	tests := []struct {
-		name     string
+		name      string
 		committee Committee
-		expected bool
+		expected  bool
 	}{
 		{
 			name: "returns true when member visibility is basic_profile",

--- a/internal/domain/model/committee_base_test.go
+++ b/internal/domain/model/committee_base_test.go
@@ -590,3 +590,66 @@ func BenchmarkCommitteeTags_Parallel(b *testing.B) {
 		}
 	})
 }
+
+func TestCommitteeIsMemberVisibilityBasicProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		committee Committee
+		expected bool
+	}{
+		{
+			name: "returns true when member visibility is basic_profile",
+			committee: Committee{
+				CommitteeBase: CommitteeBase{},
+				CommitteeSettings: &CommitteeSettings{
+					MemberVisibility: "basic_profile",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "returns false when member visibility is full_profile",
+			committee: Committee{
+				CommitteeBase: CommitteeBase{},
+				CommitteeSettings: &CommitteeSettings{
+					MemberVisibility: "full_profile",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when member visibility is empty string",
+			committee: Committee{
+				CommitteeBase: CommitteeBase{},
+				CommitteeSettings: &CommitteeSettings{
+					MemberVisibility: "",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when member visibility is other value",
+			committee: Committee{
+				CommitteeBase: CommitteeBase{},
+				CommitteeSettings: &CommitteeSettings{
+					MemberVisibility: "private",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "returns false when CommitteeSettings is nil",
+			committee: Committee{
+				CommitteeBase:     CommitteeBase{},
+				CommitteeSettings: nil,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.committee.IsMemberVisibilityBasicProfile())
+		})
+	}
+}

--- a/internal/domain/model/committee_message.go
+++ b/internal/domain/model/committee_message.go
@@ -109,6 +109,8 @@ type CommitteeAccessMessage struct {
 	// e.g. "project" and it's value is the project UID.
 	// e.g. "parent" and it's value is the parent UID.
 	References map[string]string `json:"references"`
+	// self is used to store the self relation of the object, e.g. for committee members to access their own basic profile info.
+	Self []string `json:"self"`
 }
 
 // CommitteeMemberUpdateEventData represents the data structure for committee member update events

--- a/internal/domain/model/committee_message.go
+++ b/internal/domain/model/committee_message.go
@@ -109,7 +109,8 @@ type CommitteeAccessMessage struct {
 	// e.g. "project" and it's value is the project UID.
 	// e.g. "parent" and it's value is the parent UID.
 	References map[string]string `json:"references"`
-	// self is used to store the self relation of the object, e.g. for committee members to access their own basic profile info.
+	// Self stores OpenFGA self-relation tuples that enable conditional member-to-member visibility.
+	// When populated, members can view other members' basic profiles based on committee visibility settings.
 	Self []string `json:"self"`
 }
 

--- a/internal/service/committee_writer.go
+++ b/internal/service/committee_writer.go
@@ -238,6 +238,10 @@ func (uc *committeeWriterOrchestrator) buildAccessControlMessage(ctx context.Con
 		message.Relations[constants.RelationAuditor] = committee.Auditors
 	}
 
+	if committee.CommitteeSettings != nil && committee.IsMemberVisibilityBasicProfile() {
+		message.Self = append(message.Self, constants.RelationSelfForMemberBasicProfileAccess)
+	}
+
 	slog.DebugContext(ctx, "building access control message",
 		"message", message,
 	)

--- a/internal/service/committee_writer.go
+++ b/internal/service/committee_writer.go
@@ -228,6 +228,7 @@ func (uc *committeeWriterOrchestrator) buildAccessControlMessage(ctx context.Con
 			// project is required in the flow
 			constants.RelationProject: committee.ProjectUID,
 		},
+		Self: []string{},
 	}
 
 	if committee.CommitteeSettings != nil && len(committee.Writers) > 0 {

--- a/internal/service/committee_writer_test.go
+++ b/internal/service/committee_writer_test.go
@@ -516,6 +516,7 @@ func TestCommitteeWriterOrchestrator_buildAccessControlMessage(t *testing.T) {
 				References: map[string]string{
 					"project": "project-1",
 				},
+				Self: []string{},
 			},
 		},
 		{
@@ -542,6 +543,7 @@ func TestCommitteeWriterOrchestrator_buildAccessControlMessage(t *testing.T) {
 				References: map[string]string{
 					"project": "project-2",
 				},
+				Self: []string{},
 			},
 		},
 		{
@@ -563,6 +565,63 @@ func TestCommitteeWriterOrchestrator_buildAccessControlMessage(t *testing.T) {
 				References: map[string]string{
 					"project": "project-3",
 				},
+				Self: []string{},
+			},
+		},
+		{
+			name: "committee with basic_profile member visibility",
+			committee: &model.Committee{
+				CommitteeBase: model.CommitteeBase{
+					UID:        "committee-4",
+					ProjectUID: "project-4",
+					Public:     false,
+					ParentUID:  nil,
+				},
+				CommitteeSettings: &model.CommitteeSettings{
+					MemberVisibility: "basic_profile",
+					Writers:          []string{"writer@example.com"},
+					Auditors:         []string{"auditor@example.com"},
+				},
+			},
+			expected: &model.CommitteeAccessMessage{
+				UID:        "committee-4",
+				ObjectType: "committee",
+				Public:     false,
+				Relations: map[string][]string{
+					"writer":  {"writer@example.com"},
+					"auditor": {"auditor@example.com"},
+				},
+				References: map[string]string{
+					"project": "project-4",
+				},
+				Self: []string{"self_for_member_basic_profile_access"},
+			},
+		},
+		{
+			name: "committee with non-basic_profile member visibility",
+			committee: &model.Committee{
+				CommitteeBase: model.CommitteeBase{
+					UID:        "committee-5",
+					ProjectUID: "project-5",
+					Public:     true,
+					ParentUID:  nil,
+				},
+				CommitteeSettings: &model.CommitteeSettings{
+					MemberVisibility: "full_profile",
+					Writers:          []string{"writer@example.com"},
+				},
+			},
+			expected: &model.CommitteeAccessMessage{
+				UID:        "committee-5",
+				ObjectType: "committee",
+				Public:     true,
+				Relations: map[string][]string{
+					"writer": {"writer@example.com"},
+				},
+				References: map[string]string{
+					"project": "project-5",
+				},
+				Self: []string{},
 			},
 		},
 	}

--- a/pkg/constants/access_control.go
+++ b/pkg/constants/access_control.go
@@ -12,4 +12,6 @@ const (
 	RelationWriter = "writer"
 	// RelationAuditor is the relation name for the auditor of an object.
 	RelationAuditor = "auditor"
+	// RelationSelfForMemberBasicProfileAccess is the relation name for committee members to access basic profile info.
+	RelationSelfForMemberBasicProfileAccess = "self_for_member_basic_profile_access"
 )


### PR DESCRIPTION
## Overview

Jira Ticket https://linuxfoundation.atlassian.net/browse/LFXV2-920

This pull request introduces support for a new "basic_profile" member visibility setting for committees, enabling fine-grained access control for member profile information. The changes update access control logic, constants, and configuration to reflect this new setting and its associated permissions.

Access Control & Configuration Updates:
* Changed the authorization relation in `ruleset.yaml` from `viewer` to `basic_profile_viewer` to align with the new visibility setting.
* Added a new constant `RelationSelfForMemberBasicProfileAccess` in `access_control.go` to represent self-access for committee members' basic profile information.

Committee Model Enhancements:
* Added the `memberVisibilityBasicProfileSetting` constant and the `IsMemberVisibilityBasicProfile` method to the `Committee` model to check for the "basic_profile" visibility setting. [[1]](diffhunk://#diff-c50dc4a56ba7d5584013c1657369555f1cd253302e587275b00ed8c8b9bed984R21-R22) [[2]](diffhunk://#diff-c50dc4a56ba7d5584013c1657369555f1cd253302e587275b00ed8c8b9bed984R160-R168)
* Updated the `CommitteeAccessMessage` struct to include a new `Self` field for storing self-relations related to basic profile access.
* Modified the committee writer orchestrator to populate the `Self` field in access control messages when the "basic_profile" visibility is enabled.

Chart Version Update:
* Bumped the Helm chart version for `lfx-v2-committee-service` from `0.2.19` to `0.2.20` to reflect these changes.

---

# Test

## Setup

**Committee Created:**
- Name: `Test committee - private 2026-01-08-084107`
- Committee UID: `0b93a757-2ebb-4195-95e2-24710bd2f399`
- Project UID: `cbef1ed5-17dc-4a50-84e2-6cddd70f6878`
- Category: Technical Steering Committee
- Public: `false`

**Test Users:**
- **Admin:** `project_super_admin_token` (full access)
- **Member 1:** `andres` (UID: `f326933b-6a4a-4e35-97ff-b7cca085682f`)
- **Member 2:** `mauriciozanetti` (UID: `aa2ffc1e-5f12-4db6-916c-58f51c90e92d`)
- **Auditor:** `batman`
- **Non-member:** `asitha`

---

## Test Scenario 1: Hidden Member Visibility (Default)

### Creating Committee

**Response:**
```json
{
  "member_visibility": "hidden",
  "name": "Test committee - private 2026-01-08-084107",
  "uid": "0b93a757-2ebb-4195-95e2-24710bd2f399",
  "writers": ["superman"],
  "auditors": ["batman"]
}
```

✅ **Result:** Committee created with `member_visibility: "hidden"` as default

### Adding Members

**Member 1 (andres):**
```json
{
  "username": "andres",
  "first_name": "Andres",
  "last_name": "Tobon",
  "email": "andres@example.com",
  "uid": "f326933b-6a4a-4e35-97ff-b7cca085682f",
  "role": {
    "name": "Chair",
    "start_date": "2025-01-01",
    "end_date": "2025-12-31"
  }
}
```

**Member 2 (mauriciozanetti):**
```json
{
  "username": "mauriciozanetti",
  "first_name": "Mauricio",
  "last_name": "Salomao",
  "email": "mauriciozanetti@example.com",
  "uid": "aa2ffc1e-5f12-4db6-916c-58f51c90e92d",
  "role": {
    "name": "Chair"
  }
}
```

### Access Control Tests - Hidden Mode

#### Admin User (Query Members)
```bash
GET /query/resources?v=1&parent=committee:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $project_super_admin_token
```
✅ **Result:** Returns both members (andres and mauriciozanetti)

#### Member User (Query Members)
```bash
GET /query/resources?v=1&parent=committee:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $mauriciozanetti_token
```
✅ **Result:** `{"resources": []}` - No access to member list

#### Member User (Get Specific Member)
```bash
GET /committees/0b93a757-2ebb-4195-95e2-24710bd2f399/members/f326933b-6a4a-4e35-97ff-b7cca085682f?v=1
Authorization: Bearer $mauriciozanetti_token
```
✅ **Result:** `HTTP/1.1 403 Forbidden` - Access denied

#### Member User (Query Committee)
```bash
GET /query/resources?v=1&type=committee&tags=committee_uid:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $mauriciozanetti_token
```
✅ **Result:** Returns committee info (member can see the committee they belong to)

---

## Test Scenario 2: Basic Profile Visibility

### Updating Settings to Basic Profile

```bash
PUT /committees/0b93a757-2ebb-4195-95e2-24710bd2f399/settings
```

**Response:**
```json
{
  "business_email_required": false,
  "member_visibility": "basic_profile",
  "uid": "0b93a757-2ebb-4195-95e2-24710bd2f399",
  "updated_at": "2026-01-08T12:06:20Z"
}
```

✅ **Result:** Settings updated successfully

### Access Control Tests - Basic Profile Mode

#### Member User (Query Members)
```bash
GET /query/resources?v=1&parent=committee:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $mauriciozanetti_token
```
✅ **Result:** Returns both members with full profile data
```json
{
  "resources": [
    {
      "data": {
        "username": "andres",
        "first_name": "Andres",
        "last_name": "Tobon",
        "email": "andres@example.com",
        "uid": "f326933b-6a4a-4e35-97ff-b7cca085682f"
      }
    },
    {
      "data": {
        "username": "mauriciozanetti",
        "first_name": "Mauricio",
        "last_name": "Salomao",
        "email": "mauriciozanetti@example.com",
        "uid": "aa2ffc1e-5f12-4db6-916c-58f51c90e92d"
      }
    }
  ]
}
```

#### Member User (Get Specific Member)
```bash
GET /committees/0b93a757-2ebb-4195-95e2-24710bd2f399/members/f326933b-6a4a-4e35-97ff-b7cca085682f?v=1
Authorization: Bearer $mauriciozanetti_token
```
✅ **Result:** `HTTP/1.1 200 OK` - Member data returned successfully

#### Auditor User (Query Members)
```bash
GET /query/resources?v=1&parent=committee:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $batman_token
```
✅ **Result:** Returns both members (auditors have access)

#### Non-Member User (Query Members)
```bash
GET /query/resources?v=1&parent=committee:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $asitha_token
```
✅ **Result:** `{"resources": []}` - No access

#### Non-Member User (Get Specific Member)
```bash
GET /committees/0b93a757-2ebb-4195-95e2-24710bd2f399/members/f326933b-6a4a-4e35-97ff-b7cca085682f?v=1
Authorization: Bearer $asitha_token
```
✅ **Result:** `HTTP/1.1 403 Forbidden` - Access denied

---

## Test Scenario 3: Switching Back to Hidden

### Updating Settings Back to Hidden

```bash
PUT /committees/0b93a757-2ebb-4195-95e2-24710bd2f399/settings
```

**Response:**
```json
{
  "business_email_required": false,
  "member_visibility": "hidden",
  "uid": "0b93a757-2ebb-4195-95e2-24710bd2f399",
  "updated_at": "2026-01-08T12:15:26Z"
}
```

✅ **Result:** Settings updated successfully

### Access Control Tests - Back to Hidden Mode

#### Member User (Query Members)
```bash
GET /query/resources?v=1&parent=committee:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $mauriciozanetti_token
```
✅ **Result:** `{"resources": []}` - No access to member list (as expected)

#### Member User (Query Committee)
```bash
GET /query/resources?v=1&type=committee&tags=committee_uid:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $mauriciozanetti_token
```
✅ **Result:** Returns committee info (member can still see the committee)

#### Auditor User (Query Members)
```bash
GET /query/resources?v=1&parent=committee:0b93a757-2ebb-4195-95e2-24710bd2f399
Authorization: Bearer $batman_token
```
✅ **Result:** Returns both members (auditors always have access)

---

## Summary of Test Results

| User Type | Hidden Mode | Basic Profile Mode |
|-----------|-------------|-------------------|
| **Admin** | ✅ Full access | ✅ Full access |
| **Auditor** | ✅ Full access | ✅ Full access |
| **Member** | ❌ No member access<br>✅ Committee access | ✅ Full member access<br>✅ Committee access |
| **Non-member** | ❌ No access | ❌ No access |

### Key Findings

1. **Default behavior:** New committees default to `member_visibility: "hidden"`
2. **Hidden mode:** Members cannot see other members' information
3. **Basic profile mode:** Members can view all committee members' profiles
4. **Auditor access:** Auditors maintain full access regardless of visibility setting
5. **Committee visibility:** Members can always see the committee itself, just not other members in hidden mode
6. **Dynamic updates:** Settings can be changed dynamically and take effect immediately
