### PR TITLE
feat: restrict voting_status "None" on voting-enabled committees

### DIFF
--- a/internal/domain/model/committee_member.go
+++ b/internal/domain/model/committee_member.go
@@ -16,6 +16,10 @@ import (
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/redaction"
 )
 
+// votingStatusNone is the legacy sentinel value a member may have when a
+// non-voting committee was converted to voting without migrating member statuses.
+const votingStatusNone = "None"
+
 // CommitteeMember represents the complete committee member business entity
 type CommitteeMember struct {
 	CommitteeMemberBase
@@ -177,8 +181,35 @@ func (cm *CommitteeMember) NeedsSyncWith(committee *CommitteeBase) bool {
 		cm.ProjectSlug != committee.ProjectSlug
 }
 
-// Validate validates the committee member against the committee's requirements
+// isNoneVotingStatus reports whether s represents the "None" voting status,
+// using a case-insensitive comparison to guard against legacy data casing variations.
+func isNoneVotingStatus(s string) bool {
+	return strings.EqualFold(s, votingStatusNone)
+}
+
+// Validate validates the committee member against the committee's requirements.
+// It covers all standard cases including the restriction that voting-enabled
+// committees may not have members with voting_status "None".
 func (cm *CommitteeMember) Validate(committee *Committee) error {
+	return cm.validate(committee, "")
+}
+
+// ValidateUpdate runs all of the same checks as Validate and additionally
+// applies the legacy-None exemption: if the existing member already carries
+// voting_status "None" (a v1 migration artifact), the incoming update may keep
+// or correct it without being rejected.
+func (cm *CommitteeMember) ValidateUpdate(committee *Committee, existing *CommitteeMember) error {
+	existingStatus := ""
+	if existing != nil {
+		existingStatus = existing.Voting.Status
+	}
+	return cm.validate(committee, existingStatus)
+}
+
+// validate is the shared implementation for Validate and ValidateUpdate.
+// existingStatus is the current voting status of the member being updated
+// (empty string for creates).
+func (cm *CommitteeMember) validate(committee *Committee, existingStatus string) error {
 	if cm == nil {
 		return errs.NewValidation("committee member cannot be nil")
 	}
@@ -187,13 +218,15 @@ func (cm *CommitteeMember) Validate(committee *Committee) error {
 		return errs.NewValidation("committee cannot be nil")
 	}
 
-	// Validate basic required fields
 	if err := cm.validateRequiredFields(); err != nil {
 		return err
 	}
 
-	// Validate organization fields based on committee settings
 	if err := cm.validateOrganizationFields(committee); err != nil {
+		return err
+	}
+
+	if err := cm.validateVotingStatus(committee, existingStatus); err != nil {
 		return err
 	}
 
@@ -206,6 +239,16 @@ func (cm *CommitteeMember) validateRequiredFields() error {
 		return errs.NewValidation("email is required")
 	}
 
+	return nil
+}
+
+// validateVotingStatus rejects "None" as an incoming voting status on voting-enabled committees,
+// unless the existing member already carries "None" (the legacy corrective path).
+// Pass an empty string for existingStatus on creates.
+func (cm *CommitteeMember) validateVotingStatus(committee *Committee, existingStatus string) error {
+	if committee.EnableVoting && isNoneVotingStatus(cm.Voting.Status) && !isNoneVotingStatus(existingStatus) {
+		return errs.NewValidation(`voting_status "None" is not allowed on voting-enabled committees`)
+	}
 	return nil
 }
 

--- a/internal/domain/model/committee_member_test.go
+++ b/internal/domain/model/committee_member_test.go
@@ -197,6 +197,52 @@ func TestCommitteeMember_Validate(t *testing.T) {
 			committee:   nonGacCommittee,
 			expectError: false,
 		},
+		{
+			name: "voting enabled - voting status None is rejected",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					Email: "user@corp.com",
+					Organization: CommitteeMemberOrganization{
+						ID: "org-456",
+					},
+					Voting: CommitteeMemberVotingInfo{
+						Status: "None",
+					},
+				},
+			},
+			committee:     committeeWithVoting,
+			expectError:   true,
+			expectedError: "voting_status \"None\" is not allowed on voting-enabled committees",
+		},
+		{
+			name: "voting enabled - valid voting status is accepted",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					Email: "user@corp.com",
+					Organization: CommitteeMemberOrganization{
+						ID: "org-456",
+					},
+					Voting: CommitteeMemberVotingInfo{
+						Status: "Voting Rep",
+					},
+				},
+			},
+			committee:   committeeWithVoting,
+			expectError: false,
+		},
+		{
+			name: "voting disabled - voting status None is allowed",
+			member: &CommitteeMember{
+				CommitteeMemberBase: CommitteeMemberBase{
+					Email: "user@example.com",
+					Voting: CommitteeMemberVotingInfo{
+						Status: "None",
+					},
+				},
+			},
+			committee:   nonGacCommittee,
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -533,6 +579,109 @@ func TestCommitteeMember_BuildIndexKey_Uniqueness(t *testing.T) {
 
 	if key2 == key3 {
 		t.Errorf("Expected different keys for different committee/email combinations, but got same key: %s", key2)
+	}
+}
+
+func TestCommitteeMember_ValidateUpdate(t *testing.T) {
+	committeeWithVoting := &Committee{
+		CommitteeBase:     CommitteeBase{Category: "Other", EnableVoting: true},
+		CommitteeSettings: &CommitteeSettings{},
+	}
+
+	nonVotingCommittee := &Committee{
+		CommitteeBase:     CommitteeBase{Category: "Other"},
+		CommitteeSettings: &CommitteeSettings{},
+	}
+
+	validMember := func(status string) *CommitteeMember {
+		return &CommitteeMember{
+			CommitteeMemberBase: CommitteeMemberBase{
+				Email: "user@corp.com",
+				Organization: CommitteeMemberOrganization{
+					ID: "org-123",
+				},
+				Voting: CommitteeMemberVotingInfo{Status: status},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		incoming      *CommitteeMember
+		existing      *CommitteeMember
+		committee     *Committee
+		expectError   bool
+		expectedError string
+	}{
+		{
+			name:          "voting enabled - valid existing, incoming None is rejected",
+			incoming:      validMember("None"),
+			existing:      validMember("Voting Rep"),
+			committee:     committeeWithVoting,
+			expectError:   true,
+			expectedError: "voting_status \"None\" is not allowed on voting-enabled committees",
+		},
+		{
+			name:        "voting enabled - legacy existing None, incoming valid is allowed",
+			incoming:    validMember("Voting Rep"),
+			existing:    validMember("None"),
+			committee:   committeeWithVoting,
+			expectError: false,
+		},
+		{
+			name:        "voting enabled - legacy existing None, keeping None is allowed",
+			incoming:    validMember("None"),
+			existing:    validMember("None"),
+			committee:   committeeWithVoting,
+			expectError: false,
+		},
+		{
+			name:        "voting enabled - valid to valid transition is allowed",
+			incoming:    validMember("Observer"),
+			existing:    validMember("Voting Rep"),
+			committee:   committeeWithVoting,
+			expectError: false,
+		},
+		{
+			name:        "voting disabled - any status is allowed",
+			incoming:    validMember("None"),
+			existing:    validMember("Voting Rep"),
+			committee:   nonVotingCommittee,
+			expectError: false,
+		},
+		{
+			name:          "nil incoming member",
+			incoming:      nil,
+			existing:      validMember("Voting Rep"),
+			committee:     committeeWithVoting,
+			expectError:   true,
+			expectedError: "committee member cannot be nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.incoming.ValidateUpdate(tt.committee, tt.existing)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+					return
+				}
+
+				var validationErr errs.Validation
+				if !errors.As(err, &validationErr) {
+					t.Errorf("expected validation error, got %T: %v", err, err)
+					return
+				}
+
+				if err.Error() != tt.expectedError {
+					t.Errorf("expected error %q, got %q", tt.expectedError, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -411,7 +411,7 @@ func (uc *committeeWriterOrchestrator) UpdateMember(ctx context.Context, member 
 	)
 
 	fullCommittee := &model.Committee{CommitteeBase: *committee, CommitteeSettings: settings}
-	if errValidation := member.Validate(fullCommittee); errValidation != nil {
+	if errValidation := member.ValidateUpdate(fullCommittee, existing); errValidation != nil {
 		slog.ErrorContext(ctx, "committee member validation failed during update",
 			"error", errValidation,
 			"member_uid", member.UID,


### PR DESCRIPTION
## Summary

- Adds `validateVotingStatus` to the domain model, rejecting `voting_status = "None"` on voting-enabled committees for new creates and updates from a valid status
- Introduces `ValidateUpdate(committee, existing)` for the update path, which applies the legacy-None exemption (existing `"None"` members may keep or correct their status)
- Both `Validate` and `ValidateUpdate` delegate to a shared private `validate()` so all checks apply to both paths with no duplication
- Wires `ValidateUpdate` into `UpdateMember` in the service layer

Closes LFXV2-2075