### PR TITLE
docs(weekly-brief): add group_weekly_brief to indexer contract

### DIFF
--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -527,7 +527,7 @@ _(none)_
 | Field | Value |
 |---|---|
 | `access_check_object` | `committee:{committee_uid}` |
-| `access_check_relation` | `writer` |
+| `access_check_relation` | `viewer` |
 | `history_check_object` | `committee:{committee_uid}` |
 | `history_check_relation` | `auditor` |
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -15,6 +15,7 @@ This document is the authoritative reference for all data the committee service 
 - [Committee Application](#committee-application)
 - [Committee Link](#committee-link)
 - [Committee Link Folder](#committee-link-folder)
+- [Group Weekly Brief](#group-weekly-brief)
 
 ---
 
@@ -473,6 +474,65 @@ _(none)_
 | `name_and_aliases` | `name` |
 | `sort_name` | `name` |
 | `public` | inherits from parent committee |
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `committee:{committee_uid}` | Always set |
+
+---
+
+## Group Weekly Brief
+
+**Object type:** `group_weekly_brief`
+
+**NATS subject:** `lfx.index.group_weekly_brief`
+
+**Source struct:** `internal/domain/model/group_weekly_brief.go` — `GroupWeeklyBrief`
+
+**Indexed on:** create, update, delete of a group weekly brief draft.
+
+> Published briefs will be a future separate entity; this entry covers the draft only.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Brief unique identifier |
+| `committee_uid` | string | UID of the committee this brief belongs to |
+| `window_start` | timestamp | Start of the brief's reporting window (RFC3339) |
+| `window_end` | timestamp | End of the brief's reporting window (RFC3339) |
+| `state` | string | Draft state (e.g., `Pending`, `Generating`, `Ready`, `Failed`) |
+| `brief_text` | string | Generated brief body; included in the indexed data payload |
+| `source_refs` | []object | References to the source artifacts the brief was generated from |
+| `prompt_version` | string | Version identifier of the prompt used to generate the brief |
+| `model` | string | Identifier of the model used to generate the brief |
+| `regeneration_count` | int | Number of times the brief has been regenerated |
+| `private_source_present` | bool | Whether any source artifact used was private |
+| `created_at` | timestamp | Creation time (RFC3339) |
+| `updated_at` | timestamp | Last update time (RFC3339) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `committee:{committee_uid}` | `committee:061a110a-7c38-4cd3-bfcf-fc8511a37f35` | Find weekly briefs for a committee |
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `committee:{committee_uid}` |
+| `access_check_relation` | `writer` |
+
+### Search Behavior
+
+| Field | Value |
+|---|---|
+| `fulltext` | `brief_text` |
+| `filterable` | `state`, `committee_uid`, `window_start`, `window_end`, `uid` |
+| `indexed_public` | `false` (always — intentional; even for public committees, brief drafts are never indexed as public) |
 
 ### Parent References
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -513,6 +513,8 @@ _(none)_
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 
+> **State lifecycle.** `empty` is the initial placeholder: a brief record exists for the (committee, window) pair but no generation has produced content yet. `generating` is set while a generation run is in flight. On success the brief moves to `generated`; a manual edit moves it to `edited`, and `approved` marks it ready. `error` is the terminal failure state for a generation run. Typical flow: `empty → generating → generated → (edited) → approved`, with `error` reachable from `generating`.
+
 ### Tags
 
 | Tag Format | Example | Purpose |
@@ -537,7 +539,7 @@ _(none)_
 |---|---|
 | `fulltext` | `brief_text` |
 | `name_and_aliases` | _(none)_ |
-| `sort_name` | `created_at` |
+| `sort_name` | _(none)_ |
 | `public` | `false` (always — intentional; even for public committees, brief drafts are never indexed as public) |
 
 ### Parent References

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -505,7 +505,7 @@ _(none)_
 | `window_end` | timestamp | End of the brief's reporting window (RFC3339) |
 | `state` | string | Draft state (e.g., `empty`, `generating`, `generated`, `edited`, `approved`, `error`) |
 | `brief_text` | string | Generated brief body; included in the indexed data payload |
-| `source_refs` | []object | References to the source artifacts the brief was generated from |
+| `source_refs` | []object | References to the source artifacts the brief was generated from. Each object has `kind` (string — source category, e.g. `meeting`, `mailing-list`, `doc`), `id` (string — source-system identifier, a URL or UID), and optionally `title` (string — short human label) and `excerpt` (string — the snippet the generator consumed). `kind` and `id` are always present; `title` and `excerpt` are omitted when empty |
 | `prompt_version` | string | Version identifier of the prompt used to generate the brief |
 | `model` | string | Identifier of the model used to generate the brief |
 | `regeneration_count` | int | Number of times the brief has been regenerated |

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -489,7 +489,7 @@ _(none)_
 
 **NATS subject:** `lfx.index.group_weekly_brief`
 
-**Source struct:** `internal/domain/model/group_weekly_brief.go` — `GroupWeeklyBrief`
+**Source struct:** `internal/domain/model/group_weekly_brief.go` — `GroupWeeklyBrief` _(introduced in the entity-read-path PR; this contract entry lands first)_
 
 **Indexed on:** create, update, delete of a group weekly brief draft.
 
@@ -503,7 +503,7 @@ _(none)_
 | `committee_uid` | string | UID of the committee this brief belongs to |
 | `window_start` | timestamp | Start of the brief's reporting window (RFC3339) |
 | `window_end` | timestamp | End of the brief's reporting window (RFC3339) |
-| `state` | string | Draft state (e.g., `Pending`, `Generating`, `Ready`, `Failed`) |
+| `state` | string | Draft state (e.g., `empty`, `generating`, `generated`, `edited`, `approved`, `error`) |
 | `brief_text` | string | Generated brief body; included in the indexed data payload |
 | `source_refs` | []object | References to the source artifacts the brief was generated from |
 | `prompt_version` | string | Version identifier of the prompt used to generate the brief |
@@ -517,7 +517,10 @@ _(none)_
 
 | Tag Format | Example | Purpose |
 |---|---|---|
-| `committee:{committee_uid}` | `committee:061a110a-7c38-4cd3-bfcf-fc8511a37f35` | Find weekly briefs for a committee |
+| `{uid}` | `c53dc2b0-b7ed-483f-9296-b7d904e8d168` | Direct lookup by UID |
+| `group_weekly_brief_uid:{uid}` | `group_weekly_brief_uid:c53dc2b0-b7ed-483f-9296-b7d904e8d168` | Namespaced lookup by UID |
+| `committee_uid:{value}` | `committee_uid:061a110a-7c38-4cd3-bfcf-fc8511a37f35` | Find weekly briefs for a committee |
+| `state:{value}` | `state:generated` | Find briefs by state |
 
 ### Access Control (IndexingConfig)
 
@@ -525,14 +528,17 @@ _(none)_
 |---|---|
 | `access_check_object` | `committee:{committee_uid}` |
 | `access_check_relation` | `writer` |
+| `history_check_object` | `committee:{committee_uid}` |
+| `history_check_relation` | `auditor` |
 
 ### Search Behavior
 
 | Field | Value |
 |---|---|
 | `fulltext` | `brief_text` |
-| `filterable` | `state`, `committee_uid`, `window_start`, `window_end`, `uid` |
-| `indexed_public` | `false` (always — intentional; even for public committees, brief drafts are never indexed as public) |
+| `name_and_aliases` | _(none)_ |
+| `sort_name` | `created_at` |
+| `public` | `false` (always — intentional; even for public committees, brief drafts are never indexed as public) |
 
 ### Parent References
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -513,7 +513,7 @@ _(none)_
 | `created_at` | timestamp | Creation time (RFC3339) |
 | `updated_at` | timestamp | Last update time (RFC3339) |
 
-> **State lifecycle.** `empty` is the initial placeholder: a brief record exists for the (committee, window) pair but no generation has produced content yet. `generating` is set while a generation run is in flight. On success the brief moves to `generated`; a manual edit moves it to `edited`, and `approved` marks it ready. `error` is the terminal failure state for a generation run. Typical flow: `empty → generating → generated → (edited) → approved`, with `error` reachable from `generating`.
+> **State lifecycle.** A brief is created in `generating` when a generate is requested — the request is accepted (202) and the source gather + LLM run asynchronously. On success the brief moves to `generated`; a manual edit moves it to `edited`, and `approved` marks it ready. `error` is the terminal failure state (no activity in the window, or an AI/generation failure). Typical flow: `generating → generated → (edited) → approved`, with `error` reachable from `generating`. (`empty` is a reserved enum value; the current generate flow does not create briefs in the `empty` state.)
 
 ### Tags
 


### PR DESCRIPTION
**Tracking:** [LFXV2-1977](https://linuxfoundation.atlassian.net/browse/LFXV2-1977) (part of Epic [LFXV2-1976](https://linuxfoundation.atlassian.net/browse/LFXV2-1976))

---

## Summary

Adds the `group_weekly_brief` entity to `docs/indexer-contract.md`. Docs-only change; pure preparation for the weekly-brief feature.

## Details

- Fields: uid, committee_uid, window_start/end, state, brief_text, source_refs, prompt_version, model, regeneration_count, private_source_present, created_at, updated_at
- Tags: `committee:{committee_uid}`
- Access: `committee:{committee_uid}` viewer relation; `indexed_public: false` always (intentional, even for public committees)
- Search: full-text on `brief_text`; filterable on state, committee_uid, window_start/end, uid
- Comment notes that published briefs are a future separate entity

## Stack

This is PR 1/4 in the committee-service side of the WG Weekly Brief feature. Independent of the other 3; mergeable first.

## Test plan

- [ ] Confirm format matches existing entries in `docs/indexer-contract.md`
- [ ] Verify `indexed_public: false` rationale is captured


[LFXV2-1977]: https://linuxfoundation.atlassian.net/browse/LFXV2-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-1976]: https://linuxfoundation.atlassian.net/browse/LFXV2-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ