### PR TITLE
[LFXV2-2134] fix(ci): remove eval-live gate from publish while LFXV2-2134 is fixed

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -27,8 +27,8 @@ jobs:
     # permissions beyond what its caller grants. LFXV2-2019.
     #
     # TEMPORARY: disabled while LFXV2-2134 (structured JSON output + retry in
-    # the LiteLLM adapter) is being fixed. Re-enable by removing `if: false`
-    # once LFXV2-2134 is resolved.
+    # the LiteLLM adapter) is being fixed. To re-enable: remove `if: false`
+    # here AND restore `needs: eval-live` on the publish job below.
     name: Weekly-Brief Live Eval (release gate)
     if: false
     permissions:
@@ -37,7 +37,6 @@ jobs:
     uses: ./.github/workflows/weekly-brief-eval-live.yml
 
   publish:
-    needs: eval-live
     name: Publish Tagged Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Removes `needs: eval-live` from the `publish` job so it runs unconditionally while the eval gate is disabled
- Follows up #115 which set `if: false` on `eval-live` but left `needs: eval-live` on `publish` — GitHub skips a job when all its dependencies are skipped, which kept blocking the release
- `publish`, `release-helm-chart`, and `create-ghcr-helm-provenance` will now run on every tag push
- Also updates the re-enable instructions in the `eval-live` comment to explicitly mention restoring `needs: eval-live` on the `publish` job

## Ticket

[LFXV2-2134](https://linuxfoundation.atlassian.net/browse/LFXV2-2134)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2134]: https://linuxfoundation.atlassian.net/browse/LFXV2-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ