### PR TITLE
Fix Datadog trace resource names

### DIFF
--- a/cmd/committee-api/http.go
+++ b/cmd/committee-api/http.go
@@ -16,14 +16,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
+	"goa.design/clue/debug"
+	goahttp "goa.design/goa/v3/http"
+
 	committeeservice "github.com/linuxfoundation/lfx-v2-committee-service/gen/committee_service"
 	committeeservicesvr "github.com/linuxfoundation/lfx-v2-committee-service/gen/http/committee_service/server"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/middleware"
-
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"goa.design/clue/debug"
-	goahttp "goa.design/goa/v3/http"
 )
 
 // handleHTTPServer starts configures and starts a HTTP server on the given
@@ -41,7 +44,7 @@ func handleHTTPServer(ctx context.Context, host string, committeeServiceEndpoint
 
 	// Build the service HTTP request multiplexer and mount debug and profiler
 	// endpoints in debug mode.
-	var mux goahttp.Muxer
+	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
 		if dbg {
@@ -75,6 +78,29 @@ func handleHTTPServer(ctx context.Context, host string, committeeServiceEndpoint
 			koDataDir, koDataDir, koDataDir, koDataDir,
 		)
 	}
+
+	// Register route-tagging middleware inside chi's routing chain so that
+	// http.route is set on the OTel span after chi has matched the route pattern.
+	// The span name is also updated here to avoid high-cardinality names from
+	// using raw URL paths (which contain actual path parameter values).
+	// Must be registered before Mount calls per chi convention.
+	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
+	// during routing (inside ServeHTTP), not before.
+	mux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+			rctx := chi.RouteContext(r.Context())
+			if rctx != nil {
+				routePattern := rctx.RoutePattern()
+				if routePattern != "" {
+					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+						labeler.Add(semconv.HTTPRoute(routePattern))
+					}
+					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+				}
+			}
+		})
+	})
 
 	// Configure the mux.
 	committeeservicesvr.Mount(mux, committeeServiceServer)

--- a/cmd/committee-api/http.go
+++ b/cmd/committee-api/http.go
@@ -88,17 +88,19 @@ func handleHTTPServer(ctx context.Context, host string, committeeServiceEndpoint
 	// during routing (inside ServeHTTP), not before.
 	mux.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-			rctx := chi.RouteContext(r.Context())
-			if rctx != nil {
-				routePattern := rctx.RoutePattern()
-				if routePattern != "" {
-					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
-						labeler.Add(semconv.HTTPRoute(routePattern))
+			defer func() {
+				rctx := chi.RouteContext(r.Context())
+				if rctx != nil {
+					routePattern := rctx.RoutePattern()
+					if routePattern != "" {
+						if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+							labeler.Add(semconv.HTTPRoute(routePattern))
+						}
+						trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
 					}
-					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
 				}
-			}
+			}()
+			next.ServeHTTP(w, r)
 		})
 	})
 

--- a/cmd/committee-api/http.go
+++ b/cmd/committee-api/http.go
@@ -47,6 +47,32 @@ func handleHTTPServer(ctx context.Context, host string, committeeServiceEndpoint
 	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
+		// Register route-tagging middleware inside chi's routing chain so that
+		// http.route is set on the OTel span after chi has matched the route pattern.
+		// The span name is also updated here to avoid high-cardinality names from
+		// using raw URL paths (which contain actual path parameter values).
+		// Must be registered before Mount calls per chi convention.
+		// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
+		// during routing (inside ServeHTTP), not before.
+		mux.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer func() {
+					rctx := chi.RouteContext(r.Context())
+					if rctx != nil {
+						routePattern := rctx.RoutePattern()
+						if routePattern != "" {
+							if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+								labeler.Add(semconv.HTTPRoute(routePattern))
+							}
+							span := trace.SpanFromContext(r.Context())
+							span.SetAttributes(semconv.HTTPRoute(routePattern))
+							span.SetName(r.Method + " " + routePattern)
+						}
+					}
+				}()
+				next.ServeHTTP(w, r)
+			})
+		})
 		if dbg {
 			// Mount pprof handlers for memory profiling under /debug/pprof.
 			debug.MountPprofHandlers(debug.Adapt(mux))
@@ -78,31 +104,6 @@ func handleHTTPServer(ctx context.Context, host string, committeeServiceEndpoint
 			koDataDir, koDataDir, koDataDir, koDataDir,
 		)
 	}
-
-	// Register route-tagging middleware inside chi's routing chain so that
-	// http.route is set on the OTel span after chi has matched the route pattern.
-	// The span name is also updated here to avoid high-cardinality names from
-	// using raw URL paths (which contain actual path parameter values).
-	// Must be registered before Mount calls per chi convention.
-	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
-	// during routing (inside ServeHTTP), not before.
-	mux.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			defer func() {
-				rctx := chi.RouteContext(r.Context())
-				if rctx != nil {
-					routePattern := rctx.RoutePattern()
-					if routePattern != "" {
-						if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
-							labeler.Add(semconv.HTTPRoute(routePattern))
-						}
-						trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
-					}
-				}
-			}()
-			next.ServeHTTP(w, r)
-		})
-	})
 
 	// Configure the mux.
 	committeeservicesvr.Mount(mux, committeeServiceServer)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.25.0
 require (
 	github.com/auth0/go-auth0 v1.38.0
 	github.com/auth0/go-jwt-middleware/v2 v2.3.0
+	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.15.0
@@ -31,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	goa.design/clue v1.2.3
 	goa.design/goa/v3 v3.22.6
 	golang.org/x/oauth2 v0.36.0
@@ -46,7 +48,6 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-chi/chi/v5 v5.2.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
@@ -71,7 +72,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect


### PR DESCRIPTION
## Summary

- Add chi route-tagging middleware to set `http.route` on OTel spans after chi matches the route pattern
- Update `trace.SpanFromContext().SetName()` with the matched route pattern so Datadog shows `GET /api/v1/committees/{id}` instead of just `GET`
- Change `var mux goahttp.Muxer` to `goahttp.MiddlewareMuxer` to expose the `Use()` method
- Promote `chi/v5` and `otel/trace` from indirect to direct dependencies in `go.mod`

Fixes low-cardinality Datadog trace resource names across the service by reading the chi route pattern post-`ServeHTTP` (the only point at which chi has populated it).

JIRA: [LFXV2-1935](https://linuxfoundation.atlassian.net/browse/LFXV2-1935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1935]: https://linuxfoundation.atlassian.net/browse/LFXV2-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ