### PR TITLE
[LFXV2-1701] fix: consolidate duplicate error logging to boundary callers

### DIFF
--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -65,10 +65,6 @@ func (rc *committeeReaderOrchestrator) GetBase(ctx context.Context, uid string) 
 	// Get committee base from storage
 	committeeBase, revision, err := rc.committeeReader.GetBase(ctx, uid)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee base",
-			"error", err,
-			"committee_uid", uid,
-		)
 		return nil, 0, err
 	}
 
@@ -90,10 +86,6 @@ func (rc *committeeReaderOrchestrator) GetSettings(ctx context.Context, uid stri
 	// Get committee settings from storage
 	committeeSettings, revision, err := rc.committeeReader.GetSettings(ctx, uid)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee settings",
-			"error", err,
-			"committee_uid", uid,
-		)
 		return nil, 0, err
 	}
 
@@ -137,31 +129,17 @@ func (rc *committeeReaderOrchestrator) GetMember(ctx context.Context, committeeU
 	// First, verify that the committee exists
 	_, _, err := rc.committeeReader.GetBase(ctx, committeeUID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee base - committee does not exist",
-			"error", err,
-			"committee_uid", committeeUID,
-		)
 		return nil, 0, err
 	}
 
 	// Get committee member from storage
 	committeeMember, revision, err := rc.committeeReader.GetMember(ctx, memberUID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee member",
-			"error", err,
-			"committee_uid", committeeUID,
-			"member_uid", memberUID,
-		)
 		return nil, 0, err
 	}
 
 	// Verify that the member belongs to the requested committee
 	if committeeMember.CommitteeUID != committeeUID {
-		slog.ErrorContext(ctx, "committee member does not belong to the requested committee",
-			"committee_uid", committeeUID,
-			"member_uid", memberUID,
-			"member_committee_uid", committeeMember.CommitteeUID,
-		)
 		return nil, 0, errs.NewValidation("committee member does not belong to the requested committee")
 	}
 
@@ -184,10 +162,6 @@ func (rc *committeeReaderOrchestrator) ListMembers(ctx context.Context, committe
 	// Get all committee members from storage
 	members, err := rc.committeeReader.ListMembers(ctx, committeeUID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to list committee members",
-			"error", err,
-			"committee_uid", committeeUID,
-		)
 		return nil, err
 	}
 

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/port"
 	errs "github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/fields"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/log"
 )
 
 // CommitteeReader defines the interface for committee read operations
@@ -58,6 +59,7 @@ type committeeReaderOrchestrator struct {
 // GetBase retrieves committee base information by UID
 func (rc *committeeReaderOrchestrator) GetBase(ctx context.Context, uid string) (*model.CommitteeBase, uint64, error) {
 
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
 	slog.DebugContext(ctx, "executing get committee base use case",
 		"committee_uid", uid,
 	)
@@ -79,6 +81,7 @@ func (rc *committeeReaderOrchestrator) GetBase(ctx context.Context, uid string) 
 // GetSettings retrieves committee settings by UID
 func (rc *committeeReaderOrchestrator) GetSettings(ctx context.Context, uid string) (*model.CommitteeSettings, uint64, error) {
 
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
 	slog.DebugContext(ctx, "executing get committee settings use case",
 		"committee_uid", uid,
 	)
@@ -121,6 +124,8 @@ func (rc *committeeReaderOrchestrator) GetMemberRevision(ctx context.Context, me
 // GetMember retrieves a committee member by committee UID and member UID
 func (rc *committeeReaderOrchestrator) GetMember(ctx context.Context, committeeUID, memberUID string) (*model.CommitteeMember, uint64, error) {
 
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", committeeUID))
+	ctx = log.AppendCtx(ctx, slog.String("member_uid", memberUID))
 	slog.DebugContext(ctx, "executing get committee member use case",
 		"committee_uid", committeeUID,
 		"member_uid", memberUID,
@@ -155,6 +160,7 @@ func (rc *committeeReaderOrchestrator) GetMember(ctx context.Context, committeeU
 // ListMembers retrieves all members for a given committee UID
 func (rc *committeeReaderOrchestrator) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", committeeUID))
 	slog.DebugContext(ctx, "executing list committee members use case",
 		"committee_uid", committeeUID,
 	)

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -60,9 +60,7 @@ type committeeReaderOrchestrator struct {
 func (rc *committeeReaderOrchestrator) GetBase(ctx context.Context, uid string) (*model.CommitteeBase, uint64, error) {
 
 	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
-	slog.DebugContext(ctx, "executing get committee base use case",
-		"committee_uid", uid,
-	)
+	slog.DebugContext(ctx, "executing get committee base use case")
 
 	// Get committee base from storage
 	committeeBase, revision, err := rc.committeeReader.GetBase(ctx, uid)
@@ -70,10 +68,7 @@ func (rc *committeeReaderOrchestrator) GetBase(ctx context.Context, uid string) 
 		return nil, 0, err
 	}
 
-	slog.DebugContext(ctx, "committee base retrieved successfully",
-		"committee_uid", uid,
-		"revision", revision,
-	)
+	slog.DebugContext(ctx, "committee base retrieved successfully", "revision", revision)
 
 	return committeeBase, revision, nil
 }
@@ -82,9 +77,7 @@ func (rc *committeeReaderOrchestrator) GetBase(ctx context.Context, uid string) 
 func (rc *committeeReaderOrchestrator) GetSettings(ctx context.Context, uid string) (*model.CommitteeSettings, uint64, error) {
 
 	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
-	slog.DebugContext(ctx, "executing get committee settings use case",
-		"committee_uid", uid,
-	)
+	slog.DebugContext(ctx, "executing get committee settings use case")
 
 	// Get committee settings from storage
 	committeeSettings, revision, err := rc.committeeReader.GetSettings(ctx, uid)
@@ -92,10 +85,7 @@ func (rc *committeeReaderOrchestrator) GetSettings(ctx context.Context, uid stri
 		return nil, 0, err
 	}
 
-	slog.DebugContext(ctx, "committee settings retrieved successfully",
-		"committee_uid", uid,
-		"revision", revision,
-	)
+	slog.DebugContext(ctx, "committee settings retrieved successfully", "revision", revision)
 
 	return committeeSettings, revision, nil
 }
@@ -126,10 +116,7 @@ func (rc *committeeReaderOrchestrator) GetMember(ctx context.Context, committeeU
 
 	ctx = log.AppendCtx(ctx, slog.String("committee_uid", committeeUID))
 	ctx = log.AppendCtx(ctx, slog.String("member_uid", memberUID))
-	slog.DebugContext(ctx, "executing get committee member use case",
-		"committee_uid", committeeUID,
-		"member_uid", memberUID,
-	)
+	slog.DebugContext(ctx, "executing get committee member use case")
 
 	// First, verify that the committee exists
 	_, _, err := rc.committeeReader.GetBase(ctx, committeeUID)
@@ -148,11 +135,7 @@ func (rc *committeeReaderOrchestrator) GetMember(ctx context.Context, committeeU
 		return nil, 0, errs.NewValidation("committee member does not belong to the requested committee")
 	}
 
-	slog.DebugContext(ctx, "committee member retrieved successfully",
-		"committee_uid", committeeUID,
-		"member_uid", memberUID,
-		"revision", revision,
-	)
+	slog.DebugContext(ctx, "committee member retrieved successfully", "revision", revision)
 
 	return committeeMember, revision, nil
 }
@@ -161,9 +144,7 @@ func (rc *committeeReaderOrchestrator) GetMember(ctx context.Context, committeeU
 func (rc *committeeReaderOrchestrator) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 
 	ctx = log.AppendCtx(ctx, slog.String("committee_uid", committeeUID))
-	slog.DebugContext(ctx, "executing list committee members use case",
-		"committee_uid", committeeUID,
-	)
+	slog.DebugContext(ctx, "executing list committee members use case")
 
 	// Get all committee members from storage
 	members, err := rc.committeeReader.ListMembers(ctx, committeeUID)
@@ -171,10 +152,7 @@ func (rc *committeeReaderOrchestrator) ListMembers(ctx context.Context, committe
 		return nil, err
 	}
 
-	slog.DebugContext(ctx, "committee members retrieved successfully",
-		"committee_uid", committeeUID,
-		"member_count", len(members),
-	)
+	slog.DebugContext(ctx, "committee members retrieved successfully", "member_count", len(members))
 
 	return members, nil
 }

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -64,19 +64,15 @@ func (m *messageHandlerOrchestrator) HandleCommitteeGetAttribute(ctx context.Con
 	// Parse message data to extract committee UID
 	uid := string(msg.Data())
 
-	slog.DebugContext(ctx, "committee get name request",
-		"committee_uid", uid,
-		"attribute", attribute,
-	)
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
+	ctx = log.AppendCtx(ctx, slog.String("attribute", attribute))
+	slog.DebugContext(ctx, "committee get name request")
 
 	// Validate that the committee ID is a valid UUID.
 	_, err := uuid.Parse(uid)
 	if err != nil {
 		return nil, err
 	}
-
-	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
-	ctx = log.AppendCtx(ctx, slog.String("attribute", attribute))
 
 	// Use the committee reader to get the committee base information
 	committee, _, err := m.committeeReader.GetBase(ctx, uid)
@@ -103,17 +99,14 @@ func (m *messageHandlerOrchestrator) HandleCommitteeListMembers(ctx context.Cont
 	// Parse message data to extract committee UID
 	uid := string(msg.Data())
 
-	slog.DebugContext(ctx, "committee list members request",
-		"committee_uid", uid,
-	)
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
+	slog.DebugContext(ctx, "committee list members request")
 
 	// Validate that the committee ID is a valid UUID.
 	_, err := uuid.Parse(uid)
 	if err != nil {
 		return nil, err
 	}
-
-	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
 
 	// Check if the committee exists first
 	_, _, err = m.committeeReader.GetBase(ctx, uid)
@@ -133,10 +126,7 @@ func (m *messageHandlerOrchestrator) HandleCommitteeListMembers(ctx context.Cont
 		return nil, errors.NewUnexpected("failed to marshal committee members", err)
 	}
 
-	slog.DebugContext(ctx, "committee list members response",
-		"committee_uid", uid,
-		"member_count", len(members),
-	)
+	slog.DebugContext(ctx, "committee list members response", "member_count", len(members))
 
 	return membersJSON, nil
 }
@@ -327,10 +317,7 @@ func (m *messageHandlerOrchestrator) HandleCommitteeTotalMembersSync(ctx context
 	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
 	ctx = log.AppendCtx(ctx, slog.String("committee_uid", committeeUID))
 
-	slog.DebugContext(ctx, "starting total_members sync",
-		"committee_uid", committeeUID,
-		"subject", subject,
-	)
+	slog.DebugContext(ctx, "starting total_members sync", "subject", subject)
 
 	members, err := m.committeeReader.ListMembers(ctx, committeeUID)
 	if err != nil {
@@ -344,15 +331,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeTotalMembersSync(ctx context
 	}
 
 	if committee.TotalMembers == actualCount {
-		slog.DebugContext(ctx, "total_members already correct — skipping update",
-			"committee_uid", committeeUID,
-			"total_members", actualCount,
-		)
+		slog.DebugContext(ctx, "total_members already correct — skipping update", "total_members", actualCount)
 		return nil
 	}
 
 	slog.DebugContext(ctx, "updating total_members counter",
-		"committee_uid", committeeUID,
 		"previous", committee.TotalMembers,
 		"actual", actualCount,
 	)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/fields"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/log"
 )
 
 // messageHandlerOrchestrator orchestrates the message handling process
@@ -74,6 +75,9 @@ func (m *messageHandlerOrchestrator) HandleCommitteeGetAttribute(ctx context.Con
 		return nil, err
 	}
 
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
+	ctx = log.AppendCtx(ctx, slog.String("attribute", attribute))
+
 	// Use the committee reader to get the committee base information
 	committee, _, err := m.committeeReader.GetBase(ctx, uid)
 	if err != nil {
@@ -108,6 +112,8 @@ func (m *messageHandlerOrchestrator) HandleCommitteeListMembers(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", uid))
 
 	// Check if the committee exists first
 	_, _, err = m.committeeReader.GetBase(ctx, uid)
@@ -319,6 +325,7 @@ func (m *messageHandlerOrchestrator) HandleCommitteeTotalMembersSync(ctx context
 	committeeUID := member.CommitteeUID
 
 	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
+	ctx = log.AppendCtx(ctx, slog.String("committee_uid", committeeUID))
 
 	slog.DebugContext(ctx, "starting total_members sync",
 		"committee_uid", committeeUID,

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -71,36 +71,22 @@ func (m *messageHandlerOrchestrator) HandleCommitteeGetAttribute(ctx context.Con
 	// Validate that the committee ID is a valid UUID.
 	_, err := uuid.Parse(uid)
 	if err != nil {
-		slog.ErrorContext(ctx, "error parsing committee ID", "error", err)
 		return nil, err
 	}
 
 	// Use the committee reader to get the committee base information
 	committee, _, err := m.committeeReader.GetBase(ctx, uid)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee base",
-			"error", err,
-			"committee_uid", uid,
-		)
 		return nil, err
 	}
 
 	value, ok := fields.LookupByTag(committee, "json", attribute)
 	if !ok {
-		slog.ErrorContext(ctx, "attribute not found in committee",
-			"attribute", attribute,
-			"committee_uid", uid,
-		)
 		return nil, errors.NewNotFound(fmt.Sprintf("attribute %s not found in committee %s", attribute, uid))
 	}
 
 	strValue, ok := value.(string)
 	if !ok {
-		slog.ErrorContext(ctx, "attribute value is not a string",
-			"attribute", attribute,
-			"committee_uid", uid,
-			"value_type", fmt.Sprintf("%T", value),
-		)
 		return nil, errors.NewValidation(fmt.Sprintf("attribute %s value is not a string", attribute))
 	}
 
@@ -120,37 +106,24 @@ func (m *messageHandlerOrchestrator) HandleCommitteeListMembers(ctx context.Cont
 	// Validate that the committee ID is a valid UUID.
 	_, err := uuid.Parse(uid)
 	if err != nil {
-		slog.ErrorContext(ctx, "error parsing committee ID", "error", err)
 		return nil, err
 	}
 
 	// Check if the committee exists first
 	_, _, err = m.committeeReader.GetBase(ctx, uid)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee base",
-			"error", err,
-			"committee_uid", uid,
-		)
 		return nil, err
 	}
 
 	// Get all members for the committee
 	members, err := m.committeeReader.ListMembers(ctx, uid)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to list committee members",
-			"error", err,
-			"committee_uid", uid,
-		)
 		return nil, err
 	}
 
 	// Marshal the members to JSON
 	membersJSON, err := json.Marshal(members)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to marshal committee members",
-			"error", err,
-			"committee_uid", uid,
-		)
 		return nil, errors.NewUnexpected("failed to marshal committee members", err)
 	}
 
@@ -167,7 +140,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeListMembers(ctx context.Cont
 func (m *messageHandlerOrchestrator) HandleCommitteeMailingListChanged(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 	var event model.CommitteeMailingListChangedEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
-		slog.ErrorContext(ctx, "failed to unmarshal CommitteeMailingListChangedEvent", "error", err)
 		return nil, err
 	}
 
@@ -183,8 +155,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMailingListChanged(ctx conte
 
 	committee, changed, err := m.committeeWriter.UpdateHasMailingList(ctx, event.CommitteeUID, event.HasMailingList)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to update has_mailing_list",
-			"committee_uid", event.CommitteeUID, "error", err)
 		return nil, err
 	}
 	if !changed {
@@ -202,15 +172,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMailingListChanged(ctx conte
 
 	indexerMsg, err := buildIndexerMessage(ctx, model.ActionUpdated, committee, fullCommittee.Tags())
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to build indexer message",
-			"committee_uid", event.CommitteeUID, "error", err)
 		return nil, err
 	}
 	indexerMsg.IndexingConfig = buildCommitteeIndexingConfig(fullCommittee)
 
 	if err := m.committeePublisher.Indexer(ctx, constants.IndexCommitteeSubject, indexerMsg, false); err != nil {
-		slog.ErrorContext(ctx, "failed to publish committee indexer update",
-			"committee_uid", event.CommitteeUID, "error", err)
 		return nil, err
 	}
 
@@ -229,7 +195,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context,
 
 	var event model.CommitteeEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
-		slog.ErrorContext(ctx, "failed to unmarshal CommitteeEvent", "error", err)
 		return nil, err
 	}
 
@@ -267,8 +232,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context,
 
 	members, err := m.committeeReader.ListMembers(ctx, data.CommitteeUID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to list members for sync",
-			"committee_uid", data.CommitteeUID, "error", err)
 		return nil, err
 	}
 
@@ -333,7 +296,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeTotalMembersSync(ctx context
 
 	var event model.CommitteeEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
-		slog.ErrorContext(ctx, "failed to unmarshal CommitteeEvent for total_members sync", "error", err)
 		return err
 	}
 
@@ -365,16 +327,12 @@ func (m *messageHandlerOrchestrator) HandleCommitteeTotalMembersSync(ctx context
 
 	members, err := m.committeeReader.ListMembers(ctx, committeeUID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to list members for total_members sync",
-			"committee_uid", committeeUID, "error", err)
 		return err
 	}
 	actualCount := len(members)
 
 	committee, revision, err := m.committeeReader.GetBase(ctx, committeeUID)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to get committee base for total_members sync",
-			"committee_uid", committeeUID, "error", err)
 		return err
 	}
 
@@ -395,8 +353,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeTotalMembersSync(ctx context
 	committee.TotalMembers = actualCount
 
 	if _, err := m.committeeWriterOrchestrator.Update(ctx, &model.Committee{CommitteeBase: *committee}, revision, false); err != nil {
-		slog.ErrorContext(ctx, "failed to update committee total_members",
-			"committee_uid", committeeUID, "error", err)
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Errors returned from the service orchestration layer were being logged 2-3 times per error: once in the internal orchestrator, again in the message handler, and once more at the transport boundary (`wrapError` for HTTP, `committee_handler` for NATS, `stream_consumer` for JetStream)
- Removed redundant `slog.ErrorContext` calls from `committee_reader.go` and `message_handler.go` for all errors that are simply returned to a caller
- Per-member error logs inside the `HandleCommitteeUpdated` sync loop are retained since they carry unique `member_uid` context that the outer caller cannot replicate

## Ticket

[LFXV2-1701](https://jira.linuxfoundation.org/browse/LFXV2-1701)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1701]: https://linuxfoundation.atlassian.net/browse/LFXV2-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ