### PR TITLE
[LFXV2-1993] Always resolve subject identifier from email, overriding caller-supplied username

### DIFF
--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -1167,19 +1167,24 @@ func (s *committeeServicesrvc) enrichAllRoleFields(ctx context.Context, slices .
 	return nil
 }
 
-// enrichMember resolves the LFID (username) and profile metadata for a member when only their
-// email is known (Username is empty). All lookups are best-effort: failures log a warning and
-// leave the field unchanged so the caller's write is never blocked by an enrichment error.
+// enrichMember resolves the subject identifier (username) and profile metadata for a member from
+// their email address. When email is present the auth-service lookup always runs, overriding any
+// caller-supplied plain LFID so only subject identifiers are persisted.
+// All lookups are best-effort: failures log a warning and leave the field unchanged so the
+// caller's write is never blocked by an enrichment error.
 // FirstName and LastName are only overwritten when the auth service returns a non-empty value
 // and the caller did not supply them, so caller-provided display names are preserved.
 func (s *committeeServicesrvc) enrichMember(ctx context.Context, member *model.CommitteeMember) {
-	if s.userReader == nil || strings.TrimSpace(member.Username) != "" {
+	if s.userReader == nil {
 		return
 	}
 	email := strings.ToLower(strings.TrimSpace(member.Email))
 	if email == "" {
 		return
 	}
+
+	// Clear any caller-supplied value so a failed lookup never leaves a plain LFID at rest.
+	member.Username = ""
 
 	// enrichMember is intentionally best-effort: transport errors warn and continue rather than
 	// failing the request. Individual member writes (create/update/approve) should not be blocked

--- a/cmd/committee-api/service/committee_service_test.go
+++ b/cmd/committee-api/service/committee_service_test.go
@@ -1943,7 +1943,7 @@ func TestEnrichMember(t *testing.T) {
 			},
 		},
 		{
-			name: "username already set — skipped entirely",
+			name: "caller-supplied plain LFID overridden by sub when email is present",
 			member: func() *model.CommitteeMember {
 				return &model.CommitteeMember{
 					CommitteeMemberBase: model.CommitteeMemberBase{
@@ -1953,10 +1953,10 @@ func TestEnrichMember(t *testing.T) {
 				}
 			},
 			setupReader: func(r *mockUserReader) {
-				r.withSubs("alice@example.com", "other-lfid")
+				r.withSubs("alice@example.com", "auth0|other-lfid")
 			},
 			validate: func(t *testing.T, m *model.CommitteeMember) {
-				assert.Equal(t, "existing-lfid", m.Username)
+				assert.Equal(t, "auth0|other-lfid", m.Username)
 			},
 		},
 		{

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -163,9 +163,11 @@ func (uc *committeeWriterOrchestrator) CreateMember(ctx context.Context, member 
 		}
 	}
 
-	// Step 4: Lookup username by email if username is not provided
-	if member.Username == "" && member.Email != "" {
-		slog.DebugContext(ctx, "username not provided, attempting lookup by email",
+	// Step 4: Resolve subject identifier from email, overriding any caller-supplied plain LFID.
+	// Clear first so a failed lookup never leaves an unverified value at rest.
+	if member.Email != "" {
+		member.Username = ""
+		slog.DebugContext(ctx, "resolving subject identifier from email",
 			"email", redaction.RedactEmail(member.Email),
 		)
 		sub, errLookup := uc.lookupSubByEmail(ctx, member.Email)
@@ -177,7 +179,7 @@ func (uc *committeeWriterOrchestrator) CreateMember(ctx context.Context, member 
 			// Continue without username - it's an optional field
 		} else if sub != "" {
 			member.Username = sub
-			slog.DebugContext(ctx, "username set from email lookup",
+			slog.DebugContext(ctx, "username resolved to subject identifier",
 				"email", redaction.RedactEmail(member.Email),
 				"username", redaction.Redact(member.Username),
 			)
@@ -430,9 +432,11 @@ func (uc *committeeWriterOrchestrator) UpdateMember(ctx context.Context, member 
 		staleKeys = append(staleKeys, oldLookupKey)
 	}
 
-	// Lookup username by email if username is not provided
-	if member.Username == "" && member.Email != "" {
-		slog.DebugContext(ctx, "username not provided in update, attempting lookup by email",
+	// Resolve subject identifier from email, overriding any caller-supplied plain LFID.
+	// Clear first so a failed lookup never leaves an unverified value at rest.
+	if member.Email != "" {
+		member.Username = ""
+		slog.DebugContext(ctx, "resolving subject identifier from email during update",
 			"email", redaction.RedactEmail(member.Email),
 		)
 		sub, errLookup := uc.lookupSubByEmail(ctx, member.Email)
@@ -444,7 +448,7 @@ func (uc *committeeWriterOrchestrator) UpdateMember(ctx context.Context, member 
 			// Continue without username - it's an optional field
 		} else if sub != "" {
 			member.Username = sub
-			slog.DebugContext(ctx, "username set from email lookup during update",
+			slog.DebugContext(ctx, "username resolved to subject identifier during update",
 				"email", redaction.RedactEmail(member.Email),
 				"username", redaction.Redact(member.Username),
 			)

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -211,6 +211,27 @@ func setupMemberWriterTest() (*committeeWriterOrchestrator, *mock.MockRepository
 	return orchestrator, mockRepo, memberWriter
 }
 
+// writerTestUserReader is a configurable UserReader mock for committee_member_writer tests.
+type writerTestUserReader struct {
+	subs map[string]string // email → sub
+	err  error             // returned by SubByEmail when non-nil
+}
+
+func (r *writerTestUserReader) SubByEmail(_ context.Context, email string) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.subs[email], nil
+}
+
+func (r *writerTestUserReader) EmailsByPrincipal(_ context.Context, _ string) (*model.UserEmails, error) {
+	return nil, nil
+}
+
+func (r *writerTestUserReader) UserMetadataByPrincipal(_ context.Context, _ string) (*model.UserMetadata, error) {
+	return nil, nil
+}
+
 // TestMockCommitteeReader is a minimal mock reader for testing
 type TestMockCommitteeReader struct {
 	memberRevisions map[string]uint64
@@ -847,6 +868,7 @@ func TestCommitteeWriterOrchestrator_DeleteMember_MessagePublishingFailure(t *te
 
 func TestCommitteeWriterOrchestrator_UpdateMember_Success(t *testing.T) {
 	orchestrator, mockRepo, memberWriter := setupMemberWriterTest()
+	orchestrator.userReader = &writerTestUserReader{subs: map[string]string{"new@example.com": "auth0|newuser"}}
 
 	// Setup committee with settings
 	committee := &model.Committee{
@@ -867,7 +889,7 @@ func TestCommitteeWriterOrchestrator_UpdateMember_Success(t *testing.T) {
 			UID:          "member-123",
 			CommitteeUID: "committee-123",
 			Email:        "old@example.com",
-			Username:     "olduser",
+			Username:     "auth0|olduser",
 			FirstName:    "Old",
 			LastName:     "User",
 			Organization: model.CommitteeMemberOrganization{
@@ -885,13 +907,13 @@ func TestCommitteeWriterOrchestrator_UpdateMember_Success(t *testing.T) {
 	memberWriter.members["member-123"] = existingMember
 	memberWriter.customRevisions["member-123"] = 1
 
-	// Create updated member with changes
+	// Create updated member with changes; caller supplies a plain LFID which must be overridden.
 	updatedMember := &model.CommitteeMember{
 		CommitteeMemberBase: model.CommitteeMemberBase{
 			UID:          "member-123",
 			CommitteeUID: "committee-123",
 			Email:        "new@example.com", // Email changed
-			Username:     "newuser",         // Username changed
+			Username:     "plain-lfid",      // caller-supplied; must be overridden by email lookup
 			FirstName:    "New",
 			LastName:     "User",
 			Organization: model.CommitteeMemberOrganization{
@@ -907,10 +929,10 @@ func TestCommitteeWriterOrchestrator_UpdateMember_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// Verify the member was updated
+	// Verify the member was updated and the subject identifier was resolved from email.
 	assert.Equal(t, "member-123", result.UID)
 	assert.Equal(t, "new@example.com", result.Email)
-	assert.Equal(t, "newuser", result.Username)
+	assert.Equal(t, "auth0|newuser", result.Username)
 	assert.Equal(t, "New Org", result.Organization.Name)
 
 	// Verify timestamps were preserved/updated correctly
@@ -1126,4 +1148,107 @@ func TestCommitteeWriterOrchestrator_UpdateMember_EmailAlreadyExists(t *testing.
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
 	assert.Nil(t, result)
+}
+
+func TestCommitteeWriterOrchestrator_CreateMember_UsernameResolution(t *testing.T) {
+	addCommittee := func(mockRepo *mock.MockRepository) {
+		mockRepo.AddCommittee(&model.Committee{
+			CommitteeBase: model.CommitteeBase{UID: "c-1", Name: "C", Category: "TC"},
+			CommitteeSettings: &model.CommitteeSettings{
+				UID: "c-1", BusinessEmailRequired: false,
+			},
+		})
+	}
+
+	t.Run("plain LFID overridden by subject identifier from email lookup", func(t *testing.T) {
+		orchestrator, mockRepo, _ := setupMemberWriterTest()
+		orchestrator.userReader = &writerTestUserReader{subs: map[string]string{"alice@example.com": "auth0|alice"}}
+		addCommittee(mockRepo)
+
+		result, err := orchestrator.CreateMember(context.Background(), &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				CommitteeUID: "c-1",
+				Email:        "alice@example.com",
+				Username:     "plain-lfid",
+				FirstName:    "Alice",
+				Organization: model.CommitteeMemberOrganization{Name: "Org"},
+			},
+		}, false)
+
+		require.NoError(t, err)
+		assert.Equal(t, "auth0|alice", result.Username)
+	})
+
+	t.Run("username cleared when email present but lookup fails", func(t *testing.T) {
+		orchestrator, mockRepo, _ := setupMemberWriterTest()
+		orchestrator.userReader = &writerTestUserReader{err: errs.NewServiceUnavailable("auth service down")}
+		addCommittee(mockRepo)
+
+		result, err := orchestrator.CreateMember(context.Background(), &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				CommitteeUID: "c-1",
+				Email:        "alice@example.com",
+				Username:     "plain-lfid",
+				FirstName:    "Alice",
+				Organization: model.CommitteeMemberOrganization{Name: "Org"},
+			},
+		}, false)
+
+		require.NoError(t, err)
+		assert.Empty(t, result.Username)
+	})
+}
+
+func TestCommitteeWriterOrchestrator_UpdateMember_UsernameResolution(t *testing.T) {
+	addCommitteeAndMember := func(mockRepo *mock.MockRepository, memberWriter *TestMockCommitteeMemberWriter) {
+		mockRepo.AddCommittee(&model.Committee{
+			CommitteeBase:     model.CommitteeBase{UID: "c-1", Name: "C", Category: "TC"},
+			CommitteeSettings: &model.CommitteeSettings{UID: "c-1"},
+		})
+		existing := &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				UID: "m-1", CommitteeUID: "c-1", Email: "old@example.com",
+				Username: "auth0|old", FirstName: "Old",
+				Organization: model.CommitteeMemberOrganization{Name: "Org"},
+				CreatedAt:    time.Now().Add(-time.Hour), UpdatedAt: time.Now().Add(-time.Hour),
+			},
+		}
+		mockRepo.AddCommitteeMember("c-1", existing)
+		memberWriter.members["m-1"] = existing
+		memberWriter.customRevisions["m-1"] = 1
+	}
+
+	t.Run("plain LFID overridden by subject identifier from email lookup", func(t *testing.T) {
+		orchestrator, mockRepo, memberWriter := setupMemberWriterTest()
+		orchestrator.userReader = &writerTestUserReader{subs: map[string]string{"new@example.com": "auth0|new"}}
+		addCommitteeAndMember(mockRepo, memberWriter)
+
+		result, err := orchestrator.UpdateMember(context.Background(), &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				UID: "m-1", CommitteeUID: "c-1", Email: "new@example.com",
+				Username: "plain-lfid", FirstName: "New",
+				Organization: model.CommitteeMemberOrganization{Name: "Org"},
+			},
+		}, 1, false)
+
+		require.NoError(t, err)
+		assert.Equal(t, "auth0|new", result.Username)
+	})
+
+	t.Run("username cleared when email present but lookup fails", func(t *testing.T) {
+		orchestrator, mockRepo, memberWriter := setupMemberWriterTest()
+		orchestrator.userReader = &writerTestUserReader{err: errs.NewServiceUnavailable("auth service down")}
+		addCommitteeAndMember(mockRepo, memberWriter)
+
+		result, err := orchestrator.UpdateMember(context.Background(), &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				UID: "m-1", CommitteeUID: "c-1", Email: "new@example.com",
+				Username: "plain-lfid", FirstName: "New",
+				Organization: model.CommitteeMemberOrganization{Name: "Org"},
+			},
+		}, 1, false)
+
+		require.NoError(t, err)
+		assert.Empty(t, result.Username)
+	})
 }


### PR DESCRIPTION
## Summary

- Fixes a bug where client-supplied plain LFIDs could bypass server-side enrichment and be persisted verbatim into the `Username` field on `CommitteeMember` and `CommitteeUser` records
- When a member's email is present, `SubByEmail` (NATS `lfx.auth-service.email_to_sub`) now always runs, overriding any caller-supplied value — ensuring only subject identifiers (e.g. `auth0|xxxxx`) reach KV storage and fga-sync
- Affected paths: `enrichMember` (single-member create/approve flows) and both create/update paths in `committee_member_writer.go`

## Background

Investigation for LFXV2-1993: `lfx-v2-project-service` had the same class of bug (LFXV2-1992) where plain LFIDs were written to fga-sync as `user:jmedev` while access checks used the canonical `user:auth0|jmedev` subject identifier. The previous enrichment gate (`only if Username == ""`) allowed any client-supplied username to pass through unchecked. This PR removes that gate so the auth-service lookup is authoritative whenever email is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)