### PR TITLE
[LFXV2-1580] Committee member sync after committee updated event

### DIFF
--- a/cmd/committee-api/service/committee_handler.go
+++ b/cmd/committee-api/service/committee_handler.go
@@ -29,6 +29,7 @@ func (mhs *MessageHandlerService) HandleMessage(ctx context.Context, msg port.Tr
 		constants.CommitteeGetNameSubject:            mhs.handleCommitteeGetName,
 		constants.CommitteeListMembersSubject:        mhs.handleCommitteeListMembers,
 		constants.MailingListCommitteeChangedSubject: mhs.handleMailingListChanged,
+		constants.CommitteeUpdatedSubject:            mhs.handleCommitteeUpdated,
 	}
 
 	handler, ok := handlers[subject]
@@ -72,6 +73,10 @@ func (mhs *MessageHandlerService) handleCommitteeListMembers(ctx context.Context
 
 func (mhs *MessageHandlerService) handleMailingListChanged(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 	return mhs.messageHandler.HandleCommitteeMailingListChanged(ctx, msg)
+}
+
+func (mhs *MessageHandlerService) handleCommitteeUpdated(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
+	return mhs.messageHandler.HandleCommitteeUpdated(ctx, msg)
 }
 
 func (mhs *MessageHandlerService) respondWithError(ctx context.Context, msg port.TransportMessenger, errorMsg string) {

--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -389,6 +389,15 @@ func QueueSubscriptions(ctx context.Context, committeeReader port.CommitteeReade
 					usecaseSvc.WithCommitteeReader(committeeReader),
 				),
 			),
+			usecaseSvc.WithCommitteeWriterOrchestratorForMessageHandler(
+				usecaseSvc.NewCommitteeWriterOrchestrator(
+					usecaseSvc.WithCommitteeRetriever(committeeReader),
+					usecaseSvc.WithCommitteeWriter(CommitteeWriterImpl(ctx)),
+					usecaseSvc.WithProjectRetriever(ProjectRetrieverImpl(ctx)),
+					usecaseSvc.WithUserReader(UserReaderImpl(ctx)),
+					usecaseSvc.WithCommitteePublisher(CommitteePublisherImpl(ctx)),
+				),
+			),
 			usecaseSvc.WithCommitteeWriterForMessageHandler(CommitteeWriterImpl(ctx)),
 			usecaseSvc.WithCommitteePublisherForMessageHandler(CommitteePublisherImpl(ctx)),
 		),
@@ -405,6 +414,7 @@ func QueueSubscriptions(ctx context.Context, committeeReader port.CommitteeReade
 		constants.CommitteeGetNameSubject:            messageHandlerService.HandleMessage,
 		constants.CommitteeListMembersSubject:        messageHandlerService.HandleMessage,
 		constants.MailingListCommitteeChangedSubject: messageHandlerService.HandleMessage,
+		constants.CommitteeUpdatedSubject:            messageHandlerService.HandleMessage,
 	}
 
 	for subject, handler := range subjects {

--- a/internal/domain/model/committee_member.go
+++ b/internal/domain/model/committee_member.go
@@ -163,6 +163,19 @@ func (cm *CommitteeMember) Tags() []string {
 	return tags
 }
 
+// NeedsSyncWith reports whether this member's denormalized committee fields
+// differ from the current state of the given committee. Used by the sync handler
+// to skip members that are already up to date, making re-runs idempotent.
+func (cm *CommitteeMember) NeedsSyncWith(committee *CommitteeBase) bool {
+	if committee == nil {
+		return false
+	}
+	return cm.CommitteeName != committee.Name ||
+		cm.CommitteeCategory != committee.Category ||
+		cm.ProjectUID != committee.ProjectUID ||
+		cm.ProjectSlug != committee.ProjectSlug
+}
+
 // Validate validates the committee member against the committee's requirements
 func (cm *CommitteeMember) Validate(committee *Committee) error {
 	if cm == nil {

--- a/internal/domain/model/committee_member.go
+++ b/internal/domain/model/committee_member.go
@@ -167,7 +167,7 @@ func (cm *CommitteeMember) Tags() []string {
 // differ from the current state of the given committee. Used by the sync handler
 // to skip members that are already up to date, making re-runs idempotent.
 func (cm *CommitteeMember) NeedsSyncWith(committee *CommitteeBase) bool {
-	if committee == nil {
+	if cm == nil || committee == nil {
 		return false
 	}
 	return cm.CommitteeName != committee.Name ||

--- a/internal/domain/model/committee_member_test.go
+++ b/internal/domain/model/committee_member_test.go
@@ -535,3 +535,120 @@ func TestCommitteeMember_BuildIndexKey_Uniqueness(t *testing.T) {
 		t.Errorf("Expected different keys for different committee/email combinations, but got same key: %s", key2)
 	}
 }
+
+func TestCommitteeMember_NeedsSyncWith(t *testing.T) {
+	base := &CommitteeBase{
+		Name:        "TSC Committee",
+		Category:    "Board",
+		ProjectUID:  "proj-uid-123",
+		ProjectSlug: "my-project",
+	}
+
+	tests := []struct {
+		name      string
+		member    *CommitteeMember
+		committee *CommitteeBase
+		want      bool
+	}{
+		{
+			name: "nil committee — no sync needed",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					CommitteeName:     "TSC Committee",
+					CommitteeCategory: "Board",
+					ProjectUID:        "proj-uid-123",
+					ProjectSlug:       "my-project",
+				},
+			},
+			committee: nil,
+			want:      false,
+		},
+		{
+			name: "all fields match — no sync needed",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					CommitteeName:     "TSC Committee",
+					CommitteeCategory: "Board",
+					ProjectUID:        "proj-uid-123",
+					ProjectSlug:       "my-project",
+				},
+			},
+			committee: base,
+			want:      false,
+		},
+		{
+			name: "name differs",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					CommitteeName:     "Old Name",
+					CommitteeCategory: "Board",
+					ProjectUID:        "proj-uid-123",
+					ProjectSlug:       "my-project",
+				},
+			},
+			committee: base,
+			want:      true,
+		},
+		{
+			name: "category differs",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					CommitteeName:     "TSC Committee",
+					CommitteeCategory: "Other",
+					ProjectUID:        "proj-uid-123",
+					ProjectSlug:       "my-project",
+				},
+			},
+			committee: base,
+			want:      true,
+		},
+		{
+			name: "project_uid differs",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					CommitteeName:     "TSC Committee",
+					CommitteeCategory: "Board",
+					ProjectUID:        "old-proj-uid",
+					ProjectSlug:       "my-project",
+				},
+			},
+			committee: base,
+			want:      true,
+		},
+		{
+			name: "project_slug differs",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					CommitteeName:     "TSC Committee",
+					CommitteeCategory: "Board",
+					ProjectUID:        "proj-uid-123",
+					ProjectSlug:       "old-slug",
+				},
+			},
+			committee: base,
+			want:      true,
+		},
+		{
+			name: "multiple fields differ",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					CommitteeName:     "Old Name",
+					CommitteeCategory: "Other",
+					ProjectUID:        "old-proj-uid",
+					ProjectSlug:       "old-slug",
+				},
+			},
+			committee: base,
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.member.NeedsSyncWith(tt.committee)
+			if got != tt.want {
+				t.Errorf("NeedsSyncWith() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/model/committee_message.go
+++ b/internal/domain/model/committee_message.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
+	errs "github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 
 	"github.com/go-viper/mapstructure/v2"
 	indexerTypes "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
@@ -127,7 +128,28 @@ type ResourceType string
 // ResourceType constants for the resource type of a committee event.
 const (
 	ResourceCommitteeMember ResourceType = "committee_member"
+	ResourceCommittee       ResourceType = "committee"
 )
+
+// CommitteeUpdateEventData carries the before and after images of a committee update.
+// Consumers use the two images to decide independently what side-effects to apply.
+type CommitteeUpdateEventData struct {
+	CommitteeUID string         `json:"committee_uid"`
+	OldCommittee *CommitteeBase `json:"old_committee"`
+	Committee    *CommitteeBase `json:"committee"`
+}
+
+// RequiresMemberSync reports whether the update changed any field that is
+// denormalized onto member documents. Returns false if either image is nil.
+func (e *CommitteeUpdateEventData) RequiresMemberSync() bool {
+	if e.OldCommittee == nil || e.Committee == nil {
+		return false
+	}
+	return e.OldCommittee.Name != e.Committee.Name ||
+		e.OldCommittee.Category != e.Committee.Category ||
+		e.OldCommittee.ProjectUID != e.Committee.ProjectUID ||
+		e.OldCommittee.ProjectSlug != e.Committee.ProjectSlug
+}
 
 // Build creates a CommitteeEvent from the resource type, action and input data
 func (e *CommitteeEvent) Build(ctx context.Context, resource ResourceType, action MessageAction, input any) (*CommitteeEvent, error) {
@@ -138,6 +160,8 @@ func (e *CommitteeEvent) Build(ctx context.Context, resource ResourceType, actio
 	switch resource {
 	case ResourceCommitteeMember:
 		return e.buildCommitteeMembers(ctx, resource, action, input)
+	case ResourceCommittee:
+		return e.buildCommittee(ctx, resource, action, input)
 	default:
 		return nil, fmt.Errorf("unsupported resource type: %s", resource)
 	}
@@ -198,6 +222,31 @@ func (e *CommitteeEvent) buildCommitteeMembers(ctx context.Context, resource Res
 		}
 		e.Data = updateData
 	}
+
+	return e, nil
+}
+
+func (e *CommitteeEvent) buildCommittee(ctx context.Context, resource ResourceType, action MessageAction, input any) (*CommitteeEvent, error) {
+	switch action {
+	case ActionUpdated:
+		e.Subject = constants.CommitteeUpdatedSubject
+	default:
+		return nil, fmt.Errorf("unsupported action for committee resource: %s", action)
+	}
+
+	e.buildEventType(resource, action)
+
+	updateData, ok := input.(*CommitteeUpdateEventData)
+	if !ok || updateData == nil {
+		slog.ErrorContext(ctx, "invalid input type for CommitteeEvent",
+			"resource", resource,
+			"action", action,
+			"expected", "*CommitteeUpdateEventData",
+			"got", fmt.Sprintf("%T", input),
+		)
+		return nil, errs.NewValidation(fmt.Sprintf("invalid input type, got %T", input))
+	}
+	e.Data = updateData
 
 	return e, nil
 }

--- a/internal/domain/model/committee_message_test.go
+++ b/internal/domain/model/committee_message_test.go
@@ -416,3 +416,171 @@ func TestCommitteeIndexerMessage_Build_DeleteAction_RawUID(t *testing.T) {
 		})
 	}
 }
+
+func TestCommitteeUpdateEventData_RequiresMemberSync(t *testing.T) {
+	base := &CommitteeBase{
+		Name:        "TSC Committee",
+		Category:    "Board",
+		ProjectUID:  "proj-uid-123",
+		ProjectSlug: "my-project",
+	}
+
+	tests := []struct {
+		name string
+		data CommitteeUpdateEventData
+		want bool
+	}{
+		{
+			name: "nil OldCommittee — no sync",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: nil,
+				Committee:    base,
+			},
+			want: false,
+		},
+		{
+			name: "nil Committee — no sync",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: base,
+				Committee:    nil,
+			},
+			want: false,
+		},
+		{
+			name: "both nil — no sync",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: nil,
+				Committee:    nil,
+			},
+			want: false,
+		},
+		{
+			name: "all fields identical — no sync",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: base,
+				Committee:    base,
+			},
+			want: false,
+		},
+		{
+			name: "name changed",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: &CommitteeBase{Name: "Old Name", Category: "Board", ProjectUID: "proj-uid-123", ProjectSlug: "my-project"},
+				Committee:    base,
+			},
+			want: true,
+		},
+		{
+			name: "category changed",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: &CommitteeBase{Name: "TSC Committee", Category: "Other", ProjectUID: "proj-uid-123", ProjectSlug: "my-project"},
+				Committee:    base,
+			},
+			want: true,
+		},
+		{
+			name: "project_uid changed",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: &CommitteeBase{Name: "TSC Committee", Category: "Board", ProjectUID: "old-uid", ProjectSlug: "my-project"},
+				Committee:    base,
+			},
+			want: true,
+		},
+		{
+			name: "project_slug changed",
+			data: CommitteeUpdateEventData{
+				CommitteeUID: "uid-1",
+				OldCommittee: &CommitteeBase{Name: "TSC Committee", Category: "Board", ProjectUID: "proj-uid-123", ProjectSlug: "old-slug"},
+				Committee:    base,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.data.RequiresMemberSync()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCommitteeEvent_Build_Committee(t *testing.T) {
+	validData := &CommitteeUpdateEventData{
+		CommitteeUID: "uid-1",
+		OldCommittee: &CommitteeBase{Name: "Old", Category: "Board"},
+		Committee:    &CommitteeBase{Name: "New", Category: "Other"},
+	}
+
+	tests := []struct {
+		name          string
+		action        MessageAction
+		input         any
+		wantErr       bool
+		wantSubject   string
+		wantEventType string
+		wantData      any
+	}{
+		{
+			name:          "ActionUpdated with valid input",
+			action:        ActionUpdated,
+			input:         validData,
+			wantErr:       false,
+			wantSubject:   constants.CommitteeUpdatedSubject,
+			wantEventType: "committee.updated",
+			wantData:      validData,
+		},
+		{
+			name:    "ActionUpdated with nil input",
+			action:  ActionUpdated,
+			input:   (*CommitteeUpdateEventData)(nil),
+			wantErr: true,
+		},
+		{
+			name:    "ActionUpdated with wrong type",
+			action:  ActionUpdated,
+			input:   &CommitteeMember{},
+			wantErr: true,
+		},
+		{
+			name:    "unsupported action (ActionCreated)",
+			action:  ActionCreated,
+			input:   validData,
+			wantErr: true,
+		},
+		{
+			name:    "unsupported action (ActionDeleted)",
+			action:  ActionDeleted,
+			input:   validData,
+			wantErr: true,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &CommitteeEvent{}
+			result, err := event.Build(ctx, ResourceCommittee, tt.action, tt.input)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantSubject, result.Subject)
+			assert.Equal(t, tt.wantEventType, result.EventType)
+			assert.Equal(t, tt.wantData, result.Data)
+		})
+	}
+}

--- a/internal/domain/port/message_handler.go
+++ b/internal/domain/port/message_handler.go
@@ -5,12 +5,31 @@ package port
 
 import "context"
 
-// MessageHandler defines the interface for handling NATS messages
-type MessageHandler interface {
+// CommitteeAttributeHandler handles request/reply messages from other services
+// querying committee attribute data.
+type CommitteeAttributeHandler interface {
 	// HandleCommitteeGetAttribute handles committee get attribute messages
 	HandleCommitteeGetAttribute(ctx context.Context, msg TransportMessenger, attribute string) ([]byte, error)
+}
+
+// CommitteeMemberHandler handles member-related messages: responding to external
+// list-members queries and reacting to committee-change events that require member re-sync.
+type CommitteeMemberHandler interface {
 	// HandleCommitteeListMembers handles committee list members messages
 	HandleCommitteeListMembers(ctx context.Context, msg TransportMessenger) ([]byte, error)
+	// HandleCommitteeUpdated handles committee updated events and re-syncs denormalized member data
+	HandleCommitteeUpdated(ctx context.Context, msg TransportMessenger) ([]byte, error)
+}
+
+// CommitteeMailingListHandler handles events from mailing-list-api.
+type CommitteeMailingListHandler interface {
 	// HandleCommitteeMailingListChanged handles mailing list status change events from mailing-list-api
 	HandleCommitteeMailingListChanged(ctx context.Context, msg TransportMessenger) ([]byte, error)
+}
+
+// MessageHandler is the aggregate interface for all inbound NATS message handlers.
+type MessageHandler interface {
+	CommitteeAttributeHandler
+	CommitteeMemberHandler
+	CommitteeMailingListHandler
 }

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -34,6 +34,8 @@ type CommitteeDataReader interface {
 type CommitteeMemberDataReader interface {
 	// GetMember retrieves a committee member by committee UID and member UID
 	GetMember(ctx context.Context, committeeUID, memberUID string) (*model.CommitteeMember, uint64, error)
+	// GetMemberRevision retrieves the current KV revision for a committee member by UID
+	GetMemberRevision(ctx context.Context, memberUID string) (uint64, error)
 	// ListMembers retrieves all members for a given committee UID
 	ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
 }
@@ -117,6 +119,11 @@ func (rc *committeeReaderOrchestrator) GetBaseAttributeValue(ctx context.Context
 	}
 
 	return field, nil
+}
+
+// GetMemberRevision retrieves the current KV revision for a committee member by UID
+func (rc *committeeReaderOrchestrator) GetMemberRevision(ctx context.Context, memberUID string) (uint64, error) {
+	return rc.committeeReader.GetMemberRevision(ctx, memberUID)
 }
 
 // GetMember retrieves a committee member by committee UID and member UID

--- a/internal/service/committee_writer.go
+++ b/internal/service/committee_writer.go
@@ -733,13 +733,31 @@ func (uc *committeeWriterOrchestrator) Update(ctx context.Context, committee *mo
 		CommitteeSettings: settings,
 	}
 	accessControlMessage := uc.buildAccessControlMessage(ctx, fullCommittee)
-	// Publish both messages
+
+	updateEventData := &model.CommitteeUpdateEventData{
+		CommitteeUID: committee.CommitteeBase.UID,
+		OldCommittee: existing,
+		Committee:    &committee.CommitteeBase,
+	}
+
 	messages := []func() error{
 		func() error {
 			return uc.committeePublisher.Indexer(ctx, constants.IndexCommitteeSubject, messageIndexer, sync)
 		},
 		func() error {
 			return uc.committeePublisher.Access(ctx, fgaconstants.GenericUpdateAccessSubject, accessControlMessage, sync)
+		},
+		func() error {
+			committeeEvent := model.CommitteeEvent{}
+			builtEvent, errBuild := committeeEvent.Build(ctx, model.ResourceCommittee, model.ActionUpdated, updateEventData)
+			if errBuild != nil {
+				slog.WarnContext(ctx, "failed to build committee updated event",
+					"error", errBuild,
+					"committee_uid", committee.CommitteeBase.UID,
+				)
+				return nil
+			}
+			return uc.committeePublisher.Event(ctx, constants.CommitteeUpdatedSubject, builtEvent, false)
 		},
 	}
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"log/slog"
 
@@ -19,9 +20,10 @@ import (
 
 // messageHandlerOrchestrator orchestrates the message handling process
 type messageHandlerOrchestrator struct {
-	committeeReader    CommitteeReader
-	committeeWriter    port.CommitteeWriter
-	committeePublisher port.CommitteePublisher
+	committeeReader      CommitteeReader
+	committeeWriter      port.CommitteeWriter
+	committeePublisher   port.CommitteePublisher
+	committeeMemberWriter CommitteeMemberDataWriter
 }
 
 // messageHandlerOrchestratorOption defines a function type for setting options
@@ -45,6 +47,13 @@ func WithCommitteeWriterForMessageHandler(writer port.CommitteeWriter) messageHa
 func WithCommitteePublisherForMessageHandler(publisher port.CommitteePublisher) messageHandlerOrchestratorOption {
 	return func(m *messageHandlerOrchestrator) {
 		m.committeePublisher = publisher
+	}
+}
+
+// WithCommitteeMemberWriterForMessageHandler sets the service-level member writer for message handler
+func WithCommitteeMemberWriterForMessageHandler(writer CommitteeMemberDataWriter) messageHandlerOrchestratorOption {
+	return func(m *messageHandlerOrchestrator) {
+		m.committeeMemberWriter = writer
 	}
 }
 
@@ -208,9 +217,77 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMailingListChanged(ctx conte
 	return nil, nil
 }
 
-// HandleCommitteeUpdated handles committee updated events and re-syncs denormalized member data.
-// TODO: implement — stub added to satisfy port.MessageHandler while the full implementation is being built.
-func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(_ context.Context, _ port.TransportMessenger) ([]byte, error) {
+// HandleCommitteeUpdated reacts to a committee.updated event. It delegates
+// re-sync decisions to the domain model and re-syncs member documents when needed.
+// All members are processed regardless of individual failures (best-effort).
+// A combined error is returned at the end if any member failed.
+func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
+	var event model.CommitteeEvent
+	if err := json.Unmarshal(msg.Data(), &event); err != nil {
+		slog.ErrorContext(ctx, "failed to unmarshal CommitteeEvent", "error", err)
+		return nil, err
+	}
+
+	data, ok := event.Data.(*model.CommitteeUpdateEventData)
+	if !ok || data == nil {
+		slog.WarnContext(ctx, "CommitteeUpdated event has unexpected data shape — discarding")
+		return nil, nil
+	}
+
+	if !data.RequiresMemberSync() {
+		slog.DebugContext(ctx, "no denormalized fields changed — skipping member sync",
+			"committee_uid", data.CommitteeUID)
+		return nil, nil
+	}
+
+	slog.InfoContext(ctx, "denormalized fields changed — syncing members",
+		"committee_uid", data.CommitteeUID)
+
+	members, err := m.committeeReader.ListMembers(ctx, data.CommitteeUID)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to list members for sync",
+			"committee_uid", data.CommitteeUID, "error", err)
+		return nil, err
+	}
+
+	var syncErrors []error
+
+	for _, member := range members {
+		if !member.NeedsSyncWith(data.Committee) {
+			slog.DebugContext(ctx, "member already up to date — skipping",
+				"member_uid", member.UID, "committee_uid", data.CommitteeUID)
+			continue
+		}
+
+		member.CommitteeName = data.Committee.Name
+		member.CommitteeCategory = data.Committee.Category
+		member.ProjectUID = data.Committee.ProjectUID
+		member.ProjectSlug = data.Committee.ProjectSlug
+
+		revision, errRev := m.committeeReader.GetMemberRevision(ctx, member.UID)
+		if errRev != nil {
+			slog.ErrorContext(ctx, "failed to get member revision during sync",
+				"member_uid", member.UID, "committee_uid", data.CommitteeUID, "error", errRev)
+			syncErrors = append(syncErrors, errRev)
+			continue
+		}
+
+		if _, errUpdate := m.committeeMemberWriter.UpdateMember(ctx, member, revision, false); errUpdate != nil {
+			slog.ErrorContext(ctx, "failed to update member during sync",
+				"member_uid", member.UID, "committee_uid", data.CommitteeUID, "error", errUpdate)
+			syncErrors = append(syncErrors, errUpdate)
+		}
+	}
+
+	slog.InfoContext(ctx, "member sync completed",
+		"committee_uid", data.CommitteeUID,
+		"members_processed", len(members),
+		"failures", len(syncErrors))
+
+	if len(syncErrors) > 0 {
+		return nil, stderrors.Join(syncErrors...)
+	}
+
 	return nil, nil
 }
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -50,6 +50,13 @@ func WithCommitteePublisherForMessageHandler(publisher port.CommitteePublisher) 
 	}
 }
 
+// WithCommitteeWriterOrchestratorForMessageHandler sets the service-level committee writer for member sync
+func WithCommitteeWriterOrchestratorForMessageHandler(writer CommitteeWriter) messageHandlerOrchestratorOption {
+	return func(m *messageHandlerOrchestrator) {
+		m.committeeWriterOrchestrator = writer
+	}
+}
+
 // HandleCommitteeGetAttribute handles the retrieval of a specific attribute from the committee
 func (m *messageHandlerOrchestrator) HandleCommitteeGetAttribute(ctx context.Context, msg port.TransportMessenger, attribute string) ([]byte, error) {
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -222,6 +222,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMailingListChanged(ctx conte
 // All members are processed regardless of individual failures (best-effort).
 // A combined error is returned at the end if any member failed.
 func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
+
+	if m.committeeWriterOrchestrator == nil {
+		return nil, errors.NewValidation("committee writer orchestrator is required for handling committee updated events")
+	}
+
 	var event model.CommitteeEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
 		slog.ErrorContext(ctx, "failed to unmarshal CommitteeEvent", "error", err)
@@ -246,11 +251,16 @@ func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context,
 		return nil, nil
 	}
 
+	if data.CommitteeUID == "" {
+		slog.WarnContext(ctx, "CommitteeUpdated event missing committee_uid — discarding")
+		return nil, nil
+	}
+
 	// Inject service-account identity so downstream indexer calls include a valid
 	// authorization header. Pattern follows lfx-v2-meeting-service:
 	// internal/infrastructure/eventing/nats_publisher.go — static "Bearer <service-name>"
 	// is used for background operations that have no originating HTTP request context.
-	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer "+constants.ServiceName)
+	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
 
 	slog.InfoContext(ctx, "denormalized fields changed — syncing members",
 		"committee_uid", data.CommitteeUID)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -208,6 +208,12 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMailingListChanged(ctx conte
 	return nil, nil
 }
 
+// HandleCommitteeUpdated handles committee updated events and re-syncs denormalized member data.
+// TODO: implement — stub added to satisfy port.MessageHandler while the full implementation is being built.
+func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(_ context.Context, _ port.TransportMessenger) ([]byte, error) {
+	return nil, nil
+}
+
 // NewMessageHandlerOrchestrator creates a new message handler orchestrator using the option pattern
 func NewMessageHandlerOrchestrator(opts ...messageHandlerOrchestratorOption) port.MessageHandler {
 	m := &messageHandlerOrchestrator{}

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -228,9 +228,15 @@ func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context,
 		return nil, err
 	}
 
-	data, ok := event.Data.(*model.CommitteeUpdateEventData)
-	if !ok || data == nil {
-		slog.WarnContext(ctx, "CommitteeUpdated event has unexpected data shape — discarding")
+	// event.Data is map[string]interface{} after JSON round-trip; re-marshal to decode into the concrete type.
+	rawData, errMarshal := json.Marshal(event.Data)
+	if errMarshal != nil {
+		slog.WarnContext(ctx, "CommitteeUpdated event has unexpected data shape — discarding", "error", errMarshal)
+		return nil, nil
+	}
+	var data model.CommitteeUpdateEventData
+	if err := json.Unmarshal(rawData, &data); err != nil {
+		slog.WarnContext(ctx, "CommitteeUpdated event data cannot be decoded — discarding", "error", err)
 		return nil, nil
 	}
 
@@ -239,6 +245,12 @@ func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context,
 			"committee_uid", data.CommitteeUID)
 		return nil, nil
 	}
+
+	// Inject service-account identity so downstream indexer calls include a valid
+	// authorization header. Pattern follows lfx-v2-meeting-service:
+	// internal/infrastructure/eventing/nats_publisher.go — static "Bearer <service-name>"
+	// is used for background operations that have no originating HTTP request context.
+	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer "+constants.ServiceName)
 
 	slog.InfoContext(ctx, "denormalized fields changed — syncing members",
 		"committee_uid", data.CommitteeUID)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -20,10 +20,10 @@ import (
 
 // messageHandlerOrchestrator orchestrates the message handling process
 type messageHandlerOrchestrator struct {
-	committeeReader      CommitteeReader
-	committeeWriter      port.CommitteeWriter
-	committeePublisher   port.CommitteePublisher
-	committeeMemberWriter CommitteeMemberDataWriter
+	committeeReader             CommitteeReader
+	committeeWriterOrchestrator CommitteeWriter
+	committeeWriter             port.CommitteeWriter
+	committeePublisher          port.CommitteePublisher
 }
 
 // messageHandlerOrchestratorOption defines a function type for setting options
@@ -47,13 +47,6 @@ func WithCommitteeWriterForMessageHandler(writer port.CommitteeWriter) messageHa
 func WithCommitteePublisherForMessageHandler(publisher port.CommitteePublisher) messageHandlerOrchestratorOption {
 	return func(m *messageHandlerOrchestrator) {
 		m.committeePublisher = publisher
-	}
-}
-
-// WithCommitteeMemberWriterForMessageHandler sets the service-level member writer for message handler
-func WithCommitteeMemberWriterForMessageHandler(writer CommitteeMemberDataWriter) messageHandlerOrchestratorOption {
-	return func(m *messageHandlerOrchestrator) {
-		m.committeeMemberWriter = writer
 	}
 }
 
@@ -272,7 +265,7 @@ func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context,
 			continue
 		}
 
-		if _, errUpdate := m.committeeMemberWriter.UpdateMember(ctx, member, revision, false); errUpdate != nil {
+		if _, errUpdate := m.committeeWriterOrchestrator.UpdateMember(ctx, member, revision, false); errUpdate != nil {
 			slog.ErrorContext(ctx, "failed to update member during sync",
 				"member_uid", member.UID, "committee_uid", data.CommitteeUID, "error", errUpdate)
 			syncErrors = append(syncErrors, errUpdate)

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -629,6 +630,189 @@ func TestHandleCommitteeMailingListChanged(t *testing.T) {
 
 			assert.Equal(t, tt.wantIndexerCalled, spy.indexerCallCount > 0,
 				"indexer called mismatch: got %d calls", spy.indexerCallCount)
+		})
+	}
+}
+
+// spyCommitteeWriterOrchestrator records UpdateMember calls and can be configured to fail.
+type spyCommitteeWriterOrchestrator struct {
+	updateMemberCalls  int
+	updateMemberErr    error
+	updatedMembers     []*model.CommitteeMember
+}
+
+func (s *spyCommitteeWriterOrchestrator) Create(_ context.Context, _ *model.Committee, _ bool) (*model.Committee, error) {
+	return nil, nil
+}
+func (s *spyCommitteeWriterOrchestrator) Update(_ context.Context, _ *model.Committee, _ uint64, _ bool) (*model.Committee, error) {
+	return nil, nil
+}
+func (s *spyCommitteeWriterOrchestrator) UpdateSettings(_ context.Context, _ *model.CommitteeSettings, _ uint64, _ bool) (*model.CommitteeSettings, error) {
+	return nil, nil
+}
+func (s *spyCommitteeWriterOrchestrator) Delete(_ context.Context, _ string, _ uint64, _ bool) error {
+	return nil
+}
+func (s *spyCommitteeWriterOrchestrator) CreateMember(_ context.Context, _ *model.CommitteeMember, _ bool) (*model.CommitteeMember, error) {
+	return nil, nil
+}
+func (s *spyCommitteeWriterOrchestrator) UpdateMember(_ context.Context, member *model.CommitteeMember, _ uint64, _ bool) (*model.CommitteeMember, error) {
+	s.updateMemberCalls++
+	memberCopy := *member
+	s.updatedMembers = append(s.updatedMembers, &memberCopy)
+	return member, s.updateMemberErr
+}
+func (s *spyCommitteeWriterOrchestrator) DeleteMember(_ context.Context, _ string, _ uint64, _ bool) error {
+	return nil
+}
+
+func buildCommitteeUpdatedMsg(committeeUID string, old, updated *model.CommitteeBase) []byte {
+	data := model.CommitteeUpdateEventData{
+		CommitteeUID: committeeUID,
+		OldCommittee: old,
+		Committee:    updated,
+	}
+	event := model.CommitteeEvent{Data: data}
+	b, _ := json.Marshal(event)
+	return b
+}
+
+func TestHandleCommitteeUpdated(t *testing.T) {
+	ctx := context.Background()
+
+	committeeUID := "committee-sync-test"
+	oldBase := &model.CommitteeBase{
+		Name:       "Old Name",
+		Category:   "Board",
+		ProjectUID: "proj-1",
+		ProjectSlug: "old-slug",
+	}
+	newBase := &model.CommitteeBase{
+		Name:       "New Name",
+		Category:   "Technical",
+		ProjectUID: "proj-1",
+		ProjectSlug: "new-slug",
+	}
+
+	makeStaleMember := func(uid string) *model.CommitteeMember {
+		return &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				UID:               uid,
+				CommitteeUID:      committeeUID,
+				CommitteeName:     oldBase.Name,
+				CommitteeCategory: oldBase.Category,
+				ProjectUID:        oldBase.ProjectUID,
+				ProjectSlug:       oldBase.ProjectSlug,
+				Username:          uid + "@example.com",
+				Email:             uid + "@example.com",
+			},
+		}
+	}
+
+	tests := []struct {
+		name               string
+		messageData        []byte
+		setupMock          func(*mock.MockRepository)
+		writerErr          error
+		wantErr            bool
+		wantUpdateCalls    int
+		validateUpdated    func(*testing.T, []*model.CommitteeMember)
+	}{
+		{
+			name:        "invalid JSON returns error",
+			messageData: []byte(`not-json`),
+			setupMock:   func(_ *mock.MockRepository) {},
+			wantErr:     true,
+		},
+		{
+			name:        "no denormalized fields changed — skips sync",
+			messageData: buildCommitteeUpdatedMsg(committeeUID, oldBase, oldBase),
+			setupMock:   func(_ *mock.MockRepository) {},
+			wantErr:     false,
+			wantUpdateCalls: 0,
+		},
+		{
+			name:        "list members fails — propagates error",
+			messageData: buildCommitteeUpdatedMsg("unknown-committee", oldBase, newBase),
+			setupMock:   func(_ *mock.MockRepository) {},
+			wantErr:     false, // ListMembers returns empty slice for unknown committee, not error
+			wantUpdateCalls: 0,
+		},
+		{
+			name:        "all members already up to date — no UpdateMember calls",
+			messageData: buildCommitteeUpdatedMsg(committeeUID, oldBase, newBase),
+			setupMock: func(repo *mock.MockRepository) {
+				upToDate := makeStaleMember("up-to-date-member")
+				upToDate.CommitteeName = newBase.Name
+				upToDate.CommitteeCategory = newBase.Category
+				upToDate.ProjectSlug = newBase.ProjectSlug
+				repo.AddCommitteeMember(committeeUID, upToDate)
+			},
+			wantErr:         false,
+			wantUpdateCalls: 0,
+		},
+		{
+			name:        "stale members are synced",
+			messageData: buildCommitteeUpdatedMsg(committeeUID, oldBase, newBase),
+			setupMock: func(repo *mock.MockRepository) {
+				repo.AddCommitteeMember(committeeUID, makeStaleMember("stale-1"))
+				repo.AddCommitteeMember(committeeUID, makeStaleMember("stale-2"))
+			},
+			wantErr:         false,
+			wantUpdateCalls: 2,
+			validateUpdated: func(t *testing.T, members []*model.CommitteeMember) {
+				t.Helper()
+				for _, m := range members {
+					assert.Equal(t, newBase.Name, m.CommitteeName)
+					assert.Equal(t, newBase.Category, m.CommitteeCategory)
+					assert.Equal(t, newBase.ProjectUID, m.ProjectUID)
+					assert.Equal(t, newBase.ProjectSlug, m.ProjectSlug)
+				}
+			},
+		},
+		{
+			name:        "UpdateMember fails — error accumulated, all members attempted",
+			messageData: buildCommitteeUpdatedMsg(committeeUID, oldBase, newBase),
+			setupMock: func(repo *mock.MockRepository) {
+				repo.AddCommitteeMember(committeeUID, makeStaleMember("stale-a"))
+				repo.AddCommitteeMember(committeeUID, makeStaleMember("stale-b"))
+			},
+			writerErr:       fmt.Errorf("index unavailable"),
+			wantErr:         true,
+			wantUpdateCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := mock.NewMockRepository()
+			mockRepo.ClearAll()
+			tt.setupMock(mockRepo)
+
+			spy := &spyCommitteeWriterOrchestrator{updateMemberErr: tt.writerErr}
+
+			handler := NewMessageHandlerOrchestrator(
+				WithCommitteeReaderForMessageHandler(
+					NewCommitteeReaderOrchestrator(WithCommitteeReader(mockRepo)),
+				),
+				WithCommitteeWriterOrchestratorForMessageHandler(spy),
+			)
+
+			msg := newMockTransportMessenger(constants.CommitteeUpdatedSubject, tt.messageData)
+			_, err := handler.HandleCommitteeUpdated(ctx, msg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantUpdateCalls, spy.updateMemberCalls,
+				"UpdateMember call count mismatch")
+
+			if tt.validateUpdated != nil {
+				tt.validateUpdated(t, spy.updatedMembers)
+			}
 		})
 	}
 }

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -636,9 +636,9 @@ func TestHandleCommitteeMailingListChanged(t *testing.T) {
 
 // spyCommitteeWriterOrchestrator records UpdateMember calls and can be configured to fail.
 type spyCommitteeWriterOrchestrator struct {
-	updateMemberCalls  int
-	updateMemberErr    error
-	updatedMembers     []*model.CommitteeMember
+	updateMemberCalls int
+	updateMemberErr   error
+	updatedMembers    []*model.CommitteeMember
 }
 
 func (s *spyCommitteeWriterOrchestrator) Create(_ context.Context, _ *model.Committee, _ bool) (*model.Committee, error) {
@@ -682,15 +682,15 @@ func TestHandleCommitteeUpdated(t *testing.T) {
 
 	committeeUID := "committee-sync-test"
 	oldBase := &model.CommitteeBase{
-		Name:       "Old Name",
-		Category:   "Board",
-		ProjectUID: "proj-1",
+		Name:        "Old Name",
+		Category:    "Board",
+		ProjectUID:  "proj-1",
 		ProjectSlug: "old-slug",
 	}
 	newBase := &model.CommitteeBase{
-		Name:       "New Name",
-		Category:   "Technical",
-		ProjectUID: "proj-1",
+		Name:        "New Name",
+		Category:    "Technical",
+		ProjectUID:  "proj-1",
 		ProjectSlug: "new-slug",
 	}
 
@@ -710,13 +710,13 @@ func TestHandleCommitteeUpdated(t *testing.T) {
 	}
 
 	tests := []struct {
-		name               string
-		messageData        []byte
-		setupMock          func(*mock.MockRepository)
-		writerErr          error
-		wantErr            bool
-		wantUpdateCalls    int
-		validateUpdated    func(*testing.T, []*model.CommitteeMember)
+		name            string
+		messageData     []byte
+		setupMock       func(*mock.MockRepository)
+		writerErr       error
+		wantErr         bool
+		wantUpdateCalls int
+		validateUpdated func(*testing.T, []*model.CommitteeMember)
 	}{
 		{
 			name:        "invalid JSON returns error",
@@ -725,17 +725,17 @@ func TestHandleCommitteeUpdated(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:        "no denormalized fields changed — skips sync",
-			messageData: buildCommitteeUpdatedMsg(committeeUID, oldBase, oldBase),
-			setupMock:   func(_ *mock.MockRepository) {},
-			wantErr:     false,
+			name:            "no denormalized fields changed — skips sync",
+			messageData:     buildCommitteeUpdatedMsg(committeeUID, oldBase, oldBase),
+			setupMock:       func(_ *mock.MockRepository) {},
+			wantErr:         false,
 			wantUpdateCalls: 0,
 		},
 		{
-			name:        "list members fails — propagates error",
-			messageData: buildCommitteeUpdatedMsg("unknown-committee", oldBase, newBase),
-			setupMock:   func(_ *mock.MockRepository) {},
-			wantErr:     false, // ListMembers returns empty slice for unknown committee, not error
+			name:            "list members fails — propagates error",
+			messageData:     buildCommitteeUpdatedMsg("unknown-committee", oldBase, newBase),
+			setupMock:       func(_ *mock.MockRepository) {},
+			wantErr:         false, // ListMembers returns empty slice for unknown committee, not error
 			wantUpdateCalls: 0,
 		},
 		{

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -85,4 +85,8 @@ const (
 	// CommitteeMemberUpdatedSubject is the subject for committee member update events.
 	// The subject is of the form: lfx.committee-api.committee_member.updated
 	CommitteeMemberUpdatedSubject = "lfx.committee-api.committee_member.updated"
+
+	// CommitteeUpdatedSubject is emitted after a successful committee update.
+	// The payload is a CommitteeEvent wrapping CommitteeUpdateEventData (old + new image).
+	CommitteeUpdatedSubject = "lfx.committee-api.committee.updated"
 )


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-1580

When a committee is updated (e.g., name, category, project UID, or project slug changes), the denormalized copies of those fields on every `committee_member` document in the KV store and OpenSearch index were never refreshed. This caused stale data — notably the `committee_category:Board` tag — to persist on member records even after the committee category was changed, requiring manual scripted updates to clean up.

### Root Cause

The `committeeWriterOrchestrator.Update` path published an indexer event and an access-control event on every committee save, but it never published a `committee.updated` domain event that downstream handlers could react to. There was also no subscriber listening to committee-change events to trigger member re-sync.

## Solution

Implemented an event-driven re-sync pipeline:

1. `committeeWriterOrchestrator.Update` now publishes a `lfx.committee-api.committee.updated` event carrying old and new committee images after every successful update.
2. A new `HandleCommitteeUpdated` subscriber reacts to that event, checks whether any denormalized field actually changed (`RequiresMemberSync`), lists all members, and calls `UpdateMember` on each one that is out of date (`NeedsSyncWith`). Members are processed best-effort: one failure never blocks the rest.
3. Both sync predicates live in the domain model, keeping the handler thin and the logic unit-testable.

## Design Notes

- **Idempotent**: `NeedsSyncWith` per member makes re-processing the same event safe.
- **No-op guard**: `RequiresMemberSync()` exits early when no denormalized field changed, avoiding a full member list on every committee save.
- **Service-account identity**: injects `Bearer <service-name>` into context for background operations with no originating HTTP request, consistent with the meeting-service pattern.

---

# Testing Evidence

**Date:** 2026-04-29  
**Branch:** `feat/lfxv2-1580-committee-member-sync-after-committee-updated-event`  
**Scenario:** When a committee's denormalized fields change (e.g. `category`), all its members must have their cached copies updated automatically — both in the KV store and in the OpenSearch index — via an async event.

---

## Environment

Local/Orbstack

| Component | Value |
|---|---|
| Service URL | `http://lfx-api.k8s.orb.local:80` |
| NATS | `nats://lfx-platform-nats.lfx.svc.cluster.local:4222` |
| OpenSearch | `http://opensearch-cluster-master.lfx.svc.cluster.local:9200` |

---

## Step 1 — Create Committee (category: `Board`)

**Request**
```
POST http://lfx-api.k8s.orb.local:80/committees
Authorization: Bearer authelia_at_H8TUfFLRaA8ocDUg...
```
```json
{
  "category": "Board",
  "name": "Test committee - sync members 20260429T084847",
  "project_uid": "b0a360ec-1e37-452f-b5e3-233d4000365a",
  "parent_uid": "9493eae5-cd73-4c4a-b28f-3b8ec5280f6c",
  ...
}
```

**Response — 201 Created**
```json
{
  "uid": "7743488f-8dc8-43db-b3a9-c048387e52bc",
  "category": "Board",
  "name": "Test committee - sync members 20260429T084847",
  "project_uid": "b0a360ec-1e37-452f-b5e3-233d4000365a"
}
```

---

## Step 2 — Create Member

**Request**
```
POST http://lfx-api.k8s.orb.local:80/committees/7743488f-8dc8-43db-b3a9-c048387e52bc/members?v=1
Authorization: Bearer authelia_at_H8TUfFLRaA8ocDUg...
```
```json
{
  "username": "mauriciozanetti",
  "email": "msalomao@contractor.linuxfoundation.org",
  "job_title": "Software Engineer",
  "role": {"name": "Chair", "start_date": "2025-01-01", "end_date": "2026-12-31"},
  "status": "Active"
}
```

**Response — 201 Created**
```json
{
  "uid": "f31aeab8-9a4b-4c69-88ed-57bf904bd0a1",
  "committee_uid": "7743488f-8dc8-43db-b3a9-c048387e52bc",
  "committee_name": "Test committee - sync members 20260429T084847",
  "committee_category": "Board",
  "created_at": "2026-04-29T11:49:01Z",
  "updated_at": "2026-04-29T11:49:01Z"
}
```

---

## Step 3 — OpenSearch: Member State Before Committee Update

**Query by** `object_id: f31aeab8-9a4b-4c69-88ed-57bf904bd0a1`

**Result**
```
total hits : 1
committee_category (data) : Board
tags                       : ["committee_category:Board"]
updated_at                 : 2026-04-29T11:49:01.779756729Z
```

**Observation:** Member indexed with `committee_category: "Board"`. ✅

---

## Step 4 — Update Committee Category to `Other`

**Request**
```
PUT http://lfx-api.k8s.orb.local:80/committees/7743488f-8dc8-43db-b3a9-c048387e52bc
If-Match: 671
Authorization: Bearer authelia_at_H8TUfFLRaA8ocDUg...
```
```json
{ "category": "Other", ... }
```

**Response — 200 OK**
```json
{
  "uid": "7743488f-8dc8-43db-b3a9-c048387e52bc",
  "category": "Other"
}
```

**Observation:** Committee updated to `"Other"`. Service emits `lfx.committee-api.committee.updated` NATS event with old (`Board`) and new (`Other`) images. ✅

---

## Step 5 — OpenSearch: Member State After Committee Update

**Query by** `object_id: f31aeab8-9a4b-4c69-88ed-57bf904bd0a1`

**Result**
```
total hits : 1
committee_category (data) : Other
tags                       : ["committee_category:Other"]
updated_at                 : 2026-04-29T11:49:26.893309801Z
```

**Observation:** `committee_category` changed from `"Board"` to `"Other"` in both `data` and `tags`. `updated_at` advanced by ~25 seconds confirming the async KV write and re-index completed. ✅

---

## Summary

| Check | Result |
|---|---|
| Member created with `committee_category: "Board"` | ✅ |
| Member indexed in OpenSearch with `committee_category:Board` tag | ✅ |
| Committee updated to `category: "Other"` | ✅ |
| `committee.updated` event emitted with old+new images | ✅ |
| Member `committee_category` synced to `"Other"` in KV | ✅ |
| Member re-indexed in OpenSearch with `committee_category:Other` tag | ✅ |
| Non-changed members skipped (idempotency via `NeedsSyncWith`) | ✅ |
