### PR TITLE
[LFXV2-1608] docs: remove enricher system references from comments

### DIFF
--- a/cmd/committee-api/README.md
+++ b/cmd/committee-api/README.md
@@ -130,7 +130,7 @@ This service follows clean architecture principles with clear separation of conc
 
 This service indexes committee data into the indexer service, making it searchable via the query service.
 
-Each indexer message includes an `IndexingConfig` that provides pre-computed metadata for the indexer service. When present, it bypasses server-side enrichers and controls how the document is stored, searched, and access-checked in the index. For the full field reference and message format details, see the [indexer service client guide](https://github.com/linuxfoundation/lfx-v2-indexer-service/blob/main/docs/client-guide.md).
+Create and update indexer messages include an `IndexingConfig` that provides the metadata controlling how the document is stored, searched, and access-checked in the index. Delete messages omit `IndexingConfig` — only the object ID is needed to remove the document. For the full field reference and message format details, see the [indexer service client guide](https://github.com/linuxfoundation/lfx-v2-indexer-service/blob/main/docs/client-guide.md).
 
 For the data schemas, tags, access control values, parent references, and fulltext fields for all resource types — see [`docs/indexer-contract.md`](../../docs/indexer-contract.md).
 

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -912,7 +912,7 @@ func (s *committeeServicesrvc) resolveCallerEmail(ctx context.Context) (string, 
 
 // publishInviteIndexerMessage publishes an indexer message for invite operations.
 // Publishing is best-effort: failures are logged but do not fail the request.
-// IndexingConfig is required because there is no server-side enricher for committee_invite.
+// IndexingConfig is required because the indexer is data-agnostic; publishers supply all indexing metadata.
 func (s *committeeServicesrvc) publishInviteIndexerMessage(ctx context.Context, action model.MessageAction, invite *model.CommitteeInvite, sync bool) {
 	tags := invite.Tags()
 	indexingConfig := &indexerTypes.IndexingConfig{
@@ -964,7 +964,7 @@ func (s *committeeServicesrvc) publishInviteIndexerMessage(ctx context.Context, 
 
 // publishApplicationIndexerMessage publishes an indexer message for application operations.
 // Publishing is best-effort: failures are logged but do not fail the request.
-// IndexingConfig is required because there is no server-side enricher for committee_application.
+// IndexingConfig is required because the indexer is data-agnostic; publishers supply all indexing metadata.
 func (s *committeeServicesrvc) publishApplicationIndexerMessage(ctx context.Context, action model.MessageAction, application *model.CommitteeApplication, sync bool) {
 	tags := application.Tags()
 	indexingConfig := &indexerTypes.IndexingConfig{

--- a/internal/domain/model/committee_message.go
+++ b/internal/domain/model/committee_message.go
@@ -43,8 +43,9 @@ type CommitteeIndexerMessage struct {
 	Data    any               `json:"data"`
 	// Tags is a list of tags to be set on the indexed resource for search.
 	Tags []string `json:"tags"`
-	// IndexingConfig provides indexing metadata for the resource. The indexer is data-agnostic,
-	// so publishers are responsible for supplying all indexing metadata.
+	// IndexingConfig provides indexing metadata for the resource.
+	// Callers building a CommitteeIndexerMessage must populate IndexingConfig for create and update actions;
+	// it is omitted for delete actions.
 	IndexingConfig *indexerTypes.IndexingConfig `json:"indexing_config,omitempty"`
 }
 

--- a/internal/domain/model/committee_message.go
+++ b/internal/domain/model/committee_message.go
@@ -43,8 +43,8 @@ type CommitteeIndexerMessage struct {
 	Data    any               `json:"data"`
 	// Tags is a list of tags to be set on the indexed resource for search.
 	Tags []string `json:"tags"`
-	// IndexingConfig provides pre-computed indexing metadata for resources that
-	// do not have a server-side enricher registered in the indexer service.
+	// IndexingConfig provides indexing metadata for the resource. The indexer is data-agnostic,
+	// so publishers are responsible for supplying all indexing metadata.
 	IndexingConfig *indexerTypes.IndexingConfig `json:"indexing_config,omitempty"`
 }
 

--- a/internal/service/committee_writer.go
+++ b/internal/service/committee_writer.go
@@ -24,7 +24,6 @@ import (
 )
 
 // buildCommitteeIndexingConfig constructs an IndexingConfig for a CommitteeBase document.
-// It mirrors what the CommitteeEnricher in the indexer service would derive from the data.
 func buildCommitteeIndexingConfig(committee *model.Committee) *indexerTypes.IndexingConfig {
 	var nameAndAliases []string
 	if committee.Name != "" {
@@ -71,7 +70,6 @@ func buildCommitteeIndexingConfig(committee *model.Committee) *indexerTypes.Inde
 }
 
 // buildCommitteeSettingsIndexingConfig constructs an IndexingConfig for a CommitteeSettings document.
-// It mirrors what the CommitteeSettingsEnricher in the indexer service would derive from the data.
 func buildCommitteeSettingsIndexingConfig(committee *model.Committee) *indexerTypes.IndexingConfig {
 	public := committee.Public
 	return &indexerTypes.IndexingConfig{


### PR DESCRIPTION
## Summary

- Remove stale "server-side enricher" concept references from comments and docs
- Affects: `cmd/committee-api/service/committee_service.go`, `internal/domain/model/committee_message.go`, `internal/service/committee_writer.go`, `cmd/committee-api/README.md`
- Comments now reflect the actual contract: publishers supply `IndexingConfig` for create/update; delete messages omit it

## Ticket

[LFXV2-1608](https://jira.linuxfoundation.org/browse/LFXV2-1608)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1608]: https://linuxfoundation.atlassian.net/browse/LFXV2-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ