### PR TITLE
ci(eval): temporarily disable weekly-brief release gate (LFXV2-2134)

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -17,7 +17,12 @@ permissions:
 
 jobs:
   eval-live:
-    # Release gate: blocks publish on a failing weekly-brief live LLM eval.
+    # Release gate: normally blocks publish on a failing weekly-brief live
+    # LLM eval. TEMPORARILY DISABLED per LFXV2-2134 — publish no longer
+    # declares `needs: eval-live`, so this job runs for signal only and a
+    # failure leaves the run red without blocking the release. Re-enable by
+    # restoring `needs: eval-live` on publish once the adapter is
+    # deterministic (LFXV2-2134).
     # Calls .github/workflows/weekly-brief-eval-live.yml (workflow_call).
     # The called workflow fetches LITELLM_API_KEY from AWS Secrets Manager
     # via OIDC token exchange (LITELLM_BASE_URL and LITELLM_MODEL are
@@ -32,7 +37,9 @@ jobs:
     uses: ./.github/workflows/weekly-brief-eval-live.yml
 
   publish:
-    needs: eval-live
+    # TODO(LFXV2-2134): re-enable release gate once adapter is deterministic
+    # (restore `needs: eval-live` below). Temporarily removed so a flaky
+    # eval-live no longer blocks the release. LFXV2-2134.
     name: Publish Tagged Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What

Temporarily removes `needs: eval-live` from the `publish` job in `.github/workflows/ko-build-tag.yaml` so the weekly-brief live LLM eval no longer gates the release.

## Why

The `eval-live` gate flakily fails on non-JSON model output and is blocking the **v0.3.3** image + Helm chart release. This is an **interim, reversible** unblock, approved by Jordan Evans in Slack ("yes, if Manish can't fix ASAP then disable it").

## Details

- `eval-live` job is **kept defined and running** — we still get the signal. A failing eval now leaves the run red **without** blocking `publish` → `release-helm-chart` → `create-ghcr-helm-provenance`.
- Added `# TODO(LFXV2-2134)` next to the change and updated the release-gate comment block to note the gate is temporarily disabled.
- Minimal, easily-revertable diff — no changes to `weekly-brief-eval-live.yml`, the adapter, or the evals.

## Re-enabling

Restoring `needs: eval-live` on `publish` is part of the **LFXV2-2134** fix, once the adapter is deterministic.

Refs: LFXV2-2134