### PR TITLE
[LFXV2-2040] fix: add committee→members secondary index for list_members

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 DOCKER_REGISTRY := ghcr.io/linuxfoundation
 DOCKER_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-api
 DOCKER_CLI_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-cli
-DOCKER_TAG ?= $(VERSION)
+DOCKER_TAG ?= latest
 
 # Helm variables
 HELM_CHART_PATH=./charts/lfx-v2-committee-service

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 DOCKER_REGISTRY := ghcr.io/linuxfoundation
 DOCKER_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-api
 DOCKER_CLI_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-cli
-DOCKER_TAG ?= latest
+DOCKER_TAG ?= $(VERSION)
 
 # Helm variables
 HELM_CHART_PATH=./charts/lfx-v2-committee-service

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -854,7 +854,7 @@ func (s *committeeServicesrvc) LeaveCommittee(ctx context.Context, p *committees
 	}
 
 	// Find the member by listing all members and matching email
-	members, err := s.storage.ListMembers(ctx, p.UID)
+	members, err := s.storage.ListMembersByCommittee(ctx, p.UID)
 	if err != nil {
 		return wrapError(ctx, err)
 	}

--- a/cmd/committee-api/service/group_weekly_brief_test.go
+++ b/cmd/committee-api/service/group_weekly_brief_test.go
@@ -53,7 +53,7 @@ func (r *stubCommitteeReader) GetMember(_ context.Context, _, _ string) (*model.
 	panic("not used")
 }
 
-func (r *stubCommitteeReader) ListMembers(_ context.Context, _ string) ([]*model.CommitteeMember, error) {
+func (r *stubCommitteeReader) ListMembersByCommittee(_ context.Context, _ string) ([]*model.CommitteeMember, error) {
 	panic("not used")
 }
 

--- a/cmd/committee-cli/README.md
+++ b/cmd/committee-cli/README.md
@@ -60,6 +60,44 @@ NATS_URL=nats://localhost:4222 \
   committee-cli sync total-members-attribute --committee-uid=abc-123
 ```
 
+#### `sync members-by-committee-index`
+
+Backfills the committee→member secondary index (`lookup/committee-members-by-committee/<committeeUID>.<memberUID>`) for members that existed before the index was introduced. The new `ListMembers` implementation reads exclusively from this index, so this command must be run against each environment before deploying the updated service.
+
+**Subcommand flags**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--committee-uid` | `""` | Limit backfill to members of a single committee |
+| `--sleep` | `0` | Wait between each write to reduce pressure (e.g. `200ms`, `1s`) |
+| `--dry-run` | `false` | Log what would be written without writing |
+
+**Exit code:** `0` if no members failed, `1` otherwise.
+
+**Output:** Structured JSON log line on completion with fields `total`, `updated`, `skipped`, `failed`, `duration_ms`, `rate_per_sec`.
+
+The command is idempotent — index entries are written with write-if-absent semantics and `ErrKeyExists` is treated as success, so re-running is safe.
+
+**Examples**
+
+Dry-run to preview scope (safe first step):
+```sh
+NATS_URL=nats://localhost:4222 LOG_LEVEL=info \
+  committee-cli sync members-by-committee-index --dry-run
+```
+
+Full backfill with a 100ms pause between writes:
+```sh
+NATS_URL=nats://localhost:4222 \
+  committee-cli sync members-by-committee-index --sleep=100ms
+```
+
+Backfill a single committee:
+```sh
+NATS_URL=nats://localhost:4222 \
+  committee-cli sync members-by-committee-index --committee-uid=abc-123
+```
+
 ## Building
 
 ### Local binary

--- a/cmd/committee-cli/README.md
+++ b/cmd/committee-cli/README.md
@@ -62,7 +62,7 @@ NATS_URL=nats://localhost:4222 \
 
 #### `sync members-by-committee-index`
 
-Backfills the committee→member secondary index (`lookup/committee-members-by-committee/<committeeUID>.<memberUID>`) for members that existed before the index was introduced. The new `ListMembers` implementation reads exclusively from this index, so this command must be run against each environment before deploying the updated service.
+Backfills the committee→member secondary index (`lookup/committee-members-by-committee/<committeeUID>.<memberUID>`) for members that existed before the index was introduced. The new `ListMembersByCommittee` implementation reads exclusively from this index, so this command must be run against each environment before deploying the updated service.
 
 **Subcommand flags**
 

--- a/cmd/committee-cli/commands/command.go
+++ b/cmd/committee-cli/commands/command.go
@@ -30,8 +30,12 @@ type Subcommand interface {
 type RunContext struct {
 	CommitteeReader             port.CommitteeReader
 	CommitteeWriterOrchestrator service.CommitteeWriter
-	DryRun                      bool
-	Args                        []string // remaining args after command + subcommand, for subcommand flag parsing
+	// CommitteeMemberWriter provides direct storage-layer access to member write operations
+	// (e.g. IndexMemberByCommittee). This is used by data-repair subcommands that bypass the
+	// business-logic orchestrator and write to the storage layer directly.
+	CommitteeMemberWriter port.CommitteeMemberWriter
+	DryRun                bool
+	Args                  []string // remaining args after command + subcommand, for subcommand flag parsing
 }
 
 // Stats tracks counters for a command run.

--- a/cmd/committee-cli/commands/sync/members_by_committee_index.go
+++ b/cmd/committee-cli/commands/sync/members_by_committee_index.go
@@ -1,0 +1,104 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package sync
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/cmd/committee-cli/commands"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
+)
+
+// membersByCommitteeIndexSubcommand backfills the secondary index
+// "lookup/committee-members-by-committee/<committeeUID>.<memberUID>"
+// for all members (or a single committee) that predate the index.
+type membersByCommitteeIndexSubcommand struct{}
+
+func (s *membersByCommitteeIndexSubcommand) Name() string { return "members-by-committee-index" }
+
+func (s *membersByCommitteeIndexSubcommand) Help() string {
+	return "backfill the committee→member secondary index for existing members"
+}
+
+func (s *membersByCommitteeIndexSubcommand) Run(ctx context.Context, rc commands.RunContext) error {
+	slog.DebugContext(ctx, "starting subcommand", "subcommand", s.Name(), "args", rc.Args)
+
+	fs := flag.NewFlagSet("members-by-committee-index", flag.ContinueOnError)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(fs.Output(), "usage: committee-cli sync members-by-committee-index [flags]\n\nflags:\n")
+		fs.PrintDefaults()
+	}
+	committeeUID := fs.String("committee-uid", "", "limit backfill to members of a single committee UID")
+	sleep := fs.Duration("sleep", 0, "wait between each member write (e.g. 200ms, 1s)")
+	dryRun := fs.Bool("dry-run", false, "compute what would be written without actually writing")
+	if err := fs.Parse(rc.Args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+
+	rc.DryRun = *dryRun
+
+	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
+
+	// Read all members via the full-scan path so we do not depend on an
+	// index that may not yet exist.
+	members, err := rc.CommitteeReader.ListAllMembers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list all members: %w", err)
+	}
+
+	stats := commands.NewStats()
+	stats.Total = len(members)
+	stats.DryRun = rc.DryRun
+
+	for _, member := range members {
+		if *committeeUID != "" && member.CommitteeUID != *committeeUID {
+			stats.Skipped++
+			continue
+		}
+
+		if rc.DryRun {
+			slog.InfoContext(ctx, "dry-run: would write member index",
+				"committee_uid", member.CommitteeUID,
+				"member_uid", member.UID,
+			)
+			stats.Updated++
+			continue
+		}
+
+		_, errIdx := rc.CommitteeMemberWriter.IndexMemberByCommittee(ctx, member)
+		if errIdx != nil {
+			slog.WarnContext(ctx, "failed to index member by committee",
+				"error", errIdx,
+				"committee_uid", member.CommitteeUID,
+				"member_uid", member.UID,
+			)
+			stats.Failed++
+			continue
+		}
+
+		slog.DebugContext(ctx, "indexed member by committee",
+			"committee_uid", member.CommitteeUID,
+			"member_uid", member.UID,
+		)
+		stats.Updated++
+
+		if *sleep > 0 {
+			time.Sleep(*sleep)
+		}
+	}
+
+	stats.Log(ctx, "sync members-by-committee-index")
+
+	if stats.Failed > 0 {
+		return fmt.Errorf("%d member(s) failed to index", stats.Failed)
+	}
+	return nil
+}

--- a/cmd/committee-cli/commands/sync/members_by_committee_index.go
+++ b/cmd/committee-cli/commands/sync/members_by_committee_index.go
@@ -72,7 +72,7 @@ func (s *membersByCommitteeIndexSubcommand) Run(ctx context.Context, rc commands
 		}
 
 		if rc.DryRun {
-			slog.InfoContext(ctx, "dry-run: would write member index",
+			slog.DebugContext(ctx, "dry-run: would write member index",
 				"committee_uid", member.CommitteeUID,
 				"member_uid", member.UID,
 			)

--- a/cmd/committee-cli/commands/sync/members_by_committee_index.go
+++ b/cmd/committee-cli/commands/sync/members_by_committee_index.go
@@ -45,6 +45,13 @@ func (s *membersByCommitteeIndexSubcommand) Run(ctx context.Context, rc commands
 
 	rc.DryRun = *dryRun
 
+	if rc.CommitteeReader == nil {
+		return fmt.Errorf("CommitteeReader is not wired in RunContext")
+	}
+	if rc.CommitteeMemberWriter == nil {
+		return fmt.Errorf("CommitteeMemberWriter is not wired in RunContext")
+	}
+
 	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
 
 	// Read all members via the full-scan path so we do not depend on an

--- a/cmd/committee-cli/commands/sync/members_by_committee_index_test.go
+++ b/cmd/committee-cli/commands/sync/members_by_committee_index_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-committee-service/cmd/committee-cli/commands"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
 )
 
 // mockMemberWriter is a minimal implementation of port.CommitteeMemberWriter used by
@@ -36,7 +37,7 @@ func (w *mockMemberWriter) IndexMemberByCommittee(_ context.Context, m *model.Co
 	if w.indexError != nil {
 		return "", w.indexError
 	}
-	key := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", m.CommitteeUID, m.UID)
+	key := fmt.Sprintf(constants.KVLookupMembersByCommitteePrefix, m.CommitteeUID, m.UID)
 	w.indexed = append(w.indexed, key)
 	return key, nil
 }

--- a/cmd/committee-cli/commands/sync/members_by_committee_index_test.go
+++ b/cmd/committee-cli/commands/sync/members_by_committee_index_test.go
@@ -1,0 +1,116 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/cmd/committee-cli/commands"
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+)
+
+// mockMemberWriter is a minimal implementation of port.CommitteeMemberWriter used by
+// the backfill subcommand.  Only IndexMemberByCommittee is exercised here.
+type mockMemberWriter struct {
+	indexed    []string // committee_uid+"."+member_uid keys that were written
+	indexError error
+}
+
+func (w *mockMemberWriter) CreateMember(_ context.Context, _ *model.CommitteeMember) error {
+	return nil
+}
+func (w *mockMemberWriter) UpdateMember(_ context.Context, m *model.CommitteeMember, _ uint64) (*model.CommitteeMember, error) {
+	return m, nil
+}
+func (w *mockMemberWriter) DeleteMember(_ context.Context, _ string, _ uint64) error { return nil }
+func (w *mockMemberWriter) UniqueMember(_ context.Context, _ *model.CommitteeMember) (string, error) {
+	return "", nil
+}
+func (w *mockMemberWriter) IndexMemberByCommittee(_ context.Context, m *model.CommitteeMember) (string, error) {
+	if w.indexError != nil {
+		return "", w.indexError
+	}
+	key := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", m.CommitteeUID, m.UID)
+	w.indexed = append(w.indexed, key)
+	return key, nil
+}
+
+// newBackfillRC builds a RunContext wired with the provided reader and writer mocks.
+func newBackfillRC(r *mockReader, w *mockMemberWriter, args ...string) commands.RunContext {
+	return commands.RunContext{
+		CommitteeReader:       r,
+		CommitteeMemberWriter: w,
+		Args:                  args,
+	}
+}
+
+func TestMembersByCommitteeIndex_BackfillAll(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {
+				{CommitteeMemberBase: model.CommitteeMemberBase{UID: "m1", CommitteeUID: "c1"}},
+				{CommitteeMemberBase: model.CommitteeMemberBase{UID: "m2", CommitteeUID: "c1"}},
+			},
+			"c2": {
+				{CommitteeMemberBase: model.CommitteeMemberBase{UID: "m3", CommitteeUID: "c2"}},
+			},
+		},
+	}
+	w := &mockMemberWriter{}
+
+	rc := newBackfillRC(r, w)
+	err := (&membersByCommitteeIndexSubcommand{}).Run(context.Background(), rc)
+	require.NoError(t, err)
+	assert.Len(t, w.indexed, 3)
+}
+
+func TestMembersByCommitteeIndex_FilterByCommittee(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {{CommitteeMemberBase: model.CommitteeMemberBase{UID: "m1", CommitteeUID: "c1"}}},
+			"c2": {{CommitteeMemberBase: model.CommitteeMemberBase{UID: "m2", CommitteeUID: "c2"}}},
+		},
+	}
+	w := &mockMemberWriter{}
+
+	rc := newBackfillRC(r, w, "--committee-uid=c1")
+	err := (&membersByCommitteeIndexSubcommand{}).Run(context.Background(), rc)
+	require.NoError(t, err)
+	assert.Len(t, w.indexed, 1)
+	assert.Contains(t, w.indexed[0], "c1.m1")
+}
+
+func TestMembersByCommitteeIndex_DryRun(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {{CommitteeMemberBase: model.CommitteeMemberBase{UID: "m1", CommitteeUID: "c1"}}},
+		},
+	}
+	w := &mockMemberWriter{}
+
+	rc := newBackfillRC(r, w, "--dry-run")
+	err := (&membersByCommitteeIndexSubcommand{}).Run(context.Background(), rc)
+	require.NoError(t, err)
+	// Dry-run must not write any index entries.
+	assert.Empty(t, w.indexed)
+}
+
+func TestMembersByCommitteeIndex_IndexError_ReturnsError(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {{CommitteeMemberBase: model.CommitteeMemberBase{UID: "m1", CommitteeUID: "c1"}}},
+		},
+	}
+	w := &mockMemberWriter{indexError: fmt.Errorf("nats unavailable")}
+
+	rc := newBackfillRC(r, w)
+	err := (&membersByCommitteeIndexSubcommand{}).Run(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to index")
+}

--- a/cmd/committee-cli/commands/sync/sync.go
+++ b/cmd/committee-cli/commands/sync/sync.go
@@ -16,7 +16,8 @@ func (c *command) Help() string {
 
 func (c *command) Subcommands() map[string]commands.Subcommand {
 	return map[string]commands.Subcommand{
-		"total-members-attribute": &totalMembersAttributeSubcommand{},
+		"total-members-attribute":    &totalMembersAttributeSubcommand{},
+		"members-by-committee-index": &membersByCommitteeIndexSubcommand{},
 	}
 }
 

--- a/cmd/committee-cli/commands/sync/total_members_attribute.go
+++ b/cmd/committee-cli/commands/sync/total_members_attribute.go
@@ -107,7 +107,7 @@ func (s *totalMembersAttributeSubcommand) syncOne(ctx context.Context, rc comman
 		return nil
 	}
 
-	members, err := rc.CommitteeReader.ListMembers(ctx, uid)
+	members, err := rc.CommitteeReader.ListMembersByCommittee(ctx, uid)
 	if err != nil {
 		stats.Failed++
 		slog.WarnContext(ctx, "failed to list members", "committee_uid", uid, "error", err)

--- a/cmd/committee-cli/commands/sync/total_members_attribute_test.go
+++ b/cmd/committee-cli/commands/sync/total_members_attribute_test.go
@@ -73,6 +73,13 @@ func (r *mockReader) GetSettings(_ context.Context, _ string) (*model.CommitteeS
 func (r *mockReader) GetSettingsUIDByInviteUID(_ context.Context, _ string) (string, error) {
 	return "", nil
 }
+func (r *mockReader) ListAllMembers(_ context.Context) ([]*model.CommitteeMember, error) {
+	var all []*model.CommitteeMember
+	for _, members := range r.members {
+		all = append(all, members...)
+	}
+	return all, nil
+}
 
 // mockWriter implements service.CommitteeWriter, recording Update calls.
 type mockWriter struct {

--- a/cmd/committee-cli/commands/sync/total_members_attribute_test.go
+++ b/cmd/committee-cli/commands/sync/total_members_attribute_test.go
@@ -40,7 +40,7 @@ func (r *mockReader) GetRevision(_ context.Context, uid string) (uint64, error) 
 	return r.revision[uid], nil
 }
 
-func (r *mockReader) ListMembers(_ context.Context, uid string) ([]*model.CommitteeMember, error) {
+func (r *mockReader) ListMembersByCommittee(_ context.Context, uid string) ([]*model.CommitteeMember, error) {
 	if err, ok := r.membersErr[uid]; ok {
 		return nil, err
 	}

--- a/cmd/committee-cli/main.go
+++ b/cmd/committee-cli/main.go
@@ -108,6 +108,7 @@ func run() error {
 	rc := commands.RunContext{
 		CommitteeReader:             storage,
 		CommitteeWriterOrchestrator: writerOrchestrator,
+		CommitteeMemberWriter:       storage,
 		Args:                        parsed.SubArgs,
 	}
 

--- a/evals/weekly-brief/eval_live_test.go
+++ b/evals/weekly-brief/eval_live_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 //go:build live
-// +build live
 
 // This file is built only when -tags=live is passed. It documents and
 // implements the live-LLM eval path against a LiteLLM-compatible endpoint.

--- a/internal/domain/port/committee_member_reader.go
+++ b/internal/domain/port/committee_member_reader.go
@@ -15,8 +15,8 @@ type CommitteeMemberReader interface {
 	GetMember(ctx context.Context, uid string) (*model.CommitteeMember, uint64, error)
 	// GetMemberRevision retrieves the revision number for a committee member
 	GetMemberRevision(ctx context.Context, uid string) (uint64, error)
-	// ListMembers retrieves all members for a given committee UID using the secondary index.
-	ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
+	// ListMembersByCommittee retrieves all members for a given committee UID using the secondary index.
+	ListMembersByCommittee(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
 	// ListAllMembers retrieves every member across all committees via a full bucket scan.
 	// This is intended only for backfill/repair operations that must read all members
 	// independently of the secondary index.

--- a/internal/domain/port/committee_member_reader.go
+++ b/internal/domain/port/committee_member_reader.go
@@ -15,6 +15,10 @@ type CommitteeMemberReader interface {
 	GetMember(ctx context.Context, uid string) (*model.CommitteeMember, uint64, error)
 	// GetMemberRevision retrieves the revision number for a committee member
 	GetMemberRevision(ctx context.Context, uid string) (uint64, error)
-	// ListMembers retrieves all members for a given committee UID
+	// ListMembers retrieves all members for a given committee UID using the secondary index.
 	ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
+	// ListAllMembers retrieves every member across all committees via a full bucket scan.
+	// This is intended only for backfill/repair operations that must read all members
+	// independently of the secondary index.
+	ListAllMembers(ctx context.Context) ([]*model.CommitteeMember, error)
 }

--- a/internal/domain/port/committee_member_writer.go
+++ b/internal/domain/port/committee_member_writer.go
@@ -22,7 +22,7 @@ type CommitteeMemberWriter interface {
 	UniqueMember(ctx context.Context, member *model.CommitteeMember) (string, error)
 
 	// IndexMemberByCommittee writes the secondary index entry mapping
-	// committee_uid → member_uid so that ListMembers can use a server-side
+	// committee_uid → member_uid so that ListMembersByCommittee can use a server-side
 	// filtered scan instead of a full bucket scan.
 	// Returns the written key (for rollback tracking) and nil on success.
 	// Treats ErrKeyExists as idempotent success.

--- a/internal/domain/port/committee_member_writer.go
+++ b/internal/domain/port/committee_member_writer.go
@@ -20,4 +20,11 @@ type CommitteeMemberWriter interface {
 
 	// Checkers for uniqueness
 	UniqueMember(ctx context.Context, member *model.CommitteeMember) (string, error)
+
+	// IndexMemberByCommittee writes the secondary index entry mapping
+	// committee_uid → member_uid so that ListMembers can use a server-side
+	// filtered scan instead of a full bucket scan.
+	// Returns the written key (for rollback tracking) and nil on success.
+	// Treats ErrKeyExists as idempotent success.
+	IndexMemberByCommittee(ctx context.Context, member *model.CommitteeMember) (string, error)
 }

--- a/internal/infrastructure/ai/fake_adapter.go
+++ b/internal/infrastructure/ai/fake_adapter.go
@@ -124,13 +124,13 @@ func (a *FakeAdapter) GenerateWeeklyBrief(_ context.Context, in port.WeeklyBrief
 // Used to derive synthetic IDs that are deterministic but distinct per input.
 func inputDigest(in port.WeeklyBriefInput) string {
 	h := sha256.New()
-	fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s",
+	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s",
 		in.CommitteeID, in.CommitteeName, in.ProjectName, in.PeriodStart, in.PeriodEnd)
 	// Iterate claims in a stable order: sort by ID first.
 	claims := append([]port.ClaimEvidence(nil), in.Claims...)
 	sort.Slice(claims, func(i, j int) bool { return claims[i].ID < claims[j].ID })
 	for _, c := range claims {
-		fmt.Fprintf(h, "\x01%s\x00%s", c.ID, c.Summary)
+		_, _ = fmt.Fprintf(h, "\x01%s\x00%s", c.ID, c.Summary)
 		sources := append([]port.SourceRef(nil), c.Sources...)
 		sort.Slice(sources, func(i, j int) bool {
 			if sources[i].Type != sources[j].Type {
@@ -139,7 +139,7 @@ func inputDigest(in port.WeeklyBriefInput) string {
 			return sources[i].ID < sources[j].ID
 		})
 		for _, s := range sources {
-			fmt.Fprintf(h, "\x02%s\x00%s", s.Type, s.ID)
+			_, _ = fmt.Fprintf(h, "\x02%s\x00%s", s.Type, s.ID)
 		}
 	}
 	return hex.EncodeToString(h.Sum(nil))

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -367,8 +367,8 @@ func (m *MockRepository) GetMemberRevision(ctx context.Context, memberUID string
 	return 0, errors.NewNotFound(fmt.Sprintf("member with UID %s not found", memberUID))
 }
 
-// ListMembers retrieves all members for a committee
-func (m *MockRepository) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
+// ListMembersByCommittee retrieves all members for a committee
+func (m *MockRepository) ListMembersByCommittee(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 	slog.DebugContext(ctx, "mock repository: listing committee members", "committee_uid", committeeUID)
 
 	m.mu.RLock()

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/port"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 )
 
@@ -722,7 +723,7 @@ func (w *MockCommitteeWriter) IndexMemberByCommittee(ctx context.Context, member
 		"committee_uid", member.CommitteeUID,
 		"member_uid", member.UID,
 	)
-	key := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", member.CommitteeUID, member.UID)
+	key := fmt.Sprintf(constants.KVLookupMembersByCommitteePrefix, member.CommitteeUID, member.UID)
 	return key, nil
 }
 

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -388,6 +388,24 @@ func (m *MockRepository) ListMembers(ctx context.Context, committeeUID string) (
 	return members, nil
 }
 
+// ListAllMembers retrieves all members across all committees (full scan).
+// Used for backfill/repair operations that need to read all members regardless of the index.
+func (m *MockRepository) ListAllMembers(ctx context.Context) ([]*model.CommitteeMember, error) {
+	slog.DebugContext(ctx, "mock repository: listing all committee members")
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var members []*model.CommitteeMember
+	for _, committeeMembers := range m.committeeMembers {
+		for _, member := range committeeMembers {
+			memberCopy := *member
+			members = append(members, &memberCopy)
+		}
+	}
+	return members, nil
+}
+
 // MockCommitteeWriter implements CommitteeWriter interface
 type MockCommitteeWriter struct {
 	mock *MockRepository
@@ -693,6 +711,19 @@ func (w *MockCommitteeWriter) UniqueMember(ctx context.Context, member *model.Co
 	}
 
 	return "", nil
+}
+
+// IndexMemberByCommittee records the secondary index entry for the given member.
+// In the mock this is a no-op (the mock keyed map already indexes by committee);
+// it returns the key string that the real storage would write, so callers can
+// track it for rollback.
+func (w *MockCommitteeWriter) IndexMemberByCommittee(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	slog.DebugContext(ctx, "mock committee writer: indexing member by committee",
+		"committee_uid", member.CommitteeUID,
+		"member_uid", member.UID,
+	)
+	key := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", member.CommitteeUID, member.UID)
+	return key, nil
 }
 
 // ================== CommitteeInviteReader implementation ==================

--- a/internal/infrastructure/nats/committee_weekly_member_reader.go
+++ b/internal/infrastructure/nats/committee_weekly_member_reader.go
@@ -37,7 +37,7 @@ func NewCommitteeWeeklyMemberReader(r port.CommitteeMemberReader) *CommitteeWeek
 //   - "Updated" = updated_at within window AND created_at outside window
 //     (avoids double-counting joins)
 func (r *CommitteeWeeklyMemberReader) ListMemberActivityForWindow(ctx context.Context, committeeUID string, windowStart, windowEnd time.Time) (port.WeeklyMemberActivity, error) {
-	members, err := r.memberReader.ListMembers(ctx, committeeUID)
+	members, err := r.memberReader.ListMembersByCommittee(ctx, committeeUID)
 	if err != nil {
 		return port.WeeklyMemberActivity{}, err
 	}

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -422,6 +422,12 @@ func (s *storage) GetMemberRevision(ctx context.Context, memberUID string) (uint
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return 0, errs.NewNotFound("committee member not found", fmt.Errorf("member UID: %s", memberUID))
 		}
+		// Return validation errors (e.g. empty UID) and other typed errors as-is
+		// so callers receive the correct error kind instead of an unexpected wrapper.
+		var valErr errs.Validation
+		if errors.As(err, &valErr) {
+			return 0, err
+		}
 		return 0, errs.NewUnexpected("failed to get committee member revision", err)
 	}
 	return rev, nil
@@ -541,6 +547,12 @@ func (s *storage) UniqueMember(ctx context.Context, member *model.CommitteeMembe
 // Returns the written key (for rollback tracking) and nil on success.
 // jetstream.ErrKeyExists is treated as idempotent — the entry already exists, which is fine.
 func (s *storage) IndexMemberByCommittee(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	if member == nil {
+		return "", errs.NewValidation("committee member cannot be nil")
+	}
+	if member.CommitteeUID == "" || member.UID == "" {
+		return "", errs.NewValidation("committee member CommitteeUID and UID must be non-empty")
+	}
 	key := fmt.Sprintf(constants.KVLookupMembersByCommitteePrefix, member.CommitteeUID, member.UID)
 	if _, err := s.client.kvStore[constants.KVBucketNameCommitteeMembers].Create(ctx, key, []byte(member.UID)); err != nil {
 		if errors.Is(err, jetstream.ErrKeyExists) {

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -320,11 +320,11 @@ func (s *storage) GetMember(ctx context.Context, memberUID string) (*model.Commi
 	return member, rev, nil
 }
 
-// ListMembers retrieves all members for a given committee UID using the secondary index.
+// ListMembersByCommittee retrieves all members for a given committee UID using the secondary index.
 // It performs a server-side filtered scan of keys matching
 // "lookup/committee-members-by-committee/<committeeUID>.*" so only members of the target
 // committee are fetched, rather than scanning the entire bucket.
-func (s *storage) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
+func (s *storage) ListMembersByCommittee(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 	if committeeUID == "" {
 		return nil, errs.NewValidation("committee UID cannot be empty")
 	}
@@ -527,7 +527,7 @@ func (s *storage) UniqueMember(ctx context.Context, member *model.CommitteeMembe
 
 // IndexMemberByCommittee writes the secondary index entry
 // "lookup/committee-members-by-committee/<committee_uid>.<member_uid>" → <member_uid>
-// into the committee-members bucket. This enables ListMembers to use a server-side
+// into the committee-members bucket. This enables ListMembersByCommittee to use a server-side
 // filtered scan instead of a full bucket scan.
 // Returns the written key (for rollback tracking) and nil on success.
 // jetstream.ErrKeyExists is treated as idempotent — the entry already exists, which is fine.

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -350,6 +350,8 @@ func (s *storage) ListMembersByCommittee(ctx context.Context, committeeUID strin
 			)
 			continue
 		}
+		// UIDs are UUIDs (RFC 4122 hex + hyphens only) and never contain dots,
+		// so LastIndex is safe as the committee/member separator.
 		memberUID := key[dotIdx+1:]
 
 		member := &model.CommitteeMember{}

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -320,11 +320,62 @@ func (s *storage) GetMember(ctx context.Context, memberUID string) (*model.Commi
 	return member, rev, nil
 }
 
-// ListMembers retrieves all members for a given committee UID
+// ListMembers retrieves all members for a given committee UID using the secondary index.
+// It performs a server-side filtered scan of keys matching
+// "lookup/committee-members-by-committee/<committeeUID>.*" so only members of the target
+// committee are fetched, rather than scanning the entire bucket.
 func (s *storage) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 	slog.DebugContext(ctx, "listing committee members from NATS storage", "committee_uid", committeeUID)
 
-	// Get all keys from the committee members bucket
+	filter := fmt.Sprintf(constants.KVLookupMembersByCommitteeFilter, committeeUID)
+	keys, errKeys := s.client.kvStore[constants.KVBucketNameCommitteeMembers].ListKeysFiltered(ctx, filter)
+	if errKeys != nil {
+		return nil, errs.NewUnexpected("failed to list member index keys for committee", errKeys)
+	}
+
+	var members []*model.CommitteeMember
+
+	// Each key is "lookup/committee-members-by-committee/<committeeUID>.<memberUID>".
+	// Extract the member UID from the suffix after the last dot.
+	for key := range keys.Keys() {
+		dotIdx := strings.LastIndex(key, ".")
+		if dotIdx < 0 || dotIdx == len(key)-1 {
+			slog.WarnContext(ctx, "skipping malformed member index key",
+				"key", key,
+				"committee_uid", committeeUID,
+			)
+			continue
+		}
+		memberUID := key[dotIdx+1:]
+
+		member := &model.CommitteeMember{}
+		_, errGet := s.get(ctx, constants.KVBucketNameCommitteeMembers, memberUID, member, false)
+		if errGet != nil {
+			slog.WarnContext(ctx, "failed to get member while listing by committee",
+				"member_uid", memberUID,
+				"error", errGet,
+				"committee_uid", committeeUID,
+			)
+			continue
+		}
+
+		members = append(members, member)
+	}
+
+	slog.DebugContext(ctx, "retrieved committee members from NATS storage",
+		"committee_uid", committeeUID,
+		"member_count", len(members),
+	)
+
+	return members, nil
+}
+
+// ListAllMembers retrieves every member across all committees via a full bucket scan.
+// It is intended only for backfill/repair operations (e.g. the members-by-committee-index
+// CLI subcommand) that need to read all members without relying on the secondary index.
+func (s *storage) ListAllMembers(ctx context.Context) ([]*model.CommitteeMember, error) {
+	slog.DebugContext(ctx, "listing all committee members from NATS storage")
+
 	keys, errKeys := s.client.kvStore[constants.KVBucketNameCommitteeMembers].ListKeys(ctx)
 	if errKeys != nil {
 		return nil, errs.NewUnexpected("failed to list keys from committee members bucket", errKeys)
@@ -332,32 +383,26 @@ func (s *storage) ListMembers(ctx context.Context, committeeUID string) ([]*mode
 
 	var members []*model.CommitteeMember
 
-	// Iterate through all keys and filter by committee UID
 	for key := range keys.Keys() {
-		// Skip lookup keys (they start with "lookup/")
+		// Skip all secondary-index keys.
 		if strings.HasPrefix(key, "lookup/") {
 			continue
 		}
 
-		// Get the member
 		member := &model.CommitteeMember{}
 		_, errGet := s.get(ctx, constants.KVBucketNameCommitteeMembers, key, member, false)
 		if errGet != nil {
-			slog.WarnContext(ctx, "failed to get member while listing",
+			slog.WarnContext(ctx, "failed to get member while listing all",
 				"key", key,
 				"error", errGet,
-				"committee_uid", committeeUID)
+			)
 			continue
 		}
 
-		// Filter by committee UID
-		if member.CommitteeUID == committeeUID {
-			members = append(members, member)
-		}
+		members = append(members, member)
 	}
 
-	slog.DebugContext(ctx, "retrieved committee members from NATS storage",
-		"committee_uid", committeeUID,
+	slog.DebugContext(ctx, "retrieved all committee members from NATS storage",
 		"member_count", len(members),
 	)
 
@@ -474,6 +519,24 @@ func (s *storage) UniqueMember(ctx context.Context, member *model.CommitteeMembe
 		return uniqueKey, errs.NewUnexpected("failed to create unique key for member", errUnique)
 	}
 	return uniqueKey, nil
+}
+
+// IndexMemberByCommittee writes the secondary index entry
+// "lookup/committee-members-by-committee/<committee_uid>.<member_uid>" → <member_uid>
+// into the committee-members bucket. This enables ListMembers to use a server-side
+// filtered scan instead of a full bucket scan.
+// Returns the written key (for rollback tracking) and nil on success.
+// ErrKeyExists is treated as idempotent — the entry already exists, which is fine.
+func (s *storage) IndexMemberByCommittee(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	key := fmt.Sprintf(constants.KVLookupMembersByCommitteePrefix, member.CommitteeUID, member.UID)
+	if _, err := s.client.kvStore[constants.KVBucketNameCommitteeMembers].Create(ctx, key, []byte(member.UID)); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			// Already present — idempotent; treat as success.
+			return key, nil
+		}
+		return key, errs.NewUnexpected("failed to index member by committee", err)
+	}
+	return key, nil
 }
 
 // ================== CommitteeInviteReader implementation ==================

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -415,7 +415,14 @@ func (s *storage) ListAllMembers(ctx context.Context) ([]*model.CommitteeMember,
 
 // GetMemberRevision retrieves the revision number for a committee member
 func (s *storage) GetMemberRevision(ctx context.Context, memberUID string) (uint64, error) {
-	return s.get(ctx, constants.KVBucketNameCommitteeMembers, memberUID, &model.CommitteeMember{}, true)
+	rev, err := s.get(ctx, constants.KVBucketNameCommitteeMembers, memberUID, &model.CommitteeMember{}, true)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return 0, errs.NewNotFound("committee member not found", fmt.Errorf("member UID: %s", memberUID))
+		}
+		return 0, errs.NewUnexpected("failed to get committee member revision", err)
+	}
+	return rev, nil
 }
 
 // ================== CommitteeMemberWriter implementation ==================

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -325,6 +325,10 @@ func (s *storage) GetMember(ctx context.Context, memberUID string) (*model.Commi
 // "lookup/committee-members-by-committee/<committeeUID>.*" so only members of the target
 // committee are fetched, rather than scanning the entire bucket.
 func (s *storage) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
+	if committeeUID == "" {
+		return nil, errs.NewValidation("committee UID cannot be empty")
+	}
+
 	slog.DebugContext(ctx, "listing committee members from NATS storage", "committee_uid", committeeUID)
 
 	filter := fmt.Sprintf(constants.KVLookupMembersByCommitteeFilter, committeeUID)
@@ -526,7 +530,7 @@ func (s *storage) UniqueMember(ctx context.Context, member *model.CommitteeMembe
 // into the committee-members bucket. This enables ListMembers to use a server-side
 // filtered scan instead of a full bucket scan.
 // Returns the written key (for rollback tracking) and nil on success.
-// ErrKeyExists is treated as idempotent — the entry already exists, which is fine.
+// jetstream.ErrKeyExists is treated as idempotent — the entry already exists, which is fine.
 func (s *storage) IndexMemberByCommittee(ctx context.Context, member *model.CommitteeMember) (string, error) {
 	key := fmt.Sprintf(constants.KVLookupMembersByCommitteePrefix, member.CommitteeUID, member.UID)
 	if _, err := s.client.kvStore[constants.KVBucketNameCommitteeMembers].Create(ctx, key, []byte(member.UID)); err != nil {

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -36,9 +36,19 @@ func (uc *committeeWriterOrchestrator) deleteMemberKeys(ctx context.Context, key
 	)
 
 	for _, key := range keys {
-		// Member keys should use member-specific methods
 		rev, errGet := uc.committeeReader.GetMemberRevision(ctx, key)
 		if errGet != nil {
+			var notFoundErr errs.NotFound
+			if errors.As(errGet, &notFoundErr) {
+				// Key already absent — nothing to delete. This is expected for
+				// the committee→member index on members created before the backfill
+				// was run, and for any key that was never written (e.g. failed partial write).
+				slog.DebugContext(ctx, "member key already absent during cleanup",
+					"key", key,
+					"is_rollback", isRollback,
+				)
+				continue
+			}
 			slog.ErrorContext(ctx, "failed to get revision for member key deletion",
 				"error", errGet,
 				"key", key,
@@ -232,6 +242,11 @@ func (uc *committeeWriterOrchestrator) CreateMember(ctx context.Context, member 
 	// Step 8b: Write the committee→member secondary index so ListMembers can use a
 	// targeted prefix scan rather than a full bucket scan.
 	indexKey, errIndex := uc.committeeWriter.IndexMemberByCommittee(ctx, member)
+	// Append before checking the error: if the write partially succeeded and
+	// returned an error, rollback must still be able to clean up the written key.
+	if indexKey != "" {
+		keys = append(keys, indexKey)
+	}
 	if errIndex != nil {
 		slog.ErrorContext(ctx, "failed to write committee member index",
 			"error", errIndex,
@@ -241,7 +256,6 @@ func (uc *committeeWriterOrchestrator) CreateMember(ctx context.Context, member 
 		rollbackRequired = true
 		return nil, errIndex
 	}
-	keys = append(keys, indexKey)
 
 	slog.DebugContext(ctx, "committee member created successfully",
 		"committee_uid", member.CommitteeUID,

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -239,7 +239,7 @@ func (uc *committeeWriterOrchestrator) CreateMember(ctx context.Context, member 
 	}
 	keys = append(keys, member.UID)
 
-	// Step 8b: Write the committee→member secondary index so ListMembers can use a
+	// Step 8b: Write the committee→member secondary index so ListMembersByCommittee can use a
 	// targeted prefix scan rather than a full bucket scan.
 	indexKey, errIndex := uc.committeeWriter.IndexMemberByCommittee(ctx, member)
 	// Append before checking the error: if the write partially succeeded and

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -229,6 +229,20 @@ func (uc *committeeWriterOrchestrator) CreateMember(ctx context.Context, member 
 	}
 	keys = append(keys, member.UID)
 
+	// Step 8b: Write the committee→member secondary index so ListMembers can use a
+	// targeted prefix scan rather than a full bucket scan.
+	indexKey, errIndex := uc.committeeWriter.IndexMemberByCommittee(ctx, member)
+	if errIndex != nil {
+		slog.ErrorContext(ctx, "failed to write committee member index",
+			"error", errIndex,
+			"committee_uid", member.CommitteeUID,
+			"member_uid", member.UID,
+		)
+		rollbackRequired = true
+		return nil, errIndex
+	}
+	keys = append(keys, indexKey)
+
 	slog.DebugContext(ctx, "committee member created successfully",
 		"committee_uid", member.CommitteeUID,
 		"member_uid", member.UID,
@@ -600,9 +614,13 @@ func (uc *committeeWriterOrchestrator) DeleteMember(ctx context.Context, uid str
 	// Step 2: Build list of secondary indices to delete
 	var indicesToDelete []string
 
-	// Build member lookup index key (committee_uid + email hash)
+	// Build member lookup index key (committee_uid + email hash) for uniqueness guard.
 	memberIndexKey := fmt.Sprintf(constants.KVLookupMemberPrefix, existing.BuildIndexKey(ctx))
 	indicesToDelete = append(indicesToDelete, memberIndexKey)
+
+	// Build committee→member secondary index key so it is cleaned up on delete.
+	membersByCommitteeKey := fmt.Sprintf(constants.KVLookupMembersByCommitteePrefix, existing.CommitteeUID, existing.UID)
+	indicesToDelete = append(indicesToDelete, membersByCommitteeKey)
 
 	slog.DebugContext(ctx, "secondary indices identified for member deletion",
 		"member_uid", uid,

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -271,7 +271,7 @@ func (r *TestMockCommitteeReader) GetMemberRevision(ctx context.Context, uid str
 	return 0, errs.NewNotFound("member not found")
 }
 
-func (r *TestMockCommitteeReader) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
+func (r *TestMockCommitteeReader) ListMembersByCommittee(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 	return []*model.CommitteeMember{}, errs.NewNotFound("not implemented for this test")
 }
 

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/infrastructure/mock"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
 	errs "github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 )
 
@@ -144,7 +145,7 @@ func (w *TestMockCommitteeMemberWriter) UniqueMember(ctx context.Context, member
 }
 
 func (w *TestMockCommitteeMemberWriter) IndexMemberByCommittee(_ context.Context, member *model.CommitteeMember) (string, error) {
-	key := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", member.CommitteeUID, member.UID)
+	key := fmt.Sprintf(constants.KVLookupMembersByCommitteePrefix, member.CommitteeUID, member.UID)
 	w.indexedKeys = append(w.indexedKeys, key)
 	return key, nil
 }

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -24,6 +24,7 @@ type TestMockCommitteeMemberWriter struct {
 	members         map[string]*model.CommitteeMember
 	keys            map[string]string // uniqueness keys
 	customRevisions map[string]uint64 // for testing revision conflicts
+	indexedKeys     []string          // keys written by IndexMemberByCommittee
 }
 
 func NewTestMockCommitteeMemberWriter(mockRepo *mock.MockRepository) *TestMockCommitteeMemberWriter {
@@ -144,6 +145,7 @@ func (w *TestMockCommitteeMemberWriter) UniqueMember(ctx context.Context, member
 
 func (w *TestMockCommitteeMemberWriter) IndexMemberByCommittee(_ context.Context, member *model.CommitteeMember) (string, error) {
 	key := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", member.CommitteeUID, member.UID)
+	w.indexedKeys = append(w.indexedKeys, key)
 	return key, nil
 }
 
@@ -627,11 +629,10 @@ func TestCommitteeWriterOrchestrator_deleteMemberKeys_EmptyKeys(t *testing.T) {
 	// No assertion needed, just ensure it doesn't panic
 }
 
-// TestCreateMember_IndexKeyTracked verifies that CreateMember appends the
-// committee→member index key to the rollback key set (meaning IndexMemberByCommittee
-// was called and its result was retained for potential rollback).
+// TestCreateMember_IndexKeyTracked verifies that CreateMember calls
+// IndexMemberByCommittee and records the returned key for rollback.
 func TestCreateMember_IndexKeyTracked(t *testing.T) {
-	orchestrator, mockRepo, _ := setupMemberWriterTest()
+	orchestrator, mockRepo, memberWriter := setupMemberWriterTest()
 
 	committee := &model.Committee{
 		CommitteeBase: model.CommitteeBase{
@@ -659,16 +660,21 @@ func TestCreateMember_IndexKeyTracked(t *testing.T) {
 	result, err := orchestrator.CreateMember(ctx, member, false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.NotEmpty(t, result.UID, "created member must have a UID")
+	assert.NotEmpty(t, result.UID)
 	assert.Equal(t, "committee-index-test", result.CommitteeUID)
+
+	// IndexMemberByCommittee must have been called exactly once, and the recorded
+	// key must match the expected committee→member index key format.
+	require.Len(t, memberWriter.indexedKeys, 1)
+	expectedKey := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", result.CommitteeUID, result.UID)
+	assert.Equal(t, expectedKey, memberWriter.indexedKeys[0])
 }
 
-// TestDeleteMember_IndexKeyIncluded verifies that DeleteMember includes the
-// committee→member secondary index key in the set of keys purged on deletion.
+// TestDeleteMember_IndexKeyIncluded verifies that DeleteMember enqueues the
+// committee→member secondary index key for cleanup alongside the primary record.
 func TestDeleteMember_IndexKeyIncluded(t *testing.T) {
 	orchestrator, mockRepo, memberWriter := setupMemberWriterTest()
 
-	// Pre-populate the shared mock repo so that GetMember (via MockCommitteeReader) succeeds.
 	existingMember := &model.CommitteeMember{
 		CommitteeMemberBase: model.CommitteeMemberBase{
 			UID:          "member-del-idx",
@@ -679,17 +685,32 @@ func TestDeleteMember_IndexKeyIncluded(t *testing.T) {
 			UpdatedAt:    time.Now(),
 		},
 	}
+	// Populate the shared mock repo so GetMember succeeds.
 	mockRepo.AddCommitteeMember(existingMember.CommitteeUID, existingMember)
-	// Also add to the local writer map so DeleteMember can find and remove it.
+	// Add primary record to writer so DeleteMember can find and remove it.
 	memberWriter.members["member-del-idx"] = existingMember
+
+	// Pre-register the by-committee index key in the writer's members map so
+	// deleteMemberKeys can resolve a revision for it and attempt deletion.
+	// We also point the orchestrator's reader at memberWriter: its GetMemberRevision
+	// override checks the local members map first, so it finds the synthetic index
+	// key entry without needing it to exist as a real member in the shared mock repo.
+	indexKey := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s",
+		existingMember.CommitteeUID, existingMember.UID)
+	memberWriter.members[indexKey] = existingMember
+	orchestrator.committeeReader = memberWriter
 
 	ctx := context.Background()
 	err := orchestrator.DeleteMember(ctx, "member-del-idx", 1, false)
 	require.NoError(t, err)
 
-	// The member record itself must be gone.
-	_, stillExists := memberWriter.members["member-del-idx"]
-	assert.False(t, stillExists, "main member record should be deleted")
+	// Primary record must be gone.
+	_, primaryStillExists := memberWriter.members["member-del-idx"]
+	assert.False(t, primaryStillExists, "main member record should be deleted")
+
+	// Index key must also have been removed by the cleanup pass.
+	_, indexStillExists := memberWriter.members[indexKey]
+	assert.False(t, indexStillExists, "committee→member index key should be cleaned up on delete")
 }
 
 func TestCommitteeWriterOrchestrator_validateCorporateEmailDomain(t *testing.T) {

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -142,6 +142,11 @@ func (w *TestMockCommitteeMemberWriter) UniqueMember(ctx context.Context, member
 	return key, nil
 }
 
+func (w *TestMockCommitteeMemberWriter) IndexMemberByCommittee(_ context.Context, member *model.CommitteeMember) (string, error) {
+	key := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", member.CommitteeUID, member.UID)
+	return key, nil
+}
+
 func (w *TestMockCommitteeMemberWriter) GetMemberRevision(ctx context.Context, uid string) (uint64, error) {
 	// Check if member exists in our local storage
 	if _, exists := w.members[uid]; exists {
@@ -266,6 +271,10 @@ func (r *TestMockCommitteeReader) GetMemberRevision(ctx context.Context, uid str
 
 func (r *TestMockCommitteeReader) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 	return []*model.CommitteeMember{}, errs.NewNotFound("not implemented for this test")
+}
+
+func (r *TestMockCommitteeReader) ListAllMembers(_ context.Context) ([]*model.CommitteeMember, error) {
+	return []*model.CommitteeMember{}, nil
 }
 
 func (r *TestMockCommitteeReader) GetSettingsUIDByInviteUID(ctx context.Context, inviteUID string) (string, error) {
@@ -616,6 +625,71 @@ func TestCommitteeWriterOrchestrator_deleteMemberKeys_EmptyKeys(t *testing.T) {
 	// Should handle empty keys gracefully
 	orchestrator.deleteMemberKeys(ctx, keys, false)
 	// No assertion needed, just ensure it doesn't panic
+}
+
+// TestCreateMember_IndexKeyTracked verifies that CreateMember appends the
+// committee→member index key to the rollback key set (meaning IndexMemberByCommittee
+// was called and its result was retained for potential rollback).
+func TestCreateMember_IndexKeyTracked(t *testing.T) {
+	orchestrator, mockRepo, _ := setupMemberWriterTest()
+
+	committee := &model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:      "committee-index-test",
+			Name:     "Index Test Committee",
+			Category: "Technical",
+		},
+		CommitteeSettings: &model.CommitteeSettings{
+			UID:                   "committee-index-test",
+			BusinessEmailRequired: false,
+		},
+	}
+	mockRepo.AddCommittee(committee)
+
+	member := &model.CommitteeMember{
+		CommitteeMemberBase: model.CommitteeMemberBase{
+			CommitteeUID: "committee-index-test",
+			Email:        "indextest@example.com",
+			Username:     "indexuser",
+			Organization: model.CommitteeMemberOrganization{Name: "Index Org"},
+		},
+	}
+
+	ctx := context.Background()
+	result, err := orchestrator.CreateMember(ctx, member, false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.UID, "created member must have a UID")
+	assert.Equal(t, "committee-index-test", result.CommitteeUID)
+}
+
+// TestDeleteMember_IndexKeyIncluded verifies that DeleteMember includes the
+// committee→member secondary index key in the set of keys purged on deletion.
+func TestDeleteMember_IndexKeyIncluded(t *testing.T) {
+	orchestrator, mockRepo, memberWriter := setupMemberWriterTest()
+
+	// Pre-populate the shared mock repo so that GetMember (via MockCommitteeReader) succeeds.
+	existingMember := &model.CommitteeMember{
+		CommitteeMemberBase: model.CommitteeMemberBase{
+			UID:          "member-del-idx",
+			CommitteeUID: "committee-del-idx",
+			Email:        "del-idx@example.com",
+			Username:     "delidxuser",
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		},
+	}
+	mockRepo.AddCommitteeMember(existingMember.CommitteeUID, existingMember)
+	// Also add to the local writer map so DeleteMember can find and remove it.
+	memberWriter.members["member-del-idx"] = existingMember
+
+	ctx := context.Background()
+	err := orchestrator.DeleteMember(ctx, "member-del-idx", 1, false)
+	require.NoError(t, err)
+
+	// The member record itself must be gone.
+	_, stillExists := memberWriter.members["member-del-idx"]
+	assert.False(t, stillExists, "main member record should be deleted")
 }
 
 func TestCommitteeWriterOrchestrator_validateCorporateEmailDomain(t *testing.T) {

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -38,8 +38,8 @@ type CommitteeMemberDataReader interface {
 	GetMember(ctx context.Context, committeeUID, memberUID string) (*model.CommitteeMember, uint64, error)
 	// GetMemberRevision retrieves the current KV revision for a committee member by UID
 	GetMemberRevision(ctx context.Context, memberUID string) (uint64, error)
-	// ListMembers retrieves all members for a given committee UID
-	ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
+	// ListMembersByCommittee retrieves all members for a given committee UID
+	ListMembersByCommittee(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
 }
 
 // committeeReaderOrchestratorOption defines a function type for setting options
@@ -176,15 +176,15 @@ func (rc *committeeReaderOrchestrator) GetMember(ctx context.Context, committeeU
 	return committeeMember, revision, nil
 }
 
-// ListMembers retrieves all members for a given committee UID
-func (rc *committeeReaderOrchestrator) ListMembers(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
+// ListMembersByCommittee retrieves all members for a given committee UID
+func (rc *committeeReaderOrchestrator) ListMembersByCommittee(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error) {
 
 	slog.DebugContext(ctx, "executing list committee members use case",
 		"committee_uid", committeeUID,
 	)
 
 	// Get all committee members from storage
-	members, err := rc.committeeReader.ListMembers(ctx, committeeUID)
+	members, err := rc.committeeReader.ListMembersByCommittee(ctx, committeeUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list committee members",
 			"error", err,

--- a/internal/service/committee_writer_test.go
+++ b/internal/service/committee_writer_test.go
@@ -153,6 +153,11 @@ func (w *TestMockCommitteeWriter) UniqueMember(ctx context.Context, member *mode
 	return mockWriter.UniqueMember(ctx, member)
 }
 
+func (w *TestMockCommitteeWriter) IndexMemberByCommittee(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	mockWriter := mock.NewMockCommitteeWriter(w.mock)
+	return mockWriter.IndexMemberByCommittee(ctx, member)
+}
+
 func (w *TestMockCommitteeWriter) IndexSettingsInvite(ctx context.Context, inviteUID, committeeUID string) error {
 	mockWriter := mock.NewMockCommitteeWriter(w.mock)
 	return mockWriter.IndexSettingsInvite(ctx, inviteUID, committeeUID)

--- a/internal/service/document_notification_handler.go
+++ b/internal/service/document_notification_handler.go
@@ -254,7 +254,7 @@ func (m *messageHandlerOrchestrator) collectCommitteeRecipients(ctx context.Cont
 		})
 	}
 
-	members, err := m.committeeReader.ListMembers(ctx, committeeUID)
+	members, err := m.committeeReader.ListMembersByCommittee(ctx, committeeUID)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to list members for content notification",
 			"error", err, "committee_uid", committeeUID)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -228,7 +228,7 @@ func (m *messageHandlerOrchestrator) HandleCommitteeListMembers(ctx context.Cont
 	}
 
 	// Get all members for the committee
-	members, err := m.committeeReader.ListMembers(ctx, uid)
+	members, err := m.committeeReader.ListMembersByCommittee(ctx, uid)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list committee members",
 			"error", err,
@@ -358,7 +358,7 @@ func (m *messageHandlerOrchestrator) HandleCommitteeUpdated(ctx context.Context,
 	slog.InfoContext(ctx, "denormalized fields changed — syncing members",
 		"committee_uid", data.CommitteeUID)
 
-	members, err := m.committeeReader.ListMembers(ctx, data.CommitteeUID)
+	members, err := m.committeeReader.ListMembersByCommittee(ctx, data.CommitteeUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list members for sync",
 			"committee_uid", data.CommitteeUID, "error", err)
@@ -456,7 +456,7 @@ func (m *messageHandlerOrchestrator) HandleCommitteeTotalMembersSync(ctx context
 		"subject", subject,
 	)
 
-	members, err := m.committeeReader.ListMembers(ctx, committeeUID)
+	members, err := m.committeeReader.ListMembersByCommittee(ctx, committeeUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list members for total_members sync",
 			"committee_uid", committeeUID, "error", err)

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -753,7 +753,7 @@ func TestHandleCommitteeUpdated(t *testing.T) {
 			name:            "list members fails — propagates error",
 			messageData:     buildCommitteeUpdatedMsg("unknown-committee", oldBase, newBase),
 			setupMock:       func(_ *mock.MockRepository) {},
-			wantErr:         false, // ListMembers returns empty slice for unknown committee, not error
+			wantErr:         false, // ListMembersByCommittee returns empty slice for unknown committee, not error
 			wantUpdateCalls: 0,
 		},
 		{

--- a/pkg/constants/storage.go
+++ b/pkg/constants/storage.go
@@ -26,6 +26,16 @@ const (
 	// KVLookupMemberPrefix is the prefix for member lookup keys in the KV store.
 	KVLookupMemberPrefix = "lookup/committee-members/%s"
 
+	// KVLookupMembersByCommitteePrefix is the secondary index that maps a committee UID to each
+	// of its members. Key pattern: "lookup/committee-members-by-committee/<committee_uid>.<member_uid>",
+	// Value: <member_uid>. The dot-separated tokens allow server-side filtered scans via
+	// ListKeysFiltered with a "<committee_uid>.*" subject wildcard without fetching unrelated members.
+	KVLookupMembersByCommitteePrefix = "lookup/committee-members-by-committee/%s.%s"
+
+	// KVLookupMembersByCommitteeFilter is the ListKeysFiltered subject filter for all members of
+	// one committee: "lookup/committee-members-by-committee/<committee_uid>.*"
+	KVLookupMembersByCommitteeFilter = "lookup/committee-members-by-committee/%s.*"
+
 	// KVLookupInvitePrefix is the prefix for invite lookup keys in the KV store.
 	KVLookupInvitePrefix = "lookup/committee-invites/%s"
 


### PR DESCRIPTION
## Summary

- Rewrites \`ListMembers\` in the NATS storage layer to use a server-side filtered scan (\`ListKeysFiltered\`) instead of a full bucket scan + in-memory filter, eliminating the ~1 minute latency on \`lfx.committee-api.list_members\`
- Adds \`IndexMemberByCommittee\` to write/maintain the secondary index on member create/delete
- Adds a \`committee-cli sync members-by-committee-index\` one-shot backfill subcommand to populate the index for all pre-existing members
- Also fixes two pre-existing golangci-lint failures in files not touched by the primary change (errcheck on \`hash.Write\` via \`fmt.Fprintf\`, and redundant \`//+build\` line)

## How it works

A secondary index entry is written per member:
- **Key**: \`lookup/committee-members-by-committee/<committeeUID>.<memberUID>\`
- **Value**: \`<memberUID>\`
- **Bucket**: \`committee-members\` (same bucket; \`lookup/\` prefix is already skipped by all existing full scans)

\`ListMembers\` now calls \`ListKeysFiltered(ctx, "lookup/committee-members-by-committee/<committeeUID>.*")\` — a NATS server-side subject filter — then does targeted GETs only for the matching members. Latency changes from O(all members in the bucket) to O(members in the target committee).

The three existing callers of \`ListMembers\` all benefit automatically: the \`list_members\` NATS handler, \`HandleCommitteeUpdated\`, and \`HandleCommitteeTotalMembersSync\`.

Update does not need index maintenance because the index key is composed of \`committeeUID\` + \`memberUID\`, both of which are immutable (the orchestrator already rejects committee reassignment on update).

## Ticket

[LFXV2-2040](https://linuxfoundation.atlassian.net/browse/LFXV2-2040)

## Deployment plan

**The backfill must run before the new service version is deployed in each environment.** The new \`ListMembers\` reads exclusively from the secondary index — existing members have no index entries until the sync command is run.

1. **Dev** — once this PR is approved, run the backfill against dev:
   ```
   committee-cli sync members-by-committee-index
   ```
   Then merge and deploy to dev. Verify \`lfx.committee-api.list_members\` returns correct results and replies in <30ms.

2. **Prod** — run the backfill against prod, then release the committee service to prod. Verify results and latency in prod.

> The sync command is idempotent (\`IndexMemberByCommittee\` uses write-if-absent and treats \`ErrKeyExists\` as success), so re-running it is safe.

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2040]: https://linuxfoundation.atlassian.net/browse/LFXV2-2040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ