### PR TITLE
[LFXV2-2079] feat: invite structured fields and email-based reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 DOCKER_REGISTRY := ghcr.io/linuxfoundation
 DOCKER_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-api
 DOCKER_CLI_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-cli
-DOCKER_TAG ?= $(VERSION)
+DOCKER_TAG ?= latest
 
 # Helm variables
 HELM_CHART_PATH=./charts/lfx-v2-committee-service

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 DOCKER_REGISTRY := ghcr.io/linuxfoundation
 DOCKER_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-api
 DOCKER_CLI_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)/committee-cli
-DOCKER_TAG ?= latest
+DOCKER_TAG ?= $(VERSION)
 
 # Helm variables
 HELM_CHART_PATH=./charts/lfx-v2-committee-service

--- a/cmd/committee-api/service/committee_handler.go
+++ b/cmd/committee-api/service/committee_handler.go
@@ -34,7 +34,7 @@ func (mhs *MessageHandlerService) HandleMessage(ctx context.Context, msg port.Tr
 		constants.CommitteeMemberCreatedSubject:      mhs.handleCommitteeMemberCreated,
 		constants.CommitteeMemberDeletedSubject:      mhs.handleCommitteeMemberDeleted,
 		constants.CommitteeSettingsUpdatedSubject:    mhs.handleCommitteeSettingsUpdated,
-		inviteapi.InviteAcceptedSubject:              mhs.handleInviteAccepted,
+		inviteapi.InviteServiceAcceptedSubject:       mhs.handleInviteAccepted,
 		constants.CommitteeDocumentCreatedSubject:    mhs.handleCommitteeDocumentCreated,
 		constants.CommitteeLinkCreatedSubject:        mhs.handleCommitteeLinkCreated,
 	}

--- a/cmd/committee-api/service/group_weekly_brief_test.go
+++ b/cmd/committee-api/service/group_weekly_brief_test.go
@@ -63,10 +63,6 @@ func (r *stubCommitteeReader) GetBaseAttributeValue(_ context.Context, _, _ stri
 	panic("not used")
 }
 
-func (r *stubCommitteeReader) GetSettingsUIDByInviteUID(_ context.Context, _ string) (string, error) {
-	panic("not used")
-}
-
 func (r *stubCommitteeReader) GetMemberRevision(_ context.Context, _ string) (uint64, error) {
 	panic("not used")
 }

--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -846,7 +846,7 @@ func QueueSubscriptions(ctx context.Context, committeeReader port.CommitteeReade
 		constants.CommitteeMemberCreatedSubject:      messageHandlerService.HandleMessage,
 		constants.CommitteeMemberDeletedSubject:      messageHandlerService.HandleMessage,
 		constants.CommitteeSettingsUpdatedSubject:    messageHandlerService.HandleMessage,
-		inviteapi.InviteAcceptedSubject:              messageHandlerService.HandleMessage,
+		inviteapi.InviteServiceAcceptedSubject:       messageHandlerService.HandleMessage,
 		constants.CommitteeDocumentCreatedSubject:    messageHandlerService.HandleMessage,
 		constants.CommitteeLinkCreatedSubject:        messageHandlerService.HandleMessage,
 	}

--- a/cmd/committee-cli/commands/sync/total_members_attribute_test.go
+++ b/cmd/committee-cli/commands/sync/total_members_attribute_test.go
@@ -70,9 +70,7 @@ func (r *mockReader) ListApplications(_ context.Context, _ string) ([]*model.Com
 func (r *mockReader) GetSettings(_ context.Context, _ string) (*model.CommitteeSettings, uint64, error) {
 	return nil, 0, nil
 }
-func (r *mockReader) GetSettingsUIDByInviteUID(_ context.Context, _ string) (string, error) {
-	return "", nil
-}
+
 func (r *mockReader) ListAllMembers(_ context.Context) ([]*model.CommitteeMember, error) {
 	var all []*model.CommitteeMember
 	for _, members := range r.members {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/linuxfoundation/lfx-v2-email-service v0.1.0
 	github.com/linuxfoundation/lfx-v2-fga-sync v0.2.17
 	github.com/linuxfoundation/lfx-v2-indexer-service v0.4.16
-	github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305
+	github.com/linuxfoundation/lfx-v2-invite-service v0.1.4-0.20260603200146-27b0e0162e1d
 	github.com/nats-io/nats.go v1.47.0
 	github.com/remychantenay/slog-otel v1.3.4
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/linuxfoundation/lfx-v2-indexer-service v0.4.16 h1:pOcjVN+KQo2h80je1gl
 github.com/linuxfoundation/lfx-v2-indexer-service v0.4.16/go.mod h1:hLf2Hl39PsUg2qtl5os0noXxCXWHrkO26EPT+G0RhmA=
 github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305 h1:jHNYpxuJ5re8Wjidk59AvlH83ILnyDQrQF5jfV17zSg=
 github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
+github.com/linuxfoundation/lfx-v2-invite-service v0.1.4-0.20260603200146-27b0e0162e1d h1:G+KYq8Jy9CnZilJk89q0nvTEHYfYjNpQ1GpwghdiNvc=
+github.com/linuxfoundation/lfx-v2-invite-service v0.1.4-0.20260603200146-27b0e0162e1d/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d h1:Zj+PHjnhRYWBK6RqCDBcAhLXoi3TzC27Zad/Vn+gnVQ=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d/go.mod h1:WZy8Q5coAB1zhY9AOBJP0O6J4BuDfbupUDavKY+I3+s=
 github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b h1:3E44bLeN8uKYdfQqVQycPnaVviZdBLbizFhU49mtbe4=

--- a/internal/domain/port/committee_reader.go
+++ b/internal/domain/port/committee_reader.go
@@ -28,8 +28,4 @@ type CommitteeBaseReader interface {
 // CommitteeSettingsReader handles committee settings reading operations
 type CommitteeSettingsReader interface {
 	GetSettings(ctx context.Context, committeeUID string) (*model.CommitteeSettings, uint64, error)
-	// GetSettingsUIDByInviteUID looks up the committee UID for a given invite UID via the
-	// secondary index written at invite-send time. Returns NotFound if the invite is not tracked
-	// by this service.
-	GetSettingsUIDByInviteUID(ctx context.Context, inviteUID string) (string, error)
 }

--- a/internal/domain/port/committee_writer.go
+++ b/internal/domain/port/committee_writer.go
@@ -37,10 +37,4 @@ type CommitteeBaseWriter interface {
 // CommitteeSettingsWriter handles committee settings writing operations
 type CommitteeSettingsWriter interface {
 	UpdateSetting(ctx context.Context, settings *model.CommitteeSettings, revision uint64) error
-	// IndexSettingsInvite creates a secondary index entry mapping invite_uid → committee_uid so
-	// that invite acceptance messages can be routed to the right settings record without a full scan.
-	IndexSettingsInvite(ctx context.Context, inviteUID, committeeUID string) error
-	// DeleteSettingsInviteIndex removes the secondary index entry for the given invite UID once
-	// the invite has been accepted (username set, invite field cleared).
-	DeleteSettingsInviteIndex(ctx context.Context, inviteUID string) error
 }

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -301,8 +301,17 @@ func (m *MockRepository) GetSettings(ctx context.Context, committeeUID string) (
 		return nil, 0, errors.NewNotFound(fmt.Sprintf("committee settings for UID %s not found", committeeUID))
 	}
 
-	// Return version 1 for mock (in real implementation this would be the actual version)
-	return settings, 1, nil
+	if settings == nil {
+		// Committee exists but has no settings (e.g. created without CommitteeSettings).
+		return nil, 1, nil
+	}
+
+	// Return a deep copy so caller mutations (e.g. in-place field promotion) do not bleed
+	// back into the stored pointer and corrupt subsequent reads in the same test.
+	settingsCopy := *settings
+	settingsCopy.Writers = append([]model.CommitteeUser(nil), settings.Writers...)
+	settingsCopy.Auditors = append([]model.CommitteeUser(nil), settings.Auditors...)
+	return &settingsCopy, 1, nil
 }
 
 // ================== CommitteeMemberReader implementation ==================

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -302,8 +302,10 @@ func (m *MockRepository) GetSettings(ctx context.Context, committeeUID string) (
 	}
 
 	if settings == nil {
-		// Committee exists but has no settings (e.g. created without CommitteeSettings).
-		return nil, 1, nil
+		// Committee exists but was stored without a CommitteeSettings pointer.
+		// Treat this identically to "not found" so callers cannot distinguish a nil
+		// value from a missing key — consistent with real NATS storage behavior.
+		return nil, 0, errors.NewNotFound(fmt.Sprintf("committee settings for UID %s not found", committeeUID))
 	}
 
 	// Return a deep copy so caller mutations (e.g. in-place field promotion) do not bleed

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -42,7 +42,6 @@ func NewMockRepository() *MockRepository {
 			committeeApplications: make(map[string]*model.CommitteeApplication),
 			inviteIndexKeys:       make(map[string]*model.CommitteeInvite),
 			applicationIndexKeys:  make(map[string]*model.CommitteeApplication),
-			settingsInviteIndex:   make(map[string]string),
 			committeeRevisions:    make(map[string]uint64),
 			settingsRevisions:     make(map[string]uint64),
 			memberRevisions:       make(map[string]uint64),
@@ -229,7 +228,6 @@ type MockRepository struct {
 	committeeApplications map[string]*model.CommitteeApplication // applicationUID -> application
 	inviteIndexKeys       map[string]*model.CommitteeInvite      // indexKey -> invite
 	applicationIndexKeys  map[string]*model.CommitteeApplication // indexKey -> application
-	settingsInviteIndex   map[string]string                      // inviteUID -> committeeUID secondary index
 	// Revision tracking for optimistic locking
 	committeeRevisions   map[string]uint64 // committeeUID -> revision
 	settingsRevisions    map[string]uint64 // committeeUID -> settings revision
@@ -290,20 +288,6 @@ func (m *MockRepository) ListAllUIDs(ctx context.Context) ([]string, error) {
 }
 
 // ================== CommitteeSettingsReader implementation ==================
-
-// GetSettingsUIDByInviteUID looks up the committee UID for a given invite UID via the secondary index.
-func (m *MockRepository) GetSettingsUIDByInviteUID(ctx context.Context, inviteUID string) (string, error) {
-	slog.DebugContext(ctx, "mock repository: looking up committee UID by invite UID", "invite_uid", inviteUID)
-
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	committeeUID, exists := m.settingsInviteIndex[inviteUID]
-	if !exists {
-		return "", errors.NewNotFound(fmt.Sprintf("invite index entry for UID %s not found", inviteUID))
-	}
-	return committeeUID, nil
-}
 
 // GetSettings retrieves committee settings by committee UID
 func (m *MockRepository) GetSettings(ctx context.Context, committeeUID string) (*model.CommitteeSettings, uint64, error) {
@@ -570,24 +554,6 @@ func (w *MockCommitteeWriter) UpdateSetting(ctx context.Context, settings *model
 		w.mock.committeeIndexKeys[committee.BuildIndexKey(ctx)] = committee
 	}
 
-	return nil
-}
-
-// IndexSettingsInvite creates or overwrites the secondary index entry mapping invite_uid → committee_uid.
-func (w *MockCommitteeWriter) IndexSettingsInvite(ctx context.Context, inviteUID, committeeUID string) error {
-	slog.DebugContext(ctx, "mock committee writer: indexing settings invite", "invite_uid", inviteUID, "committee_uid", committeeUID)
-	w.mock.mu.Lock()
-	defer w.mock.mu.Unlock()
-	w.mock.settingsInviteIndex[inviteUID] = committeeUID
-	return nil
-}
-
-// DeleteSettingsInviteIndex removes the secondary index entry for the given invite UID.
-func (w *MockCommitteeWriter) DeleteSettingsInviteIndex(ctx context.Context, inviteUID string) error {
-	slog.DebugContext(ctx, "mock committee writer: deleting settings invite index", "invite_uid", inviteUID)
-	w.mock.mu.Lock()
-	defer w.mock.mu.Unlock()
-	delete(w.mock.settingsInviteIndex, inviteUID)
 	return nil
 }
 
@@ -1040,7 +1006,6 @@ func (m *MockRepository) ClearAll() {
 	m.committeeApplications = make(map[string]*model.CommitteeApplication)
 	m.inviteIndexKeys = make(map[string]*model.CommitteeInvite)
 	m.applicationIndexKeys = make(map[string]*model.CommitteeApplication)
-	m.settingsInviteIndex = make(map[string]string)
 	m.committeeRevisions = make(map[string]uint64)
 	m.settingsRevisions = make(map[string]uint64)
 	m.memberRevisions = make(map[string]uint64)

--- a/internal/infrastructure/nats/invite_sender.go
+++ b/internal/infrastructure/nats/invite_sender.go
@@ -57,10 +57,10 @@ func (s *inviteSender) SendInvite(ctx context.Context, req inviteapi.SendInviteR
 	}
 
 	var result port.InviteResult
-	if resp.Invite != nil {
-		result.InviteUID = resp.Invite.UID
-		result.RecipientEmail = resp.Invite.Email
-		result.ExpiresAt = resp.Invite.ExpiresAt
+	if resp.InviteData != nil {
+		result.InviteUID = resp.UID
+		result.RecipientEmail = resp.Email
+		result.ExpiresAt = resp.ExpiresAt
 	}
 	slog.DebugContext(ctx, "invite service replied", "invite_uid", result.InviteUID, "expires_at", result.ExpiresAt)
 	return result, nil

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -691,46 +691,6 @@ func (s *storage) UniqueInvite(ctx context.Context, invite *model.CommitteeInvit
 	return uniqueKey, nil
 }
 
-// ================== CommitteeSettingsInvite secondary index ==================
-
-// GetSettingsUIDByInviteUID looks up the committee UID for a given invite UID via the
-// secondary index written at invite-send time.
-func (s *storage) GetSettingsUIDByInviteUID(ctx context.Context, inviteUID string) (string, error) {
-	key := fmt.Sprintf(constants.KVLookupSettingsInvitePrefix, inviteUID)
-	entry, err := s.client.kvStore[constants.KVBucketNameCommitteeSettings].Get(ctx, key)
-	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) {
-			return "", errs.NewNotFound("no settings record found for invite UID")
-		}
-		return "", errs.NewUnexpected("failed to look up settings by invite UID", err)
-	}
-	return string(entry.Value()), nil
-}
-
-// IndexSettingsInvite writes the secondary index entry mapping invite_uid → committee_uid.
-// It uses Create (write-if-absent) so an accidental invite UID collision from the invite
-// service surfaces as an explicit error rather than silently overwriting a valid mapping.
-func (s *storage) IndexSettingsInvite(ctx context.Context, inviteUID, committeeUID string) error {
-	key := fmt.Sprintf(constants.KVLookupSettingsInvitePrefix, inviteUID)
-	if _, err := s.client.kvStore[constants.KVBucketNameCommitteeSettings].Create(ctx, key, []byte(committeeUID)); err != nil {
-		if errors.Is(err, jetstream.ErrKeyExists) {
-			// Mapping already present — idempotent; treat as success.
-			return nil
-		}
-		return errs.NewUnexpected("failed to index settings invite", err)
-	}
-	return nil
-}
-
-// DeleteSettingsInviteIndex removes the secondary index entry for the given invite UID.
-func (s *storage) DeleteSettingsInviteIndex(ctx context.Context, inviteUID string) error {
-	key := fmt.Sprintf(constants.KVLookupSettingsInvitePrefix, inviteUID)
-	if err := s.client.kvStore[constants.KVBucketNameCommitteeSettings].Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return errs.NewUnexpected("failed to delete settings invite index", err)
-	}
-	return nil
-}
-
 // ================== CommitteeApplicationReader implementation ==================
 
 // GetApplication retrieves a committee application by application UID

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -74,16 +74,6 @@ func (w *TestMockCommitteeMemberWriter) UpdateSetting(ctx context.Context, setti
 	return mockWriter.UpdateSetting(ctx, settings, revision)
 }
 
-func (w *TestMockCommitteeMemberWriter) IndexSettingsInvite(ctx context.Context, inviteUID, committeeUID string) error {
-	mockWriter := mock.NewMockCommitteeWriter(w.MockRepository)
-	return mockWriter.IndexSettingsInvite(ctx, inviteUID, committeeUID)
-}
-
-func (w *TestMockCommitteeMemberWriter) DeleteSettingsInviteIndex(ctx context.Context, inviteUID string) error {
-	mockWriter := mock.NewMockCommitteeWriter(w.MockRepository)
-	return mockWriter.DeleteSettingsInviteIndex(ctx, inviteUID)
-}
-
 // Implement CommitteeMemberWriter interface
 func (w *TestMockCommitteeMemberWriter) CreateMember(ctx context.Context, member *model.CommitteeMember) error {
 	if member == nil {
@@ -278,10 +268,6 @@ func (r *TestMockCommitteeReader) ListMembersByCommittee(ctx context.Context, co
 
 func (r *TestMockCommitteeReader) ListAllMembers(_ context.Context) ([]*model.CommitteeMember, error) {
 	return []*model.CommitteeMember{}, nil
-}
-
-func (r *TestMockCommitteeReader) GetSettingsUIDByInviteUID(ctx context.Context, inviteUID string) (string, error) {
-	return "", errs.NewNotFound("not implemented for this test")
 }
 
 // Implement CommitteeInviteReader interface

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -28,6 +28,8 @@ type CommitteeDataReader interface {
 	GetSettings(ctx context.Context, uid string) (*model.CommitteeSettings, uint64, error)
 	// GetBaseAttributeValue retrieves an attribute value by UID and returns the revision
 	GetBaseAttributeValue(ctx context.Context, uid string, attributeName string) (any, error)
+	// ListAllUIDs returns all active committee UIDs
+	ListAllUIDs(ctx context.Context) ([]string, error)
 }
 
 // CommitteeMemberDataReader defines the interface for committee member read operations
@@ -103,6 +105,11 @@ func (rc *committeeReaderOrchestrator) GetSettings(ctx context.Context, uid stri
 	)
 
 	return committeeSettings, revision, nil
+}
+
+// ListAllUIDs returns all active committee UIDs
+func (rc *committeeReaderOrchestrator) ListAllUIDs(ctx context.Context) ([]string, error) {
+	return rc.committeeReader.ListAllUIDs(ctx)
 }
 
 // GetAttributeValue retrieves an attribute value by UID and returns the revision

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -28,8 +28,6 @@ type CommitteeDataReader interface {
 	GetSettings(ctx context.Context, uid string) (*model.CommitteeSettings, uint64, error)
 	// GetBaseAttributeValue retrieves an attribute value by UID and returns the revision
 	GetBaseAttributeValue(ctx context.Context, uid string, attributeName string) (any, error)
-	// GetSettingsUIDByInviteUID looks up the committee UID for a given invite UID via the secondary index.
-	GetSettingsUIDByInviteUID(ctx context.Context, inviteUID string) (string, error)
 }
 
 // CommitteeMemberDataReader defines the interface for committee member read operations
@@ -199,11 +197,6 @@ func (rc *committeeReaderOrchestrator) ListMembersByCommittee(ctx context.Contex
 	)
 
 	return members, nil
-}
-
-// GetSettingsUIDByInviteUID looks up the committee UID for a given invite UID via the secondary index.
-func (rc *committeeReaderOrchestrator) GetSettingsUIDByInviteUID(ctx context.Context, inviteUID string) (string, error) {
-	return rc.committeeReader.GetSettingsUIDByInviteUID(ctx, inviteUID)
 }
 
 // NewCommitteeReaderOrchestrator creates a new committee reader use case using the option pattern

--- a/internal/service/committee_writer.go
+++ b/internal/service/committee_writer.go
@@ -714,7 +714,7 @@ func (uc *committeeWriterOrchestrator) Update(ctx context.Context, committee *mo
 	messageIndexer.IndexingConfig = buildCommitteeIndexingConfig(committee)
 
 	settings, _, errGetSettings := uc.committeeReader.GetSettings(ctx, committee.CommitteeBase.UID)
-	if errGetSettings != nil && !errors.Is(errGetSettings, errs.NotFound{}) {
+	if errGetSettings != nil && !errors.As(errGetSettings, &errs.NotFound{}) {
 		slog.ErrorContext(ctx, "failed to retrieve committee settings",
 			"error", errGetSettings,
 			"committee_uid", committee.CommitteeBase.UID,

--- a/internal/service/committee_writer_test.go
+++ b/internal/service/committee_writer_test.go
@@ -158,16 +158,6 @@ func (w *TestMockCommitteeWriter) IndexMemberByCommittee(ctx context.Context, me
 	return mockWriter.IndexMemberByCommittee(ctx, member)
 }
 
-func (w *TestMockCommitteeWriter) IndexSettingsInvite(ctx context.Context, inviteUID, committeeUID string) error {
-	mockWriter := mock.NewMockCommitteeWriter(w.mock)
-	return mockWriter.IndexSettingsInvite(ctx, inviteUID, committeeUID)
-}
-
-func (w *TestMockCommitteeWriter) DeleteSettingsInviteIndex(ctx context.Context, inviteUID string) error {
-	mockWriter := mock.NewMockCommitteeWriter(w.mock)
-	return mockWriter.DeleteSettingsInviteIndex(ctx, inviteUID)
-}
-
 // Implement CommitteeInviteWriter interface
 func (w *TestMockCommitteeWriter) CreateInvite(ctx context.Context, invite *model.CommitteeInvite) error {
 	mockWriter := mock.NewMockCommitteeWriter(w.mock)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -879,9 +879,12 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 }
 
 // HandleInviteAccepted processes an invite acceptance event published by the invite service.
-// It locates the committee settings that own the invite via the resource UID in the enriched
-// payload, promotes the user from non-LFID (email-only) to LFID (username set, invite cleared),
-// and fires FGA + indexer messages via UpdateSettings.
+// It scans all committee settings for email-only user entries matching the recipient email and
+// promotes them to full LFID users (username set, invite cleared). This reconciles every
+// committee the accepted user was invited to, regardless of which resource triggered the event.
+//
+// TODO: replace the full-scan with an email → [committee_uid] index lookup so we avoid reading
+// every committee's settings on each acceptance event.
 func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
 	var event inviteapi.InviteServiceAcceptedEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
@@ -889,25 +892,15 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 		return nil, nil
 	}
 
-	if event.UID == "" || event.AcceptedBy == "" {
-		slog.WarnContext(ctx, "invite_accepted event missing uid or accepted_by — discarding",
-			"invite_uid", event.UID, "accepted_by", redaction.Redact(event.AcceptedBy))
+	if event.UID == "" || event.AcceptedBy == "" || event.Recipient.Email == "" {
+		slog.WarnContext(ctx, "invite_accepted event missing required fields — discarding",
+			"invite_uid", event.UID, "accepted_by", redaction.Redact(event.AcceptedBy), "recipient_email", event.Recipient.Email)
 		return nil, nil
 	}
 
-	// The invite service publishes this event for all resource types; only process group invites.
-	if event.Resource.Type != "group" {
-		slog.DebugContext(ctx, "invite not for a group resource — ignoring",
-			"resource_type", event.Resource.Type, "invite_uid", event.UID)
-		return nil, nil
-	}
-
-	committeeUID := event.Resource.UID
-
-	// Persist the updated settings.
 	if m.committeeWriterOrchestrator == nil {
 		slog.WarnContext(ctx, "committee writer orchestrator not available — cannot persist invite promotion",
-			"committee_uid", committeeUID)
+			"invite_uid", event.UID)
 		return nil, nil
 	}
 
@@ -917,59 +910,70 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 	// service-to-service paths in internal/middleware/auth.go.
 	writeCtx := context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
 
-	// Retry up to 3 times to handle optimistic-lock conflicts: another writer may have
-	// bumped the settings revision between our read and write. We re-read the full
-	// settings on each attempt so the promotion is applied to the latest revision.
+	normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
+
+	// Scan all committee UIDs for settings that contain the recipient email.
+	allUIDs, listErr := m.committeeReader.ListAllUIDs(ctx)
+	if listErr != nil {
+		slog.WarnContext(ctx, "failed to list committee UIDs for invite reconciliation",
+			"error", listErr, "invite_uid", event.UID)
+		return nil, nil
+	}
+
+	for _, committeeUID := range allUIDs {
+		m.promoteInvitedUserInCommitteeSettings(ctx, writeCtx, committeeUID, normalizedEmail, event.AcceptedBy, event.UID)
+	}
+
+	return nil, nil
+}
+
+// promoteInvitedUserInCommitteeSettings promotes all email-only entries matching normalizedEmail
+// in the given committee's settings to full LFID users. It retries on revision conflicts.
+func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID string) {
 	const maxRetries = 3
-	var promoted bool
 	for attempt := range maxRetries {
-		settings, revision, settingsErr := m.committeeReader.GetSettings(ctx, committeeUID)
-		if settingsErr != nil {
-			slog.ErrorContext(ctx, "failed to get settings for invite acceptance",
-				"error", settingsErr, "committee_uid", committeeUID, "invite_uid", event.UID)
-			return nil, nil
+		settings, revision, err := m.committeeReader.GetSettings(ctx, committeeUID)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to get settings for invite promotion",
+				"error", err, "committee_uid", committeeUID, "invite_uid", inviteUID)
+			return
 		}
 
-		promoted = false
-		normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
+		promoted := false
 		for i := range settings.Writers {
 			if settings.Writers[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Writers[i].Email)) == normalizedEmail {
-				settings.Writers[i].Username = event.AcceptedBy
-				settings.Writers[i].Invite = nil // clear any residual invite metadata
+				settings.Writers[i].Username = username
+				settings.Writers[i].Invite = nil
 				promoted = true
 			}
 		}
 		for i := range settings.Auditors {
 			if settings.Auditors[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Auditors[i].Email)) == normalizedEmail {
-				settings.Auditors[i].Username = event.AcceptedBy
-				settings.Auditors[i].Invite = nil // clear any residual invite metadata
+				settings.Auditors[i].Username = username
+				settings.Auditors[i].Invite = nil
 				promoted = true
 			}
 		}
 
 		if !promoted {
-			slog.WarnContext(ctx, "no email-only entry found for recipient — may have already been promoted",
-				"committee_uid", committeeUID, "invite_uid", event.UID)
-			return nil, nil
+			return
 		}
 
 		if _, writeErr := m.committeeWriterOrchestrator.UpdateSettings(writeCtx, settings, revision, false); writeErr != nil {
 			if attempt < maxRetries-1 {
 				slog.DebugContext(ctx, "revision conflict promoting invite — retrying",
-					"attempt", attempt+1, "committee_uid", committeeUID, "invite_uid", event.UID)
+					"attempt", attempt+1, "committee_uid", committeeUID, "invite_uid", inviteUID)
 				continue
 			}
 			slog.ErrorContext(ctx, "failed to update settings after invite acceptance",
-				"error", writeErr, "committee_uid", committeeUID, "invite_uid", event.UID)
-			return nil, nil
+				"error", writeErr, "committee_uid", committeeUID, "invite_uid", inviteUID)
+			return
 		}
-		break
+
+		slog.DebugContext(ctx, "invite accepted — promoted user from non-LFID to LFID in settings",
+			"committee_uid", committeeUID, "invite_uid", inviteUID, "username", redaction.Redact(username))
+		return
 	}
-
-	slog.DebugContext(ctx, "invite accepted — promoted user from non-LFID to LFID in settings",
-		"committee_uid", committeeUID, "invite_uid", event.UID, "username", redaction.Redact(event.AcceptedBy))
-
-	return nil, nil
 }
 
 // mapRoleToInviteRole converts a committee settings role string to the invite

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -715,11 +714,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(5)
 
-	// Track invite results to apply back to settings after all goroutines complete.
-	// Key: email (normalized), Value: InviteInfo
-	inviteResultsMutex := &sync.Mutex{}
-	inviteResults := make(map[string]*model.InviteInfo)
-
 	for _, c := range changes {
 		g.Go(func() error {
 			u, kind, oldRoles, newRoles := c.user, c.kind, c.oldRoles, c.newRoles
@@ -807,23 +801,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 				slog.DebugContext(gctx, "sent settings invite request",
 					"committee_uid", data.CommitteeUID, "invite_uid", result.InviteUID)
 
-				// Track invite metadata if we got a result with an invite UID
-				if result.InviteUID != "" {
-					inviteInfo := &model.InviteInfo{
-						UID:   result.InviteUID,
-						Email: result.RecipientEmail,
-					}
-					if !result.ExpiresAt.IsZero() {
-						expiresAt := result.ExpiresAt
-						inviteInfo.ExpiresAt = &expiresAt
-					}
-					inviteResultsMutex.Lock()
-					inviteResults[strings.ToLower(strings.TrimSpace(u.Email))] = inviteInfo
-					inviteResultsMutex.Unlock()
-					slog.DebugContext(gctx, "tracked invite data for settings update",
-						"committee_uid", data.CommitteeUID, "invite_uid", result.InviteUID)
-				}
-
 				return nil
 			}
 
@@ -898,66 +875,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 	}
 	_ = g.Wait()
 
-	// Apply invite data to settings if we have any results
-	if len(inviteResults) > 0 {
-		// Write back the updated settings using the service-level orchestrator.
-		// NATS event handlers have no inbound HTTP request and therefore no JWT in ctx.
-		// Inject a service-identity bearer so UpdateSettings' downstream calls (FGA, indexer)
-		// carry a recognized auth token. The auth middleware allow-lists this value for
-		// service-to-service paths in internal/middleware/auth.go.
-		if m.committeeWriterOrchestrator == nil {
-			slog.WarnContext(ctx, "committee writer orchestrator not available — cannot write back invite data",
-				"committee_uid", data.CommitteeUID)
-		} else {
-			writeCtx := context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
-
-			// Retry up to 3 times on optimistic-lock conflicts. Invites have already been
-			// published (external side effect), so we must persist the invite metadata and
-			// write the secondary index or HandleInviteAccepted will silently drop the
-			// acceptance event. Re-read settings on each attempt to get the latest revision.
-			const maxWriteRetries = 3
-			writeSucceeded := false
-			for attempt := range maxWriteRetries {
-				freshSettings, freshRevision, readErr := m.committeeReader.GetSettings(ctx, data.CommitteeUID)
-				if readErr != nil {
-					slog.WarnContext(ctx, "failed to re-read settings for invite write-back",
-						"error", readErr, "committee_uid", data.CommitteeUID)
-					break
-				}
-				// Re-apply all invite results to the freshly-read settings.
-				for i := range freshSettings.Writers {
-					key := strings.ToLower(strings.TrimSpace(freshSettings.Writers[i].Email))
-					if inviteInfo, exists := inviteResults[key]; exists {
-						freshSettings.Writers[i].Invite = inviteInfo
-					}
-				}
-				for i := range freshSettings.Auditors {
-					key := strings.ToLower(strings.TrimSpace(freshSettings.Auditors[i].Email))
-					if inviteInfo, exists := inviteResults[key]; exists {
-						freshSettings.Auditors[i].Invite = inviteInfo
-					}
-				}
-				if _, writeErr := m.committeeWriterOrchestrator.UpdateSettings(writeCtx, freshSettings, freshRevision, false); writeErr != nil {
-					if attempt < maxWriteRetries-1 {
-						slog.DebugContext(ctx, "revision conflict writing invite data — retrying",
-							"attempt", attempt+1, "committee_uid", data.CommitteeUID)
-						continue
-					}
-					slog.WarnContext(ctx, "failed to update settings with invite data after retries",
-						"error", writeErr, "committee_uid", data.CommitteeUID)
-					break
-				}
-				writeSucceeded = true
-				break
-			}
-
-			if writeSucceeded {
-				slog.DebugContext(ctx, "updated settings with invite data",
-					"committee_uid", data.CommitteeUID)
-			}
-		}
-	}
-
 	return nil, nil
 }
 
@@ -1014,24 +931,25 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 		}
 
 		promoted = false
+		normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
 		for i := range settings.Writers {
-			if settings.Writers[i].Invite != nil && settings.Writers[i].Invite.UID == event.UID {
+			if settings.Writers[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Writers[i].Email)) == normalizedEmail {
 				settings.Writers[i].Username = event.AcceptedBy
-				settings.Writers[i].Invite = nil
+				settings.Writers[i].Invite = nil // clear any residual invite metadata
 				promoted = true
 			}
 		}
 		for i := range settings.Auditors {
-			if settings.Auditors[i].Invite != nil && settings.Auditors[i].Invite.UID == event.UID {
+			if settings.Auditors[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Auditors[i].Email)) == normalizedEmail {
 				settings.Auditors[i].Username = event.AcceptedBy
-				settings.Auditors[i].Invite = nil
+				settings.Auditors[i].Invite = nil // clear any residual invite metadata
 				promoted = true
 			}
 		}
 
 		if !promoted {
-			slog.WarnContext(ctx, "invite UID not found in writers or auditors — may have already been promoted",
-				"invite_uid", event.UID, "committee_uid", committeeUID)
+			slog.WarnContext(ctx, "no email-only entry found for recipient — may have already been promoted",
+				"committee_uid", committeeUID, "invite_uid", event.UID)
 			return nil, nil
 		}
 
@@ -1118,18 +1036,12 @@ func wasInvitedInOldSettings(email string, old *model.CommitteeSettings) bool {
 	}
 	normalized := strings.ToLower(strings.TrimSpace(email))
 	for _, u := range old.GetWriters() {
-		if u.Username == "" &&
-			u.Invite != nil &&
-			u.Invite.UID != "" &&
-			strings.ToLower(strings.TrimSpace(u.Email)) == normalized {
+		if u.Username == "" && strings.ToLower(strings.TrimSpace(u.Email)) == normalized {
 			return true
 		}
 	}
 	for _, u := range old.GetAuditors() {
-		if u.Username == "" &&
-			u.Invite != nil &&
-			u.Invite.UID != "" &&
-			strings.ToLower(strings.TrimSpace(u.Email)) == normalized {
+		if u.Username == "" && strings.ToLower(strings.TrimSpace(u.Email)) == normalized {
 			return true
 		}
 	}

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -892,9 +892,10 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 		return nil, nil
 	}
 
-	if event.UID == "" || event.AcceptedBy == "" || event.Recipient.Email == "" {
+	if event.UID == "" || event.AcceptedBy == "" || strings.TrimSpace(event.Recipient.Email) == "" {
 		slog.WarnContext(ctx, "invite_accepted event missing required fields — discarding",
-			"invite_uid", event.UID, "accepted_by", redaction.Redact(event.AcceptedBy), "recipient_email", event.Recipient.Email)
+			"invite_uid", event.UID, "accepted_by", redaction.Redact(event.AcceptedBy),
+			"recipient_email", redaction.RedactEmail(event.Recipient.Email))
 		return nil, nil
 	}
 
@@ -921,7 +922,7 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 	}
 
 	for _, committeeUID := range allUIDs {
-		m.promoteInvitedUserInCommitteeSettings(ctx, writeCtx, committeeUID, normalizedEmail, event.AcceptedBy, event.UID)
+		m.promoteInvitedUserInCommitteeSettings(ctx, writeCtx, committeeUID, normalizedEmail, event.AcceptedBy, event.UID, event.Role)
 	}
 
 	return nil, nil
@@ -929,7 +930,7 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 
 // promoteInvitedUserInCommitteeSettings promotes all email-only entries matching normalizedEmail
 // in the given committee's settings to full LFID users. It retries on revision conflicts.
-func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID string) {
+func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID, role string) {
 	const maxRetries = 3
 	for attempt := range maxRetries {
 		settings, revision, err := m.committeeReader.GetSettings(ctx, committeeUID)
@@ -940,18 +941,27 @@ func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, 
 		}
 
 		promoted := false
-		for i := range settings.Writers {
-			if settings.Writers[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Writers[i].Email)) == normalizedEmail {
-				settings.Writers[i].Username = username
-				settings.Writers[i].Invite = nil
-				promoted = true
+		// Only promote the slices that correspond to the accepted invite role.
+		// "Manage" → Writers; "View" → Auditors; unknown → both (backward-compatible).
+		promoteWriters := role == string(inviteapi.InviteRoleManage) || role == ""
+		promoteAuditors := role == string(inviteapi.InviteRoleView) || role == ""
+
+		if promoteWriters {
+			for i := range settings.Writers {
+				if settings.Writers[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Writers[i].Email)) == normalizedEmail {
+					settings.Writers[i].Username = username
+					settings.Writers[i].Invite = nil
+					promoted = true
+				}
 			}
 		}
-		for i := range settings.Auditors {
-			if settings.Auditors[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Auditors[i].Email)) == normalizedEmail {
-				settings.Auditors[i].Username = username
-				settings.Auditors[i].Invite = nil
-				promoted = true
+		if promoteAuditors {
+			for i := range settings.Auditors {
+				if settings.Auditors[i].Username == "" && strings.ToLower(strings.TrimSpace(settings.Auditors[i].Email)) == normalizedEmail {
+					settings.Auditors[i].Username = username
+					settings.Auditors[i].Invite = nil
+					promoted = true
+				}
 			}
 		}
 
@@ -960,7 +970,8 @@ func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, 
 		}
 
 		if _, writeErr := m.committeeWriterOrchestrator.UpdateSettings(writeCtx, settings, revision, false); writeErr != nil {
-			if attempt < maxRetries-1 {
+			var conflictErr errors.Conflict
+			if stderrors.As(writeErr, &conflictErr) && attempt < maxRetries-1 {
 				slog.DebugContext(ctx, "revision conflict promoting invite — retrying",
 					"attempt", attempt+1, "committee_uid", committeeUID, "invite_uid", inviteUID)
 				continue

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -648,14 +648,20 @@ func (m *messageHandlerOrchestrator) sendMemberInvite(ctx context.Context, membe
 	sendCtx, cancel := context.WithTimeout(ctx, committeeNotificationTimeout)
 	defer cancel()
 	result, err := m.inviteSender.SendInvite(sendCtx, inviteapi.SendInviteRequest{
-		RecipientEmail: strings.TrimSpace(member.Email),
-		RecipientName:  recipientName,
-		InviterName:    "A committee administrator",
-		ResourceUID:    member.CommitteeUID,
-		ResourceName:   member.CommitteeName,
-		ResourceType:   "group",
-		Role:           "Member",
-		ReturnURL:      deepLinkURL,
+		Recipient: &inviteapi.Recipient{
+			Email: strings.TrimSpace(member.Email),
+			Name:  recipientName,
+		},
+		Inviter: &inviteapi.Inviter{
+			Name: "A committee administrator",
+		},
+		Resource: &inviteapi.Resource{
+			UID:  member.CommitteeUID,
+			Name: member.CommitteeName,
+			Type: "group",
+		},
+		Role:      "Member",
+		ReturnURL: deepLinkURL,
 	})
 	if err != nil {
 		slog.WarnContext(ctx, "failed to send member invite request",
@@ -776,14 +782,20 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 				inviteRole := mapRoleToInviteRole(highestRole(newRoles))
 				inviteCtx, inviteCancel := context.WithTimeout(gctx, committeeNotificationTimeout)
 				result, inviteErr := m.inviteSender.SendInvite(inviteCtx, inviteapi.SendInviteRequest{
-					RecipientEmail: strings.TrimSpace(u.Email),
-					RecipientName:  recipientName,
-					InviterName:    inviterName,
-					ResourceUID:    data.CommitteeUID,
-					ResourceName:   data.CommitteeName,
-					ResourceType:   "group",
-					Role:           inviteRole,
-					ReturnURL:      committeeURL,
+					Recipient: &inviteapi.Recipient{
+						Email: strings.TrimSpace(u.Email),
+						Name:  recipientName,
+					},
+					Inviter: &inviteapi.Inviter{
+						Name: inviterName,
+					},
+					Resource: &inviteapi.Resource{
+						UID:  data.CommitteeUID,
+						Name: data.CommitteeName,
+						Type: "group",
+					},
+					Role:      inviteRole,
+					ReturnURL: committeeURL,
 				})
 				inviteCancel()
 				if inviteErr != nil {

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -942,9 +942,17 @@ func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, 
 
 		promoted := false
 		// Only promote the slices that correspond to the accepted invite role.
-		// "Manage" → Writers; "View" → Auditors; unknown → both (backward-compatible).
-		promoteWriters := role == string(inviteapi.InviteRoleManage) || role == ""
-		promoteAuditors := role == string(inviteapi.InviteRoleView) || role == ""
+		// "Manage" → Writers; "View" → Auditors; anything else (empty or unknown) → both.
+		var promoteWriters, promoteAuditors bool
+		switch role {
+		case string(inviteapi.InviteRoleManage):
+			promoteWriters = true
+		case string(inviteapi.InviteRoleView):
+			promoteAuditors = true
+		default:
+			promoteWriters = true
+			promoteAuditors = true
+		}
 
 		if promoteWriters {
 			for i := range settings.Writers {

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -955,6 +955,8 @@ func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, 
 		case string(inviteapi.InviteRoleView):
 			promoteAuditors = true
 		default:
+			slog.WarnContext(ctx, "unrecognized invite role — promoting both Writers and Auditors as a safe fallback",
+				"role", role, "invite_uid", inviteUID, "committee_uid", committeeUID)
 			promoteWriters = true
 			promoteAuditors = true
 		}

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -907,8 +907,9 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 
 	// NATS event handlers have no inbound HTTP request and therefore no JWT in ctx.
 	// Inject a service-identity bearer so UpdateSettings' downstream calls (FGA, indexer)
-	// carry a recognized auth token. The auth middleware allow-lists this value for
-	// service-to-service paths in internal/middleware/auth.go.
+	// carry a recognized auth token. The header is propagated into context by
+	// internal/middleware/authorization.go (no allow-listing — it copies whatever header
+	// is present; trust is enforced by the downstream FGA/indexer services).
 	writeCtx := context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
 
 	normalizedEmail := strings.ToLower(strings.TrimSpace(event.Recipient.Email))
@@ -943,6 +944,10 @@ func (m *messageHandlerOrchestrator) promoteInvitedUserInCommitteeSettings(ctx, 
 		promoted := false
 		// Only promote the slices that correspond to the accepted invite role.
 		// "Manage" → Writers; "View" → Auditors; anything else (empty or unknown) → both.
+		// NOTE: the default branch intentionally promotes both slices. If the invite service
+		// introduces a new role before this switch is updated, the user gets promoted to both
+		// Writers and Auditors — an over-grant. This is acceptable given the tight internal
+		// coupling, but warrants updating this switch when new roles are added.
 		var promoteWriters, promoteAuditors bool
 		switch role {
 		case string(inviteapi.InviteRoleManage):

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -954,15 +954,6 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 			if writeSucceeded {
 				slog.DebugContext(ctx, "updated settings with invite data",
 					"committee_uid", data.CommitteeUID)
-
-				// Write the secondary invite-UID → committee-UID index for each new invite so
-				// that HandleInviteAccepted can route acceptance events without scanning all settings.
-				for _, inviteInfo := range inviteResults {
-					if indexErr := m.committeeWriter.IndexSettingsInvite(ctx, inviteInfo.UID, data.CommitteeUID); indexErr != nil {
-						slog.WarnContext(ctx, "failed to write settings invite index",
-							"error", indexErr, "invite_uid", inviteInfo.UID, "committee_uid", data.CommitteeUID)
-					}
-				}
 			}
 		}
 	}
@@ -970,42 +961,31 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 	return nil, nil
 }
 
-// inviteAcceptedEvent is the payload published by the LFX self-serve web app on InviteAcceptedSubject.
-type inviteAcceptedEvent struct {
-	InviteUID string `json:"invite_uid"`
-	Username  string `json:"username"`
-}
-
-// HandleInviteAccepted processes an invite acceptance event from the LFX self-serve web app.
-// It locates the settings record that owns the invite, promotes the user from non-LFID
-// (email-only) to LFID (username set, invite cleared), and fires FGA + indexer messages.
+// HandleInviteAccepted processes an invite acceptance event published by the invite service.
+// It locates the committee settings that own the invite via the resource UID in the enriched
+// payload, promotes the user from non-LFID (email-only) to LFID (username set, invite cleared),
+// and fires FGA + indexer messages via UpdateSettings.
 func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, msg port.TransportMessenger) ([]byte, error) {
-	var event inviteAcceptedEvent
+	var event inviteapi.InviteServiceAcceptedEvent
 	if err := json.Unmarshal(msg.Data(), &event); err != nil {
 		slog.WarnContext(ctx, "failed to unmarshal invite_accepted event", "error", err)
 		return nil, nil
 	}
 
-	if event.InviteUID == "" || event.Username == "" {
-		slog.WarnContext(ctx, "invite_accepted event missing invite_uid or username — discarding",
-			"invite_uid", event.InviteUID, "username", redaction.Redact(event.Username))
+	if event.UID == "" || event.AcceptedBy == "" {
+		slog.WarnContext(ctx, "invite_accepted event missing uid or accepted_by — discarding",
+			"invite_uid", event.UID, "accepted_by", redaction.Redact(event.AcceptedBy))
 		return nil, nil
 	}
 
-	// Look up the committee UID from the secondary index.
-	committeeUID, err := m.committeeReader.GetSettingsUIDByInviteUID(ctx, event.InviteUID)
-	if err != nil {
-		var notFound errors.NotFound
-		if stderrors.As(err, &notFound) {
-			// No mapping means this invite belongs to another service — silently ignore.
-			slog.DebugContext(ctx, "invite not tracked by this service — ignoring",
-				"invite_uid", event.InviteUID)
-			return nil, nil
-		}
-		slog.WarnContext(ctx, "KV error looking up invite mapping",
-			"error", err, "invite_uid", event.InviteUID)
+	// The invite service publishes this event for all resource types; only process group invites.
+	if event.Resource.Type != "group" {
+		slog.DebugContext(ctx, "invite not for a group resource — ignoring",
+			"resource_type", event.Resource.Type, "invite_uid", event.UID)
 		return nil, nil
 	}
+
+	committeeUID := event.Resource.UID
 
 	// Persist the updated settings.
 	if m.committeeWriterOrchestrator == nil {
@@ -1029,57 +1009,47 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 		settings, revision, settingsErr := m.committeeReader.GetSettings(ctx, committeeUID)
 		if settingsErr != nil {
 			slog.ErrorContext(ctx, "failed to get settings for invite acceptance",
-				"error", settingsErr, "committee_uid", committeeUID, "invite_uid", event.InviteUID)
+				"error", settingsErr, "committee_uid", committeeUID, "invite_uid", event.UID)
 			return nil, nil
 		}
 
 		promoted = false
 		for i := range settings.Writers {
-			if settings.Writers[i].Invite != nil && settings.Writers[i].Invite.UID == event.InviteUID {
-				settings.Writers[i].Username = event.Username
+			if settings.Writers[i].Invite != nil && settings.Writers[i].Invite.UID == event.UID {
+				settings.Writers[i].Username = event.AcceptedBy
 				settings.Writers[i].Invite = nil
 				promoted = true
 			}
 		}
 		for i := range settings.Auditors {
-			if settings.Auditors[i].Invite != nil && settings.Auditors[i].Invite.UID == event.InviteUID {
-				settings.Auditors[i].Username = event.Username
+			if settings.Auditors[i].Invite != nil && settings.Auditors[i].Invite.UID == event.UID {
+				settings.Auditors[i].Username = event.AcceptedBy
 				settings.Auditors[i].Invite = nil
 				promoted = true
 			}
 		}
 
 		if !promoted {
-			slog.WarnContext(ctx, "invite UID not found in writers or auditors — stale index, cleaning up",
-				"invite_uid", event.InviteUID, "committee_uid", committeeUID)
-			if delErr := m.committeeWriter.DeleteSettingsInviteIndex(ctx, event.InviteUID); delErr != nil {
-				slog.WarnContext(ctx, "failed to delete stale invite index",
-					"error", delErr, "invite_uid", event.InviteUID)
-			}
+			slog.WarnContext(ctx, "invite UID not found in writers or auditors — may have already been promoted",
+				"invite_uid", event.UID, "committee_uid", committeeUID)
 			return nil, nil
 		}
 
 		if _, writeErr := m.committeeWriterOrchestrator.UpdateSettings(writeCtx, settings, revision, false); writeErr != nil {
 			if attempt < maxRetries-1 {
 				slog.DebugContext(ctx, "revision conflict promoting invite — retrying",
-					"attempt", attempt+1, "committee_uid", committeeUID, "invite_uid", event.InviteUID)
+					"attempt", attempt+1, "committee_uid", committeeUID, "invite_uid", event.UID)
 				continue
 			}
 			slog.ErrorContext(ctx, "failed to update settings after invite acceptance",
-				"error", writeErr, "committee_uid", committeeUID, "invite_uid", event.InviteUID)
+				"error", writeErr, "committee_uid", committeeUID, "invite_uid", event.UID)
 			return nil, nil
 		}
 		break
 	}
 
-	// Remove the now-consumed index entry.
-	if delErr := m.committeeWriter.DeleteSettingsInviteIndex(ctx, event.InviteUID); delErr != nil {
-		slog.WarnContext(ctx, "failed to delete invite index after acceptance",
-			"error", delErr, "invite_uid", event.InviteUID)
-	}
-
 	slog.DebugContext(ctx, "invite accepted — promoted user from non-LFID to LFID in settings",
-		"committee_uid", committeeUID, "invite_uid", event.InviteUID, "username", redaction.Redact(event.Username))
+		"committee_uid", committeeUID, "invite_uid", event.UID, "username", redaction.Redact(event.AcceptedBy))
 
 	return nil, nil
 }

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -646,7 +646,7 @@ type mockStreamMessenger struct {
 func (m *mockStreamMessenger) Subject() string { return m.subject }
 func (m *mockStreamMessenger) Data() []byte    { return m.data }
 
-// spyCommitteeWriterOrchestrator records Update and UpdateMember calls and can be configured to fail.
+// spyCommitteeWriterOrchestrator records Update, UpdateMember, and UpdateSettings calls and can be configured to fail.
 type spyCommitteeWriterOrchestrator struct {
 	updateCalls      int
 	updateErr        error
@@ -655,6 +655,10 @@ type spyCommitteeWriterOrchestrator struct {
 	updateMemberCalls int
 	updateMemberErr   error
 	updatedMembers    []*model.CommitteeMember
+
+	updateSettingsCalls int
+	updateSettingsErr   error
+	capturedSettings    []*model.CommitteeSettings
 }
 
 func (s *spyCommitteeWriterOrchestrator) Create(_ context.Context, _ *model.Committee, _ bool) (*model.Committee, error) {
@@ -665,8 +669,11 @@ func (s *spyCommitteeWriterOrchestrator) Update(_ context.Context, c *model.Comm
 	s.updatedCommittee = c
 	return c, s.updateErr
 }
-func (s *spyCommitteeWriterOrchestrator) UpdateSettings(_ context.Context, _ *model.CommitteeSettings, _ uint64, _ bool) (*model.CommitteeSettings, error) {
-	return nil, nil
+func (s *spyCommitteeWriterOrchestrator) UpdateSettings(_ context.Context, settings *model.CommitteeSettings, _ uint64, _ bool) (*model.CommitteeSettings, error) {
+	s.updateSettingsCalls++
+	copy := *settings
+	s.capturedSettings = append(s.capturedSettings, &copy)
+	return settings, s.updateSettingsErr
 }
 func (s *spyCommitteeWriterOrchestrator) Delete(_ context.Context, _ string, _ uint64, _ bool) error {
 	return nil
@@ -1859,6 +1866,181 @@ func TestHandleCommitteeSettingsUpdatedRoleChanges(t *testing.T) {
 			assert.Equal(t, tt.wantInviteCount, inviteCount, "invite call count")
 			if tt.wantInviteRole != "" {
 				assert.Equal(t, tt.wantInviteRole, inviteRole, "invite role")
+			}
+		})
+	}
+}
+
+func TestHandleInviteAccepted(t *testing.T) {
+	ctx := context.Background()
+
+	const inviteUID = "inv-abc"
+	const username = "newuser"
+	const committee1UID = "committee-1"
+	const committee2UID = "committee-2"
+	const writerEmail = "writer@example.com"
+	const auditorEmail = "auditor@example.com"
+
+	makeEvent := func(invUID, acceptedBy, recipientEmail, role string) []byte {
+		event := inviteapi.InviteServiceAcceptedEvent{Invite: inviteapi.Invite{
+			UID:        invUID,
+			AcceptedBy: acceptedBy,
+			Role:       role,
+			Recipient:  inviteapi.Recipient{Email: recipientEmail},
+		}}
+		b, _ := json.Marshal(event)
+		return b
+	}
+
+	makeCommitteeWithSettings := func(uid string, settings *model.CommitteeSettings) *model.Committee {
+		return &model.Committee{
+			CommitteeBase:     model.CommitteeBase{UID: uid, ProjectUID: "proj-1", Name: "Test Committee"},
+			CommitteeSettings: settings,
+		}
+	}
+
+	makeHandler := func(repo *mock.MockRepository, spy *spyCommitteeWriterOrchestrator) *messageHandlerOrchestrator {
+		h := NewMessageHandlerOrchestrator(
+			WithCommitteeReaderForMessageHandler(
+				NewCommitteeReaderOrchestrator(WithCommitteeReader(repo)),
+			),
+			WithCommitteeWriterOrchestratorForMessageHandler(spy),
+		)
+		return h.(*messageHandlerOrchestrator)
+	}
+
+	tests := []struct {
+		name             string
+		setupRepo        func(*mock.MockRepository)
+		spyErr           error
+		msgData          []byte
+		wantUpdateCalls  int
+		validateSettings func(*testing.T, []*model.CommitteeSettings)
+	}{
+		{
+			name: "malformed payload — no update called",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
+			},
+			msgData:         []byte("not json"),
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "missing uid — discarded",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
+			},
+			msgData:         makeEvent("", username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "missing accepted_by — discarded",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
+			},
+			msgData:         makeEvent(inviteUID, "", writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "happy path — Manage role promotes Writer entries across matching committees",
+			setupRepo: func(r *mock.MockRepository) {
+				// Two committees both have an email-only Writer entry.
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
+				r.AddCommittee(makeCommitteeWithSettings(committee2UID,
+					&model.CommitteeSettings{UID: committee2UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 2,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				for _, s := range captured {
+					require.Len(t, s.Writers, 1)
+					assert.Equal(t, username, s.Writers[0].Username, "writer should be promoted")
+					assert.Nil(t, s.Writers[0].Invite, "invite should be cleared")
+				}
+			},
+		},
+		{
+			name: "View role — only Auditors promoted, Writers untouched",
+			setupRepo: func(r *mock.MockRepository) {
+				// Committee has both a pending Writer and pending Auditor entry with the same email.
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{
+					UID:      committee1UID,
+					Writers:  []model.CommitteeUser{{Email: auditorEmail}},
+					Auditors: []model.CommitteeUser{{Email: auditorEmail}},
+				}))
+			},
+			msgData:         makeEvent(inviteUID, username, auditorEmail, string(inviteapi.InviteRoleView)),
+			wantUpdateCalls: 1,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				require.Len(t, captured, 1)
+				s := captured[0]
+				assert.Equal(t, username, s.Auditors[0].Username, "auditor should be promoted")
+				assert.Equal(t, "", s.Writers[0].Username, "writer should remain email-only")
+			},
+		},
+		{
+			name: "no matching email in any committee — no update called",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: "other@example.com"}}}))
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "already-promoted entry (has Username) — not double-promoted",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail, Username: "already-set"}}}))
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "conflict on write — non-conflict error surfaces immediately, no retry",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
+			},
+			spyErr:          fmt.Errorf("NATS unavailable"),
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 1,
+		},
+		{
+			name: "conflict on write — retries once then finds entry already promoted on re-read",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
+			},
+			spyErr:  errs.NewConflict("revision mismatch"),
+			msgData: makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			// The mock returns the same pointer, so our in-memory promotion is visible on
+			// re-read; the retry finds no email-only entry and exits cleanly after 1 attempt.
+			wantUpdateCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := mock.NewMockRepository()
+			mockRepo.ClearAll()
+			tt.setupRepo(mockRepo)
+
+			spy := &spyCommitteeWriterOrchestrator{updateSettingsErr: tt.spyErr}
+			handler := makeHandler(mockRepo, spy)
+
+			msg := newMockTransportMessenger(inviteapi.InviteServiceAcceptedSubject, tt.msgData)
+			_, err := handler.HandleInviteAccepted(ctx, msg)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantUpdateCalls, spy.updateSettingsCalls, "UpdateSettings call count")
+
+			if tt.validateSettings != nil && len(spy.capturedSettings) > 0 {
+				tt.validateSettings(t, spy.capturedSettings)
 			}
 		})
 	}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -658,7 +658,10 @@ type spyCommitteeWriterOrchestrator struct {
 
 	updateSettingsCalls int
 	updateSettingsErr   error
-	capturedSettings    []*model.CommitteeSettings
+	// updateSettingsErrs is an optional per-call error queue. If non-empty, each call to
+	// UpdateSettings drains one entry from the front; once exhausted, updateSettingsErr is used.
+	updateSettingsErrs []error
+	capturedSettings   []*model.CommitteeSettings
 }
 
 func (s *spyCommitteeWriterOrchestrator) Create(_ context.Context, _ *model.Committee, _ bool) (*model.Committee, error) {
@@ -671,8 +674,17 @@ func (s *spyCommitteeWriterOrchestrator) Update(_ context.Context, c *model.Comm
 }
 func (s *spyCommitteeWriterOrchestrator) UpdateSettings(_ context.Context, settings *model.CommitteeSettings, _ uint64, _ bool) (*model.CommitteeSettings, error) {
 	s.updateSettingsCalls++
-	copy := *settings
-	s.capturedSettings = append(s.capturedSettings, &copy)
+	// Deep-copy the snapshot so later in-place mutations by the handler don't overwrite it.
+	snap := *settings
+	snap.Writers = append([]model.CommitteeUser(nil), settings.Writers...)
+	snap.Auditors = append([]model.CommitteeUser(nil), settings.Auditors...)
+	s.capturedSettings = append(s.capturedSettings, &snap)
+	// Drain per-call error queue; fall back to the fixed error when exhausted.
+	if len(s.updateSettingsErrs) > 0 {
+		err := s.updateSettingsErrs[0]
+		s.updateSettingsErrs = s.updateSettingsErrs[1:]
+		return settings, err
+	}
 	return settings, s.updateSettingsErr
 }
 func (s *spyCommitteeWriterOrchestrator) Delete(_ context.Context, _ string, _ uint64, _ bool) error {
@@ -1913,6 +1925,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 		name             string
 		setupRepo        func(*mock.MockRepository)
 		spyErr           error
+		spyErrs          []error // per-call error queue; takes precedence over spyErr when non-nil
 		msgData          []byte
 		wantUpdateCalls  int
 		validateSettings func(*testing.T, []*model.CommitteeSettings)
@@ -2029,16 +2042,17 @@ func TestHandleInviteAccepted(t *testing.T) {
 			wantUpdateCalls: 1,
 		},
 		{
-			name: "conflict on write — retries once then finds entry already promoted on re-read",
+			name: "conflict on write — retries and succeeds on second attempt",
 			setupRepo: func(r *mock.MockRepository) {
 				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
 					&model.CommitteeSettings{UID: committee1UID, Writers: []model.CommitteeUser{{Email: writerEmail}}}))
 			},
-			spyErr:  errs.NewConflict("revision mismatch"),
-			msgData: makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
-			// The mock returns the same pointer, so our in-memory promotion is visible on
-			// re-read; the retry finds no email-only entry and exits cleanly after 1 attempt.
-			wantUpdateCalls: 1,
+			// First UpdateSettings call returns a conflict; second succeeds.
+			// GetSettings returns a deep copy each time, so the in-memory promotion
+			// from attempt 1 is not visible on re-read — a genuine second write happens.
+			spyErrs:         []error{errs.NewConflict("revision mismatch"), nil},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 2,
 		},
 	}
 
@@ -2048,7 +2062,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 			mockRepo.ClearAll()
 			tt.setupRepo(mockRepo)
 
-			spy := &spyCommitteeWriterOrchestrator{updateSettingsErr: tt.spyErr}
+			spy := &spyCommitteeWriterOrchestrator{updateSettingsErr: tt.spyErr, updateSettingsErrs: tt.spyErrs}
 			handler := makeHandler(mockRepo, spy)
 
 			msg := newMockTransportMessenger(inviteapi.InviteServiceAcceptedSubject, tt.msgData)

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -1286,12 +1286,15 @@ func TestHandleCommitteeMemberCreated(t *testing.T) {
 			if tt.inviteSender != nil {
 				assert.Len(t, tt.inviteSender.calls, tt.wantInviteCount, "invite call count")
 				if tt.wantInviteCount > 0 {
-					assert.Equal(t, "committee-1", tt.inviteSender.calls[0].ResourceUID)
-					assert.Equal(t, "TSC Committee", tt.inviteSender.calls[0].ResourceName)
-					assert.Equal(t, "group", tt.inviteSender.calls[0].ResourceType)
-					assert.Contains(t, tt.inviteSender.calls[0].ReturnURL, "committee-1")
+					req := tt.inviteSender.calls[0]
+					if assert.NotNil(t, req.Resource, "Resource must be set") {
+						assert.Equal(t, "committee-1", req.Resource.UID)
+						assert.Equal(t, "TSC Committee", req.Resource.Name)
+						assert.Equal(t, "group", req.Resource.Type)
+					}
+					assert.Contains(t, req.ReturnURL, "committee-1")
 					if tt.wantInviteRole != "" {
-						assert.Equal(t, tt.wantInviteRole, tt.inviteSender.calls[0].Role, "invite role")
+						assert.Equal(t, tt.wantInviteRole, req.Role, "invite role")
 					}
 				}
 			}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -1983,6 +1983,24 @@ func TestHandleInviteAccepted(t *testing.T) {
 			},
 		},
 		{
+			name: "unknown role (e.g. 'Member') — both Writers and Auditors promoted",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{
+					UID:      committee1UID,
+					Writers:  []model.CommitteeUser{{Email: writerEmail}},
+					Auditors: []model.CommitteeUser{{Email: writerEmail}},
+				}))
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, "Member"),
+			wantUpdateCalls: 1,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				require.Len(t, captured, 1)
+				s := captured[0]
+				assert.Equal(t, username, s.Writers[0].Username, "writer should be promoted for unknown role")
+				assert.Equal(t, username, s.Auditors[0].Username, "auditor should be promoted for unknown role")
+			},
+		},
+		{
 			name: "no matching email in any committee — no update called",
 			setupRepo: func(r *mock.MockRepository) {
 				r.AddCommittee(makeCommitteeWithSettings(committee1UID,


### PR DESCRIPTION
## Summary

**1. Migrate `SendInviteRequest` to structured fields**
- Switch invite construction from deprecated scalar fields (`RecipientEmail`, `InviterName`, `ResourceUID`, etc.) to the new structured objects (`Recipient`, `Inviter`, `Resource`) in both `sendMemberInvite` and `HandleCommitteeSettingsUpdated`
- Fix response parsing: `SendInviteResponse` embeds `*InviteData` (not a named `Invite` field), so nil-check `resp.InviteData` and read `resp.UID`/`resp.Email`/`resp.ExpiresAt` via embedding
- Bump `lfx-v2-invite-service` dependency to `v0.1.4-0.20260603200146-27b0e0162e1d`

**2. Subscribe to invite-service enriched `invite_accepted` subject**
- Subscribe to `lfx.invite-service.invite_accepted` (published by the invite service after processing) instead of the raw `lfx.invite.accepted` subject
- Use `inviteapi.InviteServiceAcceptedEvent` payload which includes the full `Recipient.Email`, `AcceptedBy`, and `Resource` fields populated by the invite service

**3. Stop storing invite data in committee settings user records**
- Remove `InviteUID`, `InviteEmail`, and `InviteExpiresAt` from `UserInfo` in committee settings
- `HandleInviteAccepted` no longer matches by invite UID — matching is now done by email against email-only user records (`Username == ""`)

**4. Email-based reconciliation across all committee settings**
- On invite acceptance, scan **all** committees via `ListAllUIDs` for email-only user entries (`Username == ""`) matching `event.Recipient.Email`
- Promote every matching entry across every committee, regardless of which resource type triggered the event (removes the former `Resource.Type == "group"` guard)
- Adds `ListAllUIDs` to the `CommitteeDataReader` service-layer interface and its passthrough implementation on `committeeReaderOrchestrator`
- Each committee uses a read-check-write retry loop with optimistic locking (3 attempts, retries on revision conflict)
- Adds empty-email guard to discard malformed events before scanning
- TODO: replace full scan with an email → `[committee_uid]` index for scale

## Ticket

[LFXV2-2079](https://jira.linuxfoundation.org/browse/LFXV2-2079)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2079]: https://linuxfoundation.atlassian.net/browse/LFXV2-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ