### PR TITLE
fix: default self-serve base URL to prod when LFX_ENVIRONMENT is unset

### DIFF
--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -459,17 +459,20 @@ func InviteSenderImpl(ctx context.Context) port.InviteSender {
 
 // LFXSelfServeBaseURL derives the LFX Self-Serve base URL from environment variables.
 // LFX_SELF_SERVE_BASE_URL takes precedence; otherwise it falls back to LFX_ENVIRONMENT.
+// When LFX_ENVIRONMENT is unset, prod is assumed (safe default for deployed environments).
 func LFXSelfServeBaseURL() string {
 	if url := os.Getenv("LFX_SELF_SERVE_BASE_URL"); url != "" {
 		return url
 	}
 	switch os.Getenv("LFX_ENVIRONMENT") {
-	case "prod":
+	case "prod", "production":
 		return "https://app.lfx.dev"
-	case "staging", "stg":
+	case "staging", "stg", "stage":
 		return "https://app.staging.lfx.dev"
-	default:
+	case "dev", "development":
 		return "https://app.dev.lfx.dev"
+	default:
+		return "https://app.lfx.dev"
 	}
 }
 

--- a/cmd/committee-api/service/providers_test.go
+++ b/cmd/committee-api/service/providers_test.go
@@ -42,6 +42,11 @@ func TestLFXSelfServeBaseURL(t *testing.T) {
 			want:        "https://app.staging.lfx.dev",
 		},
 		{
+			name:        "stage alias",
+			environment: "stage",
+			want:        "https://app.staging.lfx.dev",
+		},
+		{
 			name:        "dev environment",
 			environment: "dev",
 			want:        "https://app.dev.lfx.dev",
@@ -54,6 +59,11 @@ func TestLFXSelfServeBaseURL(t *testing.T) {
 		{
 			name: "unset environment defaults to prod",
 			want: "https://app.lfx.dev",
+		},
+		{
+			name:        "unrecognized environment defaults to prod",
+			environment: "qa",
+			want:        "https://app.lfx.dev",
 		},
 	}
 

--- a/cmd/committee-api/service/providers_test.go
+++ b/cmd/committee-api/service/providers_test.go
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLFXSelfServeBaseURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseURL     string
+		environment string
+		want        string
+	}{
+		{
+			name:    "explicit base URL takes precedence",
+			baseURL: "https://custom.example.com",
+			want:    "https://custom.example.com",
+		},
+		{
+			name:        "prod environment",
+			environment: "prod",
+			want:        "https://app.lfx.dev",
+		},
+		{
+			name:        "production alias",
+			environment: "production",
+			want:        "https://app.lfx.dev",
+		},
+		{
+			name:        "staging environment",
+			environment: "staging",
+			want:        "https://app.staging.lfx.dev",
+		},
+		{
+			name:        "stg alias",
+			environment: "stg",
+			want:        "https://app.staging.lfx.dev",
+		},
+		{
+			name:        "dev environment",
+			environment: "dev",
+			want:        "https://app.dev.lfx.dev",
+		},
+		{
+			name:        "development alias",
+			environment: "development",
+			want:        "https://app.dev.lfx.dev",
+		},
+		{
+			name: "unset environment defaults to prod",
+			want: "https://app.lfx.dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LFX_SELF_SERVE_BASE_URL", tt.baseURL)
+			t.Setenv("LFX_ENVIRONMENT", tt.environment)
+
+			assert.Equal(t, tt.want, LFXSelfServeBaseURL())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Change `LFXSelfServeBaseURL()` to default to `https://app.lfx.dev` when `LFX_ENVIRONMENT` is unset, instead of dev
- Recognize common environment aliases (`production`, `development`, `stg`, `stage`)
- Add unit tests for all resolution paths

Fixes prod invite return URLs pointing at `https://app.dev.lfx.dev` when `LFX_ENVIRONMENT` is not configured.

Made with [Cursor](https://cursor.com)