### PR TITLE
feat: add EMAIL_ALLOWED_DOMAINS to restrict outbound emails/invites by recipient domain

### DIFF
--- a/charts/lfx-v2-committee-service/values.yaml
+++ b/charts/lfx-v2-committee-service/values.yaml
@@ -470,6 +470,11 @@ app:
     # INVITES_ENABLED gates outbound invite requests for non-LFID users.
     INVITES_ENABLED:
       value: "false"
+    # EMAIL_ALLOWED_DOMAINS restricts outbound emails and invites to the listed recipient
+    # domains (comma-separated, e.g. "linuxfoundation.org"). When empty (the default) all
+    # domains are permitted. Set in non-prod environments to prevent accidental email to real users.
+    EMAIL_ALLOWED_DOMAINS:
+      value: ""
     # AI_SOURCE selects the AI adapter: "fake" (default when unset; safe for
     # local dev / CI / fresh installs without LiteLLM credentials) or "live"
     # (requires LITELLM_BASE_URL, LITELLM_API_KEY, LITELLM_MODEL — startup

--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -473,6 +474,24 @@ func lfxSelfServeBaseURL() string {
 	}
 }
 
+// emailAllowedDomains parses the EMAIL_ALLOWED_DOMAINS environment variable into a slice
+// of lowercase domain strings. Returns nil (permit all) when the variable is unset or empty.
+func emailAllowedDomains() []string {
+	raw := os.Getenv("EMAIL_ALLOWED_DOMAINS")
+	if raw == "" {
+		return nil
+	}
+	var domains []string
+	for _, part := range strings.Split(raw, ",") {
+		d := strings.ToLower(strings.TrimSpace(part))
+		d = strings.TrimPrefix(d, "@")
+		if d != "" {
+			domains = append(domains, d)
+		}
+	}
+	return domains
+}
+
 // GroupWeeklyBriefReaderImpl initializes the working-group weekly brief reader.
 // Phase 1 only supports the NATS-backed implementation; the storage struct
 // already satisfies port.GroupWeeklyBriefReader.
@@ -825,6 +844,7 @@ func QueueSubscriptions(ctx context.Context, committeeReader port.CommitteeReade
 			usecaseSvc.WithCommitteePublisherForMessageHandler(CommitteePublisherImpl(ctx)),
 			usecaseSvc.WithEmailSenderForMessageHandler(EmailSenderImpl(ctx)),
 			usecaseSvc.WithInviteSenderForMessageHandler(InviteSenderImpl(ctx)),
+			usecaseSvc.WithEmailAllowedDomainsForMessageHandler(emailAllowedDomains()),
 			usecaseSvc.WithLFXSelfServeBaseURLForMessageHandler(lfxSelfServeBaseURL()),
 			usecaseSvc.WithUserReaderForMessageHandler(UserReaderImpl(ctx)),
 			usecaseSvc.WithLinkReaderForMessageHandler(CommitteeLinkReaderWriterImpl(ctx)),

--- a/cmd/committee-cli/commands/sync/members_by_committee_index.go
+++ b/cmd/committee-cli/commands/sync/members_by_committee_index.go
@@ -8,9 +8,11 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/linuxfoundation/lfx-v2-committee-service/cmd/committee-cli/commands"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/concurrent"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
 )
 
@@ -34,8 +36,9 @@ func (s *membersByCommitteeIndexSubcommand) Run(ctx context.Context, rc commands
 		fs.PrintDefaults()
 	}
 	committeeUID := fs.String("committee-uid", "", "limit backfill to members of a single committee UID")
-	sleep := fs.Duration("sleep", 0, "wait between each member write (e.g. 200ms, 1s)")
+	sleep := fs.Duration("sleep", 0, "wait between each member write; ignored when --workers > 1 (e.g. 200ms, 1s)")
 	dryRun := fs.Bool("dry-run", false, "compute what would be written without actually writing")
+	workers := fs.Int("workers", 1, "number of concurrent index writes (default 1; set higher, e.g. 50, for large buckets)")
 	if err := fs.Parse(rc.Args); err != nil {
 		if err == flag.ErrHelp {
 			return nil
@@ -54,54 +57,90 @@ func (s *membersByCommitteeIndexSubcommand) Run(ctx context.Context, rc commands
 
 	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
 
+	slog.InfoContext(ctx, "listing all members via WatchAll stream")
+
 	// Read all members via the full-scan path so we do not depend on an
-	// index that may not yet exist.
+	// index that may not yet exist. Uses WatchAll internally (one streaming
+	// round trip instead of N individual GETs).
 	members, err := rc.CommitteeReader.ListAllMembers(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list all members: %w", err)
 	}
 
+	// Filter to the requested committee if --committee-uid was given.
+	filtered := members[:0]
+	skipped := 0
+	for _, m := range members {
+		if *committeeUID != "" && m.CommitteeUID != *committeeUID {
+			skipped++
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+
 	stats := commands.NewStats()
 	stats.Total = len(members)
+	stats.Skipped = skipped
 	stats.DryRun = rc.DryRun
 
-	for _, member := range members {
-		if *committeeUID != "" && member.CommitteeUID != *committeeUID {
-			stats.Skipped++
-			continue
-		}
+	slog.InfoContext(ctx, "starting index backfill",
+		"total_members", len(members),
+		"to_index", len(filtered),
+		"skipped", skipped,
+		"workers", *workers,
+		"dry_run", rc.DryRun,
+	)
 
-		if rc.DryRun {
-			slog.DebugContext(ctx, "dry-run: would write member index",
-				"committee_uid", member.CommitteeUID,
-				"member_uid", member.UID,
+	if rc.DryRun {
+		slog.DebugContext(ctx, "dry-run: would write member index entries", "count", len(filtered))
+		stats.Updated = len(filtered)
+		stats.Log(ctx, "sync members-by-committee-index")
+		return nil
+	}
+
+	// Build one job per member and run them through the worker pool.
+	// Each job returns nil so the pool never short-circuits on a single
+	// failure — errors are tracked via atomics and logged per-member.
+	var (
+		updated atomic.Int64
+		failed  atomic.Int64
+	)
+
+	jobs := make([]func() error, len(filtered))
+	for i, m := range filtered {
+		m := m
+		jobs[i] = func() error {
+			_, errIdx := rc.CommitteeMemberWriter.IndexMemberByCommittee(ctx, m)
+			if errIdx != nil {
+				slog.WarnContext(ctx, "failed to index member by committee",
+					"error", errIdx,
+					"committee_uid", m.CommitteeUID,
+					"member_uid", m.UID,
+				)
+				failed.Add(1)
+				return nil
+			}
+			slog.DebugContext(ctx, "indexed member by committee",
+				"committee_uid", m.CommitteeUID,
+				"member_uid", m.UID,
 			)
-			stats.Updated++
-			continue
-		}
+			updated.Add(1)
 
-		_, errIdx := rc.CommitteeMemberWriter.IndexMemberByCommittee(ctx, member)
-		if errIdx != nil {
-			slog.WarnContext(ctx, "failed to index member by committee",
-				"error", errIdx,
-				"committee_uid", member.CommitteeUID,
-				"member_uid", member.UID,
-			)
-			stats.Failed++
-			continue
-		}
-
-		slog.DebugContext(ctx, "indexed member by committee",
-			"committee_uid", member.CommitteeUID,
-			"member_uid", member.UID,
-		)
-		stats.Updated++
-
-		if *sleep > 0 {
-			time.Sleep(*sleep)
+			// --sleep only applies in single-worker mode to avoid
+			// interleaved sleeps defeating the throttle intent.
+			if *workers == 1 && *sleep > 0 {
+				time.Sleep(*sleep)
+			}
+			return nil
 		}
 	}
 
+	if err := concurrent.NewWorkerPool(*workers).Run(ctx, jobs...); err != nil {
+		return fmt.Errorf("worker pool error: %w", err)
+	}
+
+	stats.Updated = int(updated.Load())
+	stats.Failed = int(failed.Load())
 	stats.Log(ctx, "sync members-by-committee-index")
 
 	if stats.Failed > 0 {

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -376,31 +376,38 @@ func (s *storage) ListMembersByCommittee(ctx context.Context, committeeUID strin
 	return members, nil
 }
 
-// ListAllMembers retrieves every member across all committees via a full bucket scan.
-// It is intended only for backfill/repair operations (e.g. the members-by-committee-index
-// CLI subcommand) that need to read all members without relying on the secondary index.
+// ListAllMembers retrieves every member across all committees using a single
+// WatchAll stream. This is significantly faster than ListKeys + N individual
+// GETs because NATS delivers all entries (with their values) in one streaming
+// response instead of one round trip per member.
+// It is intended only for backfill/repair operations that need to read all
+// members without relying on the secondary index.
 func (s *storage) ListAllMembers(ctx context.Context) ([]*model.CommitteeMember, error) {
-	slog.DebugContext(ctx, "listing all committee members from NATS storage")
+	slog.DebugContext(ctx, "listing all committee members from NATS storage via WatchAll")
 
-	keys, errKeys := s.client.kvStore[constants.KVBucketNameCommitteeMembers].ListKeys(ctx)
-	if errKeys != nil {
-		return nil, errs.NewUnexpected("failed to list keys from committee members bucket", errKeys)
+	watcher, err := s.client.kvStore[constants.KVBucketNameCommitteeMembers].WatchAll(ctx, jetstream.IgnoreDeletes())
+	if err != nil {
+		return nil, errs.NewUnexpected("failed to watch committee members bucket", err)
 	}
+	defer func() { _ = watcher.Stop() }()
 
 	var members []*model.CommitteeMember
 
-	for key := range keys.Keys() {
-		// Skip all secondary-index keys.
-		if strings.HasPrefix(key, "lookup/") {
+	for entry := range watcher.Updates() {
+		// nil signals that all current entries have been delivered.
+		if entry == nil {
+			break
+		}
+		// Skip secondary-index keys — they live in the same bucket.
+		if strings.HasPrefix(entry.Key(), "lookup/") {
 			continue
 		}
 
 		member := &model.CommitteeMember{}
-		_, errGet := s.get(ctx, constants.KVBucketNameCommitteeMembers, key, member, false)
-		if errGet != nil {
-			slog.WarnContext(ctx, "failed to get member while listing all",
-				"key", key,
-				"error", errGet,
+		if errUnmarshal := json.Unmarshal(entry.Value(), member); errUnmarshal != nil {
+			slog.WarnContext(ctx, "failed to unmarshal member while listing all",
+				"key", entry.Key(),
+				"error", errUnmarshal,
 			)
 			continue
 		}

--- a/internal/service/document_notification_handler.go
+++ b/internal/service/document_notification_handler.go
@@ -167,6 +167,11 @@ func (m *messageHandlerOrchestrator) handleContentCreated(ctx context.Context, i
 					"username", redaction.Redact(recipient.username))
 				return nil
 			}
+			if !m.isRecipientDomainAllowed(email) {
+				slog.DebugContext(gctx, "skipping content notification — recipient domain not in EMAIL_ALLOWED_DOMAINS",
+					"committee_uid", item.committeeUID)
+				return nil
+			}
 
 			recipientName := recipient.name
 			if recipientName == "" {

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -39,6 +39,11 @@ type messageHandlerOrchestrator struct {
 	linkReader                  port.CommitteeLinkReader
 	lfxSelfServeBaseURL         string
 	weeklyBriefGenerator        GroupWeeklyBriefGenerator
+	// emailAllowedDomains is an allowlist of recipient email domains for outbound emails and invites.
+	// When empty (the default) all domains are permitted. When set, only recipients whose email
+	// domain (case-insensitive, exact match) appears in the list will receive messages.
+	// Set via EMAIL_ALLOWED_DOMAINS (comma-separated, e.g. "linuxfoundation.org").
+	emailAllowedDomains []string
 }
 
 // messageHandlerOrchestratorOption defines a function type for setting options
@@ -113,6 +118,35 @@ func WithGroupWeeklyBriefGeneratorForMessageHandler(generator GroupWeeklyBriefGe
 	return func(m *messageHandlerOrchestrator) {
 		m.weeklyBriefGenerator = generator
 	}
+}
+
+// WithEmailAllowedDomainsForMessageHandler sets the allowlist of recipient email domains
+// for outbound emails and invites. When empty (the default) all domains are permitted.
+func WithEmailAllowedDomainsForMessageHandler(domains []string) messageHandlerOrchestratorOption {
+	return func(m *messageHandlerOrchestrator) {
+		m.emailAllowedDomains = domains
+	}
+}
+
+// isRecipientDomainAllowed reports whether an outbound email or invite may be sent to addr.
+// When no allowlist is configured (emailAllowedDomains is empty) all addresses are permitted.
+// Otherwise the domain portion of addr (the part after the last "@") must match one of the
+// allowed domains (case-insensitive, exact match). Addresses without an "@" are not allowed.
+func (m *messageHandlerOrchestrator) isRecipientDomainAllowed(addr string) bool {
+	if len(m.emailAllowedDomains) == 0 {
+		return true
+	}
+	at := strings.LastIndex(addr, "@")
+	if at < 0 {
+		return false
+	}
+	domain := strings.ToLower(addr[at+1:])
+	for _, allowed := range m.emailAllowedDomains {
+		if domain == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 // HandleGenerateWeeklyBriefRequested reacts to generate-requested stream events.
@@ -603,6 +637,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberCreated(ctx context.Co
 		slog.DebugContext(ctx, "email sender not configured — skipping member notification")
 		return nil, nil
 	}
+	if !m.isRecipientDomainAllowed(member.Email) {
+		slog.DebugContext(ctx, "skipping member notification email — recipient domain not in EMAIL_ALLOWED_DOMAINS",
+			"committee_uid", member.CommitteeUID)
+		return nil, nil
+	}
 
 	subject, html, text, err := emailsvc.RenderCommitteeRoleNotification(emailsvc.CommitteeRoleNotificationData{
 		RecipientName: recipientName,
@@ -641,6 +680,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberCreated(ctx context.Co
 func (m *messageHandlerOrchestrator) sendMemberInvite(ctx context.Context, member *model.CommitteeMember, recipientName, deepLinkURL string) (port.InviteResult, error) {
 	if m.inviteSender == nil {
 		slog.DebugContext(ctx, "invite sender not configured — skipping member invite",
+			"committee_uid", member.CommitteeUID)
+		return port.InviteResult{}, nil
+	}
+	if !m.isRecipientDomainAllowed(member.Email) {
+		slog.DebugContext(ctx, "skipping member invite — recipient domain not in EMAIL_ALLOWED_DOMAINS",
 			"committee_uid", member.CommitteeUID)
 		return port.InviteResult{}, nil
 	}
@@ -766,6 +810,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 						"committee_uid", data.CommitteeUID)
 					return nil
 				}
+				if !m.isRecipientDomainAllowed(u.Email) {
+					slog.DebugContext(gctx, "skipping settings invite — recipient domain not in EMAIL_ALLOWED_DOMAINS",
+						"committee_uid", data.CommitteeUID)
+					return nil
+				}
 				// Skip re-invite when effective access is unchanged (e.g. gaining Auditor on top of Writer).
 				if kind == roleChangeKindUpdated && effectiveRoleUnchanged(oldRoles, newRoles) {
 					slog.DebugContext(gctx, "skipping non-LF invite — effective role unchanged",
@@ -818,6 +867,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 			// LFID present — send a direct notification email.
 			if m.emailSender == nil {
 				slog.DebugContext(gctx, "email sender not configured — skipping settings notification",
+					"committee_uid", data.CommitteeUID)
+				return nil
+			}
+			if !m.isRecipientDomainAllowed(u.Email) {
+				slog.DebugContext(gctx, "skipping settings notification email — recipient domain not in EMAIL_ALLOWED_DOMAINS",
 					"committee_uid", data.CommitteeUID)
 				return nil
 			}
@@ -1215,6 +1269,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberDeleted(ctx context.Co
 
 	if m.emailSender == nil {
 		slog.DebugContext(ctx, "email sender not configured — skipping member-deleted notification")
+		return nil, nil
+	}
+	if !m.isRecipientDomainAllowed(member.Email) {
+		slog.DebugContext(ctx, "skipping member-deleted notification — recipient domain not in EMAIL_ALLOWED_DOMAINS",
+			"committee_uid", member.CommitteeUID)
 		return nil, nil
 	}
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -9,6 +9,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -122,9 +123,17 @@ func WithGroupWeeklyBriefGeneratorForMessageHandler(generator GroupWeeklyBriefGe
 
 // WithEmailAllowedDomainsForMessageHandler sets the allowlist of recipient email domains
 // for outbound emails and invites. When empty (the default) all domains are permitted.
+// Entries are normalized to lowercase and trimmed so callers need not pre-normalize them.
 func WithEmailAllowedDomainsForMessageHandler(domains []string) messageHandlerOrchestratorOption {
 	return func(m *messageHandlerOrchestrator) {
-		m.emailAllowedDomains = domains
+		normalized := make([]string, 0, len(domains))
+		for _, d := range domains {
+			d = strings.ToLower(strings.TrimSpace(d))
+			if d != "" {
+				normalized = append(normalized, d)
+			}
+		}
+		m.emailAllowedDomains = normalized
 	}
 }
 
@@ -141,12 +150,7 @@ func (m *messageHandlerOrchestrator) isRecipientDomainAllowed(addr string) bool 
 		return false
 	}
 	domain := strings.ToLower(addr[at+1:])
-	for _, allowed := range m.emailAllowedDomains {
-		if domain == allowed {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(m.emailAllowedDomains, domain)
 }
 
 // HandleGenerateWeeklyBriefRequested reacts to generate-requested stream events.

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -123,12 +123,14 @@ func WithGroupWeeklyBriefGeneratorForMessageHandler(generator GroupWeeklyBriefGe
 
 // WithEmailAllowedDomainsForMessageHandler sets the allowlist of recipient email domains
 // for outbound emails and invites. When empty (the default) all domains are permitted.
-// Entries are normalized to lowercase and trimmed so callers need not pre-normalize them.
+// Entries are normalized (lowercase, trimmed, leading "@" stripped) so callers need not
+// pre-normalize them — consistent with the emailAllowedDomains() env-var provider.
 func WithEmailAllowedDomainsForMessageHandler(domains []string) messageHandlerOrchestratorOption {
 	return func(m *messageHandlerOrchestrator) {
 		normalized := make([]string, 0, len(domains))
 		for _, d := range domains {
 			d = strings.ToLower(strings.TrimSpace(d))
+			d = strings.TrimPrefix(d, "@")
 			if d != "" {
 				normalized = append(normalized, d)
 			}
@@ -145,6 +147,7 @@ func (m *messageHandlerOrchestrator) isRecipientDomainAllowed(addr string) bool 
 	if len(m.emailAllowedDomains) == 0 {
 		return true
 	}
+	addr = strings.TrimSpace(addr)
 	at := strings.LastIndex(addr, "@")
 	if at < 0 {
 		return false

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -1404,6 +1404,18 @@ func TestMessageHandlerOrchestrator_isRecipientDomainAllowed(t *testing.T) {
 			addr:    "user@linuxfoundation.org",
 			want:    true,
 		},
+		{
+			name:    "allowlist entry with leading @ stripped — allowed",
+			domains: []string{"@linuxfoundation.org"},
+			addr:    "user@linuxfoundation.org",
+			want:    true,
+		},
+		{
+			name:    "recipient address with trailing whitespace trimmed — allowed",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@linuxfoundation.org ",
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -1297,6 +1297,109 @@ func TestHandleCommitteeMemberCreated(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("emailAllowedDomains set — LFID member with disallowed domain skipped", func(t *testing.T) {
+		// alice@example.com is not in the linuxfoundation.org allowlist.
+		emailSender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+			emailSender:         emailSender,
+			inviteSender:        &mockInviteSender{},
+			emailAllowedDomains: []string{"linuxfoundation.org"},
+		}
+		msg := newMockTransportMessenger(constants.CommitteeMemberCreatedSubject, buildMemberCreatedPayload(t, lfidMember))
+		resp, err := h.HandleCommitteeMemberCreated(context.Background(), msg)
+		assert.NoError(t, err)
+		assert.Nil(t, resp)
+		assert.Len(t, emailSender.calls, 0, "email must be suppressed for disallowed domain")
+	})
+
+	t.Run("emailAllowedDomains set — non-LFID member with disallowed domain invite skipped", func(t *testing.T) {
+		// bob@example.com is not in the linuxfoundation.org allowlist.
+		inviteSender := &mockInviteSender{}
+		h := &messageHandlerOrchestrator{
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+			emailSender:         &mockEmailSender{},
+			inviteSender:        inviteSender,
+			emailAllowedDomains: []string{"linuxfoundation.org"},
+		}
+		msg := newMockTransportMessenger(constants.CommitteeMemberCreatedSubject, buildMemberCreatedPayload(t, nonLFIDMember))
+		resp, err := h.HandleCommitteeMemberCreated(context.Background(), msg)
+		assert.NoError(t, err)
+		assert.Nil(t, resp)
+		assert.Len(t, inviteSender.calls, 0, "invite must be suppressed for disallowed domain")
+	})
+}
+
+func TestMessageHandlerOrchestrator_isRecipientDomainAllowed(t *testing.T) {
+	tests := []struct {
+		name    string
+		domains []string
+		addr    string
+		want    bool
+	}{
+		{
+			name:    "empty allowlist — all addresses allowed",
+			domains: nil,
+			addr:    "user@example.com",
+			want:    true,
+		},
+		{
+			name:    "matching domain — allowed",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@linuxfoundation.org",
+			want:    true,
+		},
+		{
+			name:    "non-matching domain — blocked",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@gmail.com",
+			want:    false,
+		},
+		{
+			name:    "case-insensitive domain comparison — allowed",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@LINUXFOUNDATION.ORG",
+			want:    true,
+		},
+		{
+			name:    "multiple allowed domains — matches second entry",
+			domains: []string{"linuxfoundation.org", "example.org"},
+			addr:    "user@example.org",
+			want:    true,
+		},
+		{
+			name:    "multiple allowed domains — no match",
+			domains: []string{"linuxfoundation.org", "example.org"},
+			addr:    "user@gmail.com",
+			want:    false,
+		},
+		{
+			name:    "malformed address with no @ — blocked",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "notanemail",
+			want:    false,
+		},
+		{
+			name:    "empty address — blocked",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "",
+			want:    false,
+		},
+		{
+			name:    "subdomain not in allowlist — blocked (exact match only)",
+			domains: []string{"linuxfoundation.org"},
+			addr:    "user@sub.linuxfoundation.org",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &messageHandlerOrchestrator{emailAllowedDomains: tt.domains}
+			assert.Equal(t, tt.want, h.isRecipientDomainAllowed(tt.addr))
+		})
+	}
 }
 
 func TestHandleCommitteeSettingsUpdated(t *testing.T) {

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -1392,11 +1392,25 @@ func TestMessageHandlerOrchestrator_isRecipientDomainAllowed(t *testing.T) {
 			addr:    "user@sub.linuxfoundation.org",
 			want:    false,
 		},
+		{
+			name:    "mixed-case allowlist entry normalized via option — allowed",
+			domains: []string{"LinuxFoundation.Org"},
+			addr:    "user@linuxfoundation.org",
+			want:    true,
+		},
+		{
+			name:    "allowlist entry with leading/trailing whitespace normalized — allowed",
+			domains: []string{"  linuxfoundation.org  "},
+			addr:    "user@linuxfoundation.org",
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := &messageHandlerOrchestrator{emailAllowedDomains: tt.domains}
+			// Use the option function so normalization is applied, matching real usage.
+			h := &messageHandlerOrchestrator{}
+			WithEmailAllowedDomainsForMessageHandler(tt.domains)(h)
 			assert.Equal(t, tt.want, h.isRecipientDomainAllowed(tt.addr))
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds \`EMAIL_ALLOWED_DOMAINS\` env var (comma-separated domain list) to gate all outbound emails and invite requests by recipient domain
- When unset or empty (the default), all domains are permitted — no change to prod behaviour
- When set, only recipients whose email domain exactly matches an entry in the list receive messages
- Applies to all five send sites: member created (LFID email + non-LFID invite), settings updated (LFID email + non-LFID invite), document/link upload notification, and member deleted email
- Chart exposes \`EMAIL_ALLOWED_DOMAINS\` via the existing \`app.environment\` map; no template changes needed
- ArgoCD overlays for dev and staging set \`linuxfoundation.org\` in a companion PR (lfx-v2-argocd)

## Test plan

- [x] \`go build ./...\` succeeds
- [x] \`go test ./...\` — all packages pass including new tests
- [x] \`golangci-lint\` — 0 issues
- [x] \`TestMessageHandlerOrchestrator_isRecipientDomainAllowed\` — 9 table-driven cases (empty allowlist, match, no-match, case-insensitivity, multiple domains, malformed address, subdomain exact-match)
- [x] Two new sub-tests in \`TestHandleCommitteeMemberCreated\` assert LFID email and non-LFID invite are suppressed when domain is not in allowlist

## Notes

- Subdomain matching is **not** supported — \`sub.linuxfoundation.org\` does not match \`linuxfoundation.org\` (intentional, exact match only)
- The guard is applied after the existing \`emailSender == nil\` / \`inviteSender == nil\` checks, so feature flags and domain filter compose correctly

🤖 Generated with [Claude Code](https://claude.ai/code)