### PR TITLE
Annotate kv buckets for backstage discovery

### DIFF
--- a/charts/lfx-v2-committee-service/templates/nats-kv-buckets.yaml
+++ b/charts/lfx-v2-committee-service/templates/nats-kv-buckets.yaml
@@ -11,6 +11,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committees_kv_bucket.name }}
   history: {{ .Values.nats.committees_kv_bucket.history }}
@@ -31,6 +33,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committees_settings_kv_bucket.name }}
   history: {{ .Values.nats.committees_settings_kv_bucket.history }}
@@ -51,6 +55,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committee_members_kv_bucket.name }}
   history: {{ .Values.nats.committee_members_kv_bucket.history }}
@@ -71,6 +77,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committee_invites_kv_bucket.name }}
   history: {{ .Values.nats.committee_invites_kv_bucket.history }}
@@ -91,6 +99,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committee_links_kv_bucket.name }}
   history: {{ .Values.nats.committee_links_kv_bucket.history }}
@@ -111,6 +121,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committee_link_folders_kv_bucket.name }}
   history: {{ .Values.nats.committee_link_folders_kv_bucket.history }}
@@ -131,6 +143,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committee_applications_kv_bucket.name }}
   history: {{ .Values.nats.committee_applications_kv_bucket.history }}
@@ -151,6 +165,8 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   bucket: {{ .Values.nats.committee_documents_metadata_kv_bucket.name }}
   history: {{ .Values.nats.committee_documents_metadata_kv_bucket.history }}


### PR DESCRIPTION
For the `keyvalues` CRD to populate in backstage, these must be labeled. We'll use this data to check replica counts

```
➜ k get keyvalues -A --show-labels
NAMESPACE              NAME                             STATE   KV STORE NAME                    LABELS
committee-service      committee-applications           Ready   committee-applications           <none>
committee-service      committee-documents-metadata     Ready   committee-documents-metadata     <none>
committee-service      committee-folders                Ready   committee-folders                <none>
committee-service      committee-invites                Ready   committee-invites                <none>
committee-service      committee-links                  Ready   committee-links                  <none>
committee-service      committee-members                Ready   committee-members                <none>
committee-service      committee-settings               Ready   committee-settings               <none>
committee-service      committees                       Ready   committees                       <none>
```