### PR TITLE
[LFXV2-2134] fix(ci): disable weekly-brief eval gate while LFXV2-2134 is fixed

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   eval-live:
-    # Release gate: blocks publish on a failing weekly-brief live LLM eval.
+    # Release gate: runs the weekly-brief live LLM eval suite.
     # Calls .github/workflows/weekly-brief-eval-live.yml (workflow_call).
     # The called workflow fetches LITELLM_API_KEY from AWS Secrets Manager
     # via OIDC token exchange (LITELLM_BASE_URL and LITELLM_MODEL are
@@ -25,7 +25,13 @@ jobs:
     # GitHub repo secrets to map at the call site. id-token: write is
     # required here because a reusable workflow cannot elevate
     # permissions beyond what its caller grants. LFXV2-2019.
+    #
+    # TEMPORARY: continue-on-error is set to true while LFXV2-2134 (structured
+    # JSON output + retry in the LiteLLM adapter) is being fixed. The eval still
+    # runs and its result is visible, but a failure will not block the release.
+    # Remove continue-on-error once LFXV2-2134 is resolved.
     name: Weekly-Brief Live Eval (release gate)
+    continue-on-error: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -26,12 +26,11 @@ jobs:
     # required here because a reusable workflow cannot elevate
     # permissions beyond what its caller grants. LFXV2-2019.
     #
-    # TEMPORARY: continue-on-error is set to true while LFXV2-2134 (structured
-    # JSON output + retry in the LiteLLM adapter) is being fixed. The eval still
-    # runs and its result is visible, but a failure will not block the release.
-    # Remove continue-on-error once LFXV2-2134 is resolved.
+    # TEMPORARY: disabled while LFXV2-2134 (structured JSON output + retry in
+    # the LiteLLM adapter) is being fixed. Re-enable by removing `if: false`
+    # once LFXV2-2134 is resolved.
     name: Weekly-Brief Live Eval (release gate)
-    continue-on-error: true
+    if: false
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Sets `if: false` on the `eval-live` job in `ko-build-tag.yaml` to disable it entirely
- Unblocks `publish`, `release-helm-chart`, and `create-ghcr-helm-provenance` on every tag push
- Avoids wasted AWS OIDC token exchanges and LiteLLM API calls on each release while the underlying bug is open
- Re-enable by removing `if: false` once LFXV2-2134 lands

## Ticket

[LFXV2-2134](https://linuxfoundation.atlassian.net/browse/LFXV2-2134)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2134]: https://linuxfoundation.atlassian.net/browse/LFXV2-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ