### PR TITLE
ci(eval): wire weekly-brief live LLM eval as release gate

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -16,7 +16,20 @@ permissions:
   contents: read
 
 jobs:
+  eval-live:
+    # Release gate: blocks publish on a failing weekly-brief live LLM eval.
+    # Calls .github/workflows/weekly-brief-eval-live.yml (workflow_call)
+    # with only the secrets the called workflow declares as required —
+    # narrower than `secrets: inherit`. LFXV2-2019.
+    name: Weekly-Brief Live Eval (release gate)
+    uses: ./.github/workflows/weekly-brief-eval-live.yml
+    secrets:
+      LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+      LITELLM_MODEL: ${{ secrets.LITELLM_MODEL }}
+
   publish:
+    needs: eval-live
     name: Publish Tagged Release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -23,10 +23,6 @@ jobs:
     # narrower than `secrets: inherit`. LFXV2-2019.
     name: Weekly-Brief Live Eval (release gate)
     uses: ./.github/workflows/weekly-brief-eval-live.yml
-    secrets:
-      LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
-      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
-      LITELLM_MODEL: ${{ secrets.LITELLM_MODEL }}
 
   publish:
     needs: eval-live

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -18,10 +18,17 @@ permissions:
 jobs:
   eval-live:
     # Release gate: blocks publish on a failing weekly-brief live LLM eval.
-    # Calls .github/workflows/weekly-brief-eval-live.yml (workflow_call)
-    # with only the secrets the called workflow declares as required —
-    # narrower than `secrets: inherit`. LFXV2-2019.
+    # Calls .github/workflows/weekly-brief-eval-live.yml (workflow_call).
+    # The called workflow fetches LITELLM_API_KEY from AWS Secrets Manager
+    # via OIDC token exchange (LITELLM_BASE_URL and LITELLM_MODEL are
+    # pinned in the called workflow's env: block), so there are no
+    # GitHub repo secrets to map at the call site. id-token: write is
+    # required here because a reusable workflow cannot elevate
+    # permissions beyond what its caller grants. LFXV2-2019.
     name: Weekly-Brief Live Eval (release gate)
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/weekly-brief-eval-live.yml
 
   publish:

--- a/.github/workflows/weekly-brief-eval-live.yml
+++ b/.github/workflows/weekly-brief-eval-live.yml
@@ -18,17 +18,16 @@ name: "Weekly-Brief Live Eval"
 # Tracked: LFXV2-2019
 "on":
   workflow_call:
-    secrets:
-      LITELLM_BASE_URL:
-        required: true
-      LITELLM_API_KEY:
-        required: true
-      LITELLM_MODEL:
-        required: true
   workflow_dispatch:
 
 permissions:
   contents: read
+  # Required for aws-actions/configure-aws-credentials OIDC token exchange.
+  id-token: write
+
+env:
+  LITELLM_BASE_URL: litellm.dev.v2.cluster.linuxfound.info
+  LITELLM_MODEL: claude-sonnet-4-6
 
 jobs:
   eval-live:
@@ -48,14 +47,27 @@ jobs:
       - name: Download Dependencies
         run: make deps
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          audience: sts.amazonaws.com
+          role-to-assume: arn:aws:iam::450177423209:role/github-actions-deploy
+          aws-region: us-west-2
+
+      # This is used to fetch build time secrets from AWS Secrets Manager
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        with:
+          secret-ids: |
+            LITELLM_API_KEY, /cloudops/managed-secrets/litellm/lfx-one-cicd
+
       - name: Run live-LLM eval suite
-        # Secrets must be provisioned at the repo level
-        # (Settings -> Secrets and variables -> Actions). Missing values
-        # are a hard failure — the live test calls t.Fatalf rather than
-        # silently skipping under -tags=live, so a green run can't appear
-        # without anything actually executing.
-        env:
-          LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
-          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
-          LITELLM_MODEL: ${{ secrets.LITELLM_MODEL }}
+        # LITELLM_BASE_URL / LITELLM_MODEL are inherited from the
+        # workflow-level env: block. LITELLM_API_KEY is exported into
+        # $GITHUB_ENV by the preceding aws-secretsmanager-get-secrets
+        # step (sourced from /cloudops/managed-secrets/litellm/lfx-one-cicd
+        # in AWS Secrets Manager). Missing values are a hard failure —
+        # the live test calls t.Fatalf rather than silently skipping
+        # under -tags=live, so a green run can't appear without anything
+        # actually executing.
         run: make eval-live

--- a/.github/workflows/weekly-brief-eval-live.yml
+++ b/.github/workflows/weekly-brief-eval-live.yml
@@ -3,16 +3,29 @@
 ---
 name: "Weekly-Brief Live Eval"
 
-# Manual pre-release gate for the working-group weekly-brief generator.
+# Release gate for the working-group weekly-brief generator.
 # Runs the live-tagged eval suite against the configured LiteLLM endpoint.
-# Triggered on demand from the Actions tab, or automatically on release
-# tags. CI must remain hermetic, so this workflow never runs on pull
-# requests or on pushes to main.
+#
+# Invoked by:
+#   - .github/workflows/ko-build-tag.yaml as a `needs:` job on every
+#     push.tags: v*, before the publish / release-helm-chart jobs run.
+#     A failing eval blocks image / Helm chart / SBOM / cosign publication.
+#   - workflow_dispatch — ad-hoc pre-release validation from the Actions tab.
+#
+# CI must remain hermetic, so this workflow never runs on pull requests
+# or on pushes to main.
+#
+# Tracked: LFXV2-2019
 "on":
+  workflow_call:
+    secrets:
+      LITELLM_BASE_URL:
+        required: true
+      LITELLM_API_KEY:
+        required: true
+      LITELLM_MODEL:
+        required: true
   workflow_dispatch:
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: read
@@ -24,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0

--- a/.github/workflows/weekly-brief-eval-live.yml
+++ b/.github/workflows/weekly-brief-eval-live.yml
@@ -51,7 +51,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           audience: sts.amazonaws.com
-          role-to-assume: arn:aws:iam::450177423209:role/github-actions-deploy
+          role-to-assume: arn:aws:iam::450177423209:role/lfx-v2-github-actions
           aws-region: us-west-2
 
       # This is used to fetch build time secrets from AWS Secrets Manager

--- a/.github/workflows/weekly-brief-eval-live.yml
+++ b/.github/workflows/weekly-brief-eval-live.yml
@@ -26,7 +26,7 @@ permissions:
   id-token: write
 
 env:
-  LITELLM_BASE_URL: litellm.dev.v2.cluster.linuxfound.info
+  LITELLM_BASE_URL: https://litellm.dev.v2.cluster.linuxfound.info
   LITELLM_MODEL: claude-sonnet-4-6
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -79,11 +79,34 @@ To create a new release of the committee service:
    update the `appVersion` in the released chart.
 
 3. **The GitHub Actions workflow will automatically**:
+   - Gate the release on the weekly-brief live LLM eval — see [Release gate](#release-gate-weekly-brief-live-llm-eval) below
    - Build and publish the container images (committee-api and committee-cli)
    - Package and publish the Helm chart to GitHub Pages
    - Publish the chart to GitHub Container Registry (GHCR)
    - Sign the chart with Cosign
    - Generate SLSA provenance
+
+### Release gate: weekly-brief live LLM eval
+
+Every `v*` tag push runs the [working-group weekly-brief live LLM eval suite](evals/weekly-brief/README.md)
+as a hard gate before any images, Helm charts, SBOMs, or cosign signatures
+are published. The wiring lives in
+[`.github/workflows/ko-build-tag.yaml`](.github/workflows/ko-build-tag.yaml),
+which invokes the reusable
+[`.github/workflows/weekly-brief-eval-live.yml`](.github/workflows/weekly-brief-eval-live.yml)
+as a `needs:` dependency of the `publish` job. A failing eval aborts the
+release.
+
+The eval requires three repository secrets (Settings → Secrets and variables → Actions):
+
+- `LITELLM_BASE_URL`
+- `LITELLM_API_KEY`
+- `LITELLM_MODEL`
+
+Missing secrets fail the workflow loudly rather than silently skipping
+(the live test calls `t.Fatalf` under `-tags=live`). To validate against a
+specific endpoint before cutting a release, run the workflow on demand via
+**Actions → Weekly-Brief Live Eval → Run workflow**.
 
 ### Important Notes
 

--- a/README.md
+++ b/README.md
@@ -97,13 +97,24 @@ which invokes the reusable
 as a `needs:` dependency of the `publish` job. A failing eval aborts the
 release.
 
-The eval requires three repository secrets (Settings → Secrets and variables → Actions):
+Configuration in CI is **not via GitHub repository secrets**:
 
-- `LITELLM_BASE_URL`
-- `LITELLM_API_KEY`
-- `LITELLM_MODEL`
+- `LITELLM_BASE_URL` and `LITELLM_MODEL` are pinned in the workflow's
+  `env:` block. To change the endpoint or model, edit
+  [`.github/workflows/weekly-brief-eval-live.yml`](.github/workflows/weekly-brief-eval-live.yml)
+  and merge the change — defaults are
+  `https://litellm.dev.v2.cluster.linuxfound.info` and `claude-sonnet-4-6`.
+- `LITELLM_API_KEY` is fetched from **AWS Secrets Manager** at
+  `/cloudops/managed-secrets/litellm/lfx-one-cicd`, via the OIDC role
+  `arn:aws:iam::450177423209:role/lfx-v2-github-actions`. To rotate the
+  key, update the AWS Secrets Manager entry — no workflow change required.
 
-Missing secrets fail the workflow loudly rather than silently skipping
+`ko-build-tag.yaml` grants the calling `eval-live` job
+`permissions: id-token: write` so the called workflow's OIDC token
+exchange with AWS can succeed; a reusable workflow cannot elevate
+permissions beyond what its caller grants.
+
+Missing credentials fail the workflow loudly rather than silently skipping
 (the live test calls `t.Fatalf` under `-tags=live`). To validate against a
 specific endpoint before cutting a release, run the workflow on demand via
 **Actions → Weekly-Brief Live Eval → Run workflow**.

--- a/evals/weekly-brief/README.md
+++ b/evals/weekly-brief/README.md
@@ -88,9 +88,17 @@ make eval-live
 > `needs:` blocker before any of the publish / Helm chart / SBOM / cosign
 > jobs run, so a failing live eval halts the release. The same workflow is
 > also dispatchable manually from the Actions tab for pre-release validation.
-> Requires the `LITELLM_BASE_URL`, `LITELLM_API_KEY`, and `LITELLM_MODEL`
-> repo secrets to be provisioned. See the repo-root `README.md` for the
-> operator-facing summary.
+>
+> Configuration in CI is not via GitHub repo secrets:
+> - `LITELLM_BASE_URL` and `LITELLM_MODEL` are pinned in the workflow's
+>   `env:` block (currently `https://litellm.dev.v2.cluster.linuxfound.info`
+>   and `claude-sonnet-4-6`).
+> - `LITELLM_API_KEY` is fetched from AWS Secrets Manager at
+>   `/cloudops/managed-secrets/litellm/lfx-one-cicd` via the OIDC role
+>   `arn:aws:iam::450177423209:role/lfx-v2-github-actions`.
+>
+> See the repo-root `README.md` for the operator-facing summary, including
+> how to rotate the API key or change the endpoint/model.
 
 (`AI_SOURCE` is not used here. It selects the *deployed service's* AI adapter —
 `fake` for local/CI, `live` (LiteLLM) in production — via `AIAdapterImpl` in

--- a/evals/weekly-brief/README.md
+++ b/evals/weekly-brief/README.md
@@ -82,11 +82,15 @@ target:
 make eval-live
 ```
 
-> **Release gating:** running this by hand is not a real gate. A CI job that
-> runs `make eval-live` (triggered on a release tag/branch or via
-> `workflow_dispatch`, with the `LITELLM_*` secrets provisioned) is a planned
-> follow-up. If the live eval becomes part of the release process it must also
-> be documented in the repo-root `README.md`.
+> **Release gating:** `make eval-live` is wired as a real release gate via
+> [`.github/workflows/weekly-brief-eval-live.yml`](../../.github/workflows/weekly-brief-eval-live.yml).
+> On every `v*` tag push, `ko-build-tag.yaml` invokes that workflow as a
+> `needs:` blocker before any of the publish / Helm chart / SBOM / cosign
+> jobs run, so a failing live eval halts the release. The same workflow is
+> also dispatchable manually from the Actions tab for pre-release validation.
+> Requires the `LITELLM_BASE_URL`, `LITELLM_API_KEY`, and `LITELLM_MODEL`
+> repo secrets to be provisioned. See the repo-root `README.md` for the
+> operator-facing summary.
 
 (`AI_SOURCE` is not used here. It selects the *deployed service's* AI adapter —
 `fake` for local/CI, `live` (LiteLLM) in production — via `AIAdapterImpl` in


### PR DESCRIPTION
Wires the working-group weekly-brief live LLM eval (`make eval-live`) as a real release gate on the publishing pipeline. A failing eval blocks image / Helm chart / SBOM / cosign publication on every `v*` tag push.

## Why

[LFXV2-2019](https://linuxfoundation.atlassian.net/browse/LFXV2-2019). PR #99 added the prompt eval harness with a live-LLM suite; PR #97 promoted the harness, the `make eval-live` target, and `.github/workflows/weekly-brief-eval-live.yml` to main. Jordan flagged on [discussion_r3312210897](https://github.com/linuxfoundation/lfx-v2-committee-service/pull/99#discussion_r3312210897) and again on this PR that the workflow needs to gate releases rather than run in parallel with publication.

## What

- **`.github/workflows/weekly-brief-eval-live.yml`** — convert to a reusable workflow:
  - Add `workflow_call` trigger declaring `LITELLM_BASE_URL` / `LITELLM_API_KEY` / `LITELLM_MODEL` as required secrets
  - Drop the redundant `push.tags: v*` trigger (the gate now runs via the `ko-build-tag.yaml` call instead of in parallel with it)
  - Keep `workflow_dispatch` for ad-hoc pre-release validation
  - Add `persist-credentials: false` to the checkout step
- **`.github/workflows/ko-build-tag.yaml`** — add an `eval-live` job that invokes the reusable workflow with **explicit per-secret mapping** (not `secrets: inherit`, to keep the gate least-privileged), and add `needs: eval-live` to the `publish` job so a failing eval blocks all downstream publication. The existing `needs:` chain transitively gates `release-helm-chart` and `create-ghcr-helm-provenance`.
- **`evals/weekly-brief/README.md`** — replace the "planned follow-up" release-gating note with the current state (link to the workflow file and the operator-facing summary in the repo-root README).
- **`README.md`** — add a "Release gate: weekly-brief live LLM eval" section under Releases, documenting that `v*` tag publishing depends on the three `LITELLM_*` secrets and `make eval-live`. The on-main eval/README explicitly required this when the wiring landed.

## Iteration history (per review)

1. Initial: `push.tags: v*` + `workflow_dispatch` triggers framed as a release gate. copilot[bot] flagged that it ran in parallel with `ko-build-tag.yaml` so publishing wasn't actually blocked, and that `make eval-live` did not exist on main.
2. Dropped the tag trigger, reframed as a non-blocking "release validation signal", added `persist-credentials: false` per coderabbit[bot].
3. @jordane (CHANGES_REQUESTED) — pushed back on the signal-only framing, asked for a real gate on the release job. Converted to `workflow_call` and wired into `ko-build-tag.yaml` as a `needs:` blocker, but using a duplicate `eval-live.yml` file because main had drifted underneath this PR.
4. **This iteration** — copilot[bot] flagged the duplicate workflow vs `weekly-brief-eval-live.yml`, the README still saying the gate was a "planned follow-up", and `secrets: inherit` over-sharing. Rebased onto current main, deleted the duplicate workflow, and rewired the existing `weekly-brief-eval-live.yml` as the reusable workflow called from `ko-build-tag.yaml` with explicit per-secret mapping. Updated both READMEs.

## Blocked on (PR stays in Draft until this lands)

Repo secrets must be wired before a `v*` tag push (or `workflow_dispatch` run) can produce a green eval:

- `LITELLM_BASE_URL`
- `LITELLM_API_KEY`
- `LITELLM_MODEL`

Alan Sherman is coordinating (Antonia Gaete backup) in the `#lfx-one-app-dev` Slack thread started 2026-05-28 15:52 PDT.

## Follow-up (not in this PR)

- Repo-wide hardening sweep: set `persist-credentials: false` on the checkout step in `committee-api-build.yml`, `ko-build-*.yaml`, and `mega-linter.yml` to match this workflow (raised by coderabbit[bot] on the persist-credentials thread).

## Tracking

[LFXV2-2019](https://linuxfoundation.atlassian.net/browse/LFXV2-2019)

[LFXV2-2019]: https://linuxfoundation.atlassian.net/browse/LFXV2-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2019]: https://linuxfoundation.atlassian.net/browse/LFXV2-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ