### PR TITLE
[LFXV2-2402] fix: add committee_invite FGA access object and tuple publishing

### DIFF
--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -30,6 +30,8 @@ import (
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/redaction"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/utils"
+	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
+	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 	indexerTypes "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 	"golang.org/x/sync/errgroup"
@@ -716,6 +718,7 @@ func (s *committeeServicesrvc) CreateInvite(ctx context.Context, p *committeeser
 		}
 
 		s.publishInviteIndexerMessage(ctx, model.ActionUpdated, revokedInvite, p.XSync)
+		s.publishInviteAccessControlMessage(ctx, model.ActionUpdated, revokedInvite, p.XSync)
 		s.dispatchInviteEmail(ctx, committeeBase, revokedInvite)
 
 		return s.convertInviteDomainToResponse(revokedInvite), nil
@@ -726,6 +729,7 @@ func (s *committeeServicesrvc) CreateInvite(ctx context.Context, p *committeeser
 	}
 
 	s.publishInviteIndexerMessage(ctx, model.ActionCreated, invite, p.XSync)
+	s.publishInviteAccessControlMessage(ctx, model.ActionCreated, invite, p.XSync)
 	s.dispatchInviteEmail(ctx, committeeBase, invite)
 
 	return s.convertInviteDomainToResponse(invite), nil
@@ -803,6 +807,7 @@ func (s *committeeServicesrvc) RevokeInvite(ctx context.Context, p *committeeser
 	}
 
 	s.publishInviteIndexerMessage(ctx, model.ActionUpdated, invite, false)
+	s.publishInviteAccessControlMessage(ctx, model.ActionUpdated, invite, false)
 
 	return nil
 }
@@ -870,6 +875,10 @@ func (s *committeeServicesrvc) AcceptInvite(ctx context.Context, p *committeeser
 	}
 
 	s.publishInviteIndexerMessage(ctx, model.ActionUpdated, invite, false)
+	// Re-publish the access control message on accept: the invitee may now have an LFID
+	// account (e.g. they registered via the LFID invite flow), so this resolves and writes
+	// the invitee tuple if it wasn't written at invite creation time.
+	s.publishInviteAccessControlMessage(ctx, model.ActionUpdated, invite, false)
 
 	return s.convertMemberDomainToFullResponse(response), nil
 }
@@ -909,6 +918,7 @@ func (s *committeeServicesrvc) DeclineInvite(ctx context.Context, p *committeese
 	}
 
 	s.publishInviteIndexerMessage(ctx, model.ActionUpdated, invite, false)
+	s.publishInviteAccessControlMessage(ctx, model.ActionUpdated, invite, false)
 
 	return s.convertInviteDomainToResponse(invite), nil
 }
@@ -1255,7 +1265,7 @@ func (s *committeeServicesrvc) publishInviteIndexerMessage(ctx context.Context, 
 	tags := invite.Tags()
 	indexingConfig := &indexerTypes.IndexingConfig{
 		ObjectID:             invite.UID,
-		AccessCheckObject:    fmt.Sprintf("committee:%s", invite.CommitteeUID),
+		AccessCheckObject:    fmt.Sprintf("committee_invite:%s", invite.UID),
 		AccessCheckRelation:  "viewer",
 		HistoryCheckObject:   fmt.Sprintf("committee:%s", invite.CommitteeUID),
 		HistoryCheckRelation: "auditor",
@@ -1293,6 +1303,69 @@ func (s *committeeServicesrvc) publishInviteIndexerMessage(ctx context.Context, 
 
 	if pubErr := s.publisher.Indexer(ctx, constants.IndexCommitteeInviteSubject, built, sync); pubErr != nil {
 		slog.WarnContext(ctx, "failed to publish invite indexer message",
+			"error", pubErr,
+			"action", string(action),
+			"invite_uid", invite.UID,
+		)
+	}
+}
+
+// publishInviteAccessControlMessage publishes an FGA access control message for a committee invite.
+// For create/update it writes update_access tuples so that:
+//   - the parent committee relation is set (enables auditor from committee visibility), and
+//   - the invitee relation is set when the email resolves to an LFID username.
+//
+// For delete it writes a delete_access message to clean up all tuples for the invite object.
+// Publishing is best-effort: failures are logged but do not fail the request.
+func (s *committeeServicesrvc) publishInviteAccessControlMessage(ctx context.Context, action model.MessageAction, invite *model.CommitteeInvite, sync bool) {
+	var msg fgatypes.GenericFGAMessage
+
+	if action == model.ActionDeleted {
+		msg = fgatypes.GenericFGAMessage{
+			ObjectType: "committee_invite",
+			Operation:  "delete_access",
+			Data:       fgatypes.GenericDeleteData{UID: invite.UID},
+		}
+	} else {
+		data := fgatypes.GenericAccessData{
+			UID: invite.UID,
+			// References the parent committee so that auditor from committee resolves.
+			References: map[string][]string{
+				constants.RelationCommittee: {invite.CommitteeUID},
+			},
+		}
+
+		// Resolve the invitee email to an LFID username and, if found, include the
+		// invitee relation tuple. Mirrors the committee member path: unresolved emails
+		// (no LFID account yet) skip the tuple; it will be written on invite acceptance.
+		if s.userReader != nil {
+			if username, err := s.userReader.UsernameByEmail(ctx, invite.InviteeEmail); err == nil && username != "" {
+				data.Relations = map[string][]string{
+					constants.RelationInvitee: {username},
+				}
+			} else if err != nil {
+				slog.DebugContext(ctx, "invite access control: username lookup failed, invitee tuple skipped",
+					"error", err,
+					"invite_uid", invite.UID,
+					"email", redaction.RedactEmail(invite.InviteeEmail),
+				)
+			}
+		}
+
+		msg = fgatypes.GenericFGAMessage{
+			ObjectType: "committee_invite",
+			Operation:  "update_access",
+			Data:       data,
+		}
+	}
+
+	subject := fgaconstants.GenericUpdateAccessSubject
+	if action == model.ActionDeleted {
+		subject = fgaconstants.GenericDeleteAccessSubject
+	}
+
+	if pubErr := s.publisher.Access(ctx, subject, msg, sync); pubErr != nil {
+		slog.WarnContext(ctx, "failed to publish invite access control message",
 			"error", pubErr,
 			"action", string(action),
 			"invite_uid", invite.UID,

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -1352,6 +1352,13 @@ func (s *committeeServicesrvc) publishInviteAccessControlMessage(ctx context.Con
 			}
 		}
 
+		// ExcludeRelations prevents fga-sync from deleting a previously-written invitee
+		// tuple when we have no resolved username (e.g. transient user-service outage or
+		// unregistered email). Mirrors the committee member ExcludeRelations pattern.
+		if data.Relations == nil {
+			data.ExcludeRelations = []string{constants.RelationInvitee}
+		}
+
 		msg = fgatypes.GenericFGAMessage{
 			ObjectType: "committee_invite",
 			Operation:  "update_access",

--- a/cmd/committee-cli/commands/command.go
+++ b/cmd/committee-cli/commands/command.go
@@ -34,8 +34,12 @@ type RunContext struct {
 	// (e.g. IndexMemberByCommittee). This is used by data-repair subcommands that bypass the
 	// business-logic orchestrator and write to the storage layer directly.
 	CommitteeMemberWriter port.CommitteeMemberWriter
-	DryRun                bool
-	Args                  []string // remaining args after command + subcommand, for subcommand flag parsing
+	// Publisher provides direct access to indexer and access-control messaging (e.g. reindex
+	// subcommands that need to publish without going through the writer orchestrator).
+	Publisher  port.CommitteePublisher
+	UserReader port.UserReader
+	DryRun     bool
+	Args       []string // remaining args after command + subcommand, for subcommand flag parsing
 }
 
 // Stats tracks counters for a command run.

--- a/cmd/committee-cli/commands/sync/reindex_invites.go
+++ b/cmd/committee-cli/commands/sync/reindex_invites.go
@@ -1,0 +1,196 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package sync
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/cmd/committee-cli/commands"
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
+	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
+	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
+	indexerTypes "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
+)
+
+// reindexInvitesSubcommand re-publishes all committee invites from NATS KV to both the
+// indexer (OpenSearch) and fga-sync (OpenFGA), correcting their access-check objects to
+// use the committee_invite FGA type introduced in model v14.
+type reindexInvitesSubcommand struct{}
+
+func (s *reindexInvitesSubcommand) Name() string { return "reindex-invites" }
+
+func (s *reindexInvitesSubcommand) Help() string {
+	return "re-publish all committee invites from NATS KV to OpenSearch and OpenFGA"
+}
+
+func (s *reindexInvitesSubcommand) Run(ctx context.Context, rc commands.RunContext) error {
+	slog.DebugContext(ctx, "starting subcommand", "subcommand", s.Name(), "args", rc.Args)
+
+	fs := flag.NewFlagSet("reindex-invites", flag.ContinueOnError)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(fs.Output(), "usage: committee-cli sync reindex-invites [flags]\n\nflags:\n")
+		fs.PrintDefaults()
+	}
+	committeeUID := fs.String("committee-uid", "", "limit reindex to invites of a single committee UID")
+	sleep := fs.Duration("sleep", 0, "wait between each invite publish (e.g. 200ms, 1s)")
+	dryRun := fs.Bool("dry-run", false, "log what would be published without actually publishing")
+	if err := fs.Parse(rc.Args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+
+	rc.DryRun = *dryRun
+
+	if rc.CommitteeReader == nil {
+		return fmt.Errorf("CommitteeReader is not wired in RunContext")
+	}
+	if rc.Publisher == nil {
+		return fmt.Errorf("publisher is not wired in RunContext")
+	}
+
+	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
+
+	invites, err := rc.CommitteeReader.ListAllInvites(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list all invites: %w", err)
+	}
+
+	stats := commands.NewStats()
+	stats.Total = len(invites)
+	stats.DryRun = rc.DryRun
+
+	for _, invite := range invites {
+		if *committeeUID != "" && invite.CommitteeUID != *committeeUID {
+			stats.Skipped++
+			continue
+		}
+
+		if rc.DryRun {
+			slog.InfoContext(ctx, "dry-run: would reindex invite",
+				"invite_uid", invite.UID,
+				"committee_uid", invite.CommitteeUID,
+				"status", invite.Status,
+			)
+			stats.Updated++
+			continue
+		}
+
+		failed := false
+
+		if err := publishIndexerMessage(ctx, rc, invite); err != nil {
+			slog.WarnContext(ctx, "failed to publish indexer message",
+				"error", err,
+				"invite_uid", invite.UID,
+				"committee_uid", invite.CommitteeUID,
+			)
+			failed = true
+		}
+
+		if err := publishAccessControlMessage(ctx, rc, invite); err != nil {
+			slog.WarnContext(ctx, "failed to publish access control message",
+				"error", err,
+				"invite_uid", invite.UID,
+				"committee_uid", invite.CommitteeUID,
+			)
+			failed = true
+		}
+
+		if failed {
+			stats.Failed++
+		} else {
+			slog.DebugContext(ctx, "reindexed invite",
+				"invite_uid", invite.UID,
+				"committee_uid", invite.CommitteeUID,
+				"status", invite.Status,
+			)
+			stats.Updated++
+		}
+
+		if *sleep > 0 {
+			time.Sleep(*sleep)
+		}
+	}
+
+	stats.Log(ctx, "sync reindex-invites")
+
+	if stats.Failed > 0 {
+		return fmt.Errorf("%d invite(s) failed to reindex", stats.Failed)
+	}
+	return nil
+}
+
+// publishIndexerMessage re-publishes an invite to the indexer (OpenSearch) with the
+// corrected AccessCheckObject pointing to the committee_invite FGA type.
+func publishIndexerMessage(ctx context.Context, rc commands.RunContext, invite *model.CommitteeInvite) error {
+	public := false
+	indexingConfig := &indexerTypes.IndexingConfig{
+		ObjectID:             invite.UID,
+		AccessCheckObject:    fmt.Sprintf("committee_invite:%s", invite.UID),
+		AccessCheckRelation:  "viewer",
+		HistoryCheckObject:   fmt.Sprintf("committee:%s", invite.CommitteeUID),
+		HistoryCheckRelation: "auditor",
+		ParentRefs:           []string{fmt.Sprintf("committee:%s", invite.CommitteeUID)},
+		SortName:             invite.InviteeEmail,
+		NameAndAliases:       []string{invite.InviteeEmail},
+		Fulltext:             invite.InviteeEmail,
+		Tags:                 invite.Tags(),
+		Public:               &public,
+	}
+
+	indexerMessage := model.CommitteeIndexerMessage{
+		Action:         model.ActionUpdated,
+		Tags:           invite.Tags(),
+		IndexingConfig: indexingConfig,
+	}
+
+	built, err := indexerMessage.Build(ctx, invite)
+	if err != nil {
+		return fmt.Errorf("failed to build indexer message: %w", err)
+	}
+
+	return rc.Publisher.Indexer(ctx, constants.IndexCommitteeInviteSubject, built, false)
+}
+
+// publishAccessControlMessage re-publishes an invite's FGA tuples to fga-sync.
+// It writes:
+//   - committee_invite:<uid>#committee@committee:<committeeUID>  (enables auditor from committee)
+//   - committee_invite:<uid>#invitee@user:<username>             (when email resolves to an LFID)
+func publishAccessControlMessage(ctx context.Context, rc commands.RunContext, invite *model.CommitteeInvite) error {
+	data := fgatypes.GenericAccessData{
+		UID: invite.UID,
+		References: map[string][]string{
+			constants.RelationCommittee: {invite.CommitteeUID},
+		},
+	}
+
+	// Resolve email → LFID username; skip the invitee tuple for unregistered emails.
+	// Mirrors the committee member and API-layer invite paths.
+	if rc.UserReader != nil {
+		if username, err := rc.UserReader.UsernameByEmail(ctx, invite.InviteeEmail); err == nil && username != "" {
+			data.Relations = map[string][]string{
+				constants.RelationInvitee: {username},
+			}
+		} else if err != nil {
+			slog.DebugContext(ctx, "username lookup failed, invitee tuple skipped",
+				"error", err,
+				"invite_uid", invite.UID,
+			)
+		}
+	}
+
+	msg := fgatypes.GenericFGAMessage{
+		ObjectType: "committee_invite",
+		Operation:  "update_access",
+		Data:       data,
+	}
+
+	return rc.Publisher.Access(ctx, fgaconstants.GenericUpdateAccessSubject, msg, false)
+}

--- a/cmd/committee-cli/commands/sync/reindex_invites.go
+++ b/cmd/committee-cli/commands/sync/reindex_invites.go
@@ -5,6 +5,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"github.com/linuxfoundation/lfx-v2-committee-service/cmd/committee-cli/commands"
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
+	errs "github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
 	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 	indexerTypes "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
@@ -50,17 +52,23 @@ func (s *reindexInvitesSubcommand) Run(ctx context.Context, rc commands.RunConte
 	rc.DryRun = *dryRun
 
 	if rc.CommitteeReader == nil {
-		return fmt.Errorf("CommitteeReader is not wired in RunContext")
+		return errs.NewUnexpected("CommitteeReader is not wired in RunContext")
 	}
 	if rc.Publisher == nil {
-		return fmt.Errorf("publisher is not wired in RunContext")
+		return errs.NewUnexpected("publisher is not wired in RunContext")
 	}
 
 	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
 
-	invites, err := rc.CommitteeReader.ListAllInvites(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list all invites: %w", err)
+	var invites []*model.CommitteeInvite
+	var listErr error
+	if *committeeUID != "" {
+		invites, listErr = rc.CommitteeReader.ListInvites(ctx, *committeeUID)
+	} else {
+		invites, listErr = rc.CommitteeReader.ListAllInvites(ctx)
+	}
+	if listErr != nil {
+		return errs.NewUnexpected("failed to list invites", listErr)
 	}
 
 	stats := commands.NewStats()
@@ -68,10 +76,6 @@ func (s *reindexInvitesSubcommand) Run(ctx context.Context, rc commands.RunConte
 	stats.DryRun = rc.DryRun
 
 	for _, invite := range invites {
-		if *committeeUID != "" && invite.CommitteeUID != *committeeUID {
-			stats.Skipped++
-			continue
-		}
 
 		if rc.DryRun {
 			slog.InfoContext(ctx, "dry-run: would reindex invite",
@@ -122,7 +126,7 @@ func (s *reindexInvitesSubcommand) Run(ctx context.Context, rc commands.RunConte
 	stats.Log(ctx, "sync reindex-invites")
 
 	if stats.Failed > 0 {
-		return fmt.Errorf("%d invite(s) failed to reindex", stats.Failed)
+		return errs.NewUnexpected(fmt.Sprintf("%d invite(s) failed to reindex", stats.Failed))
 	}
 	return nil
 }
@@ -171,19 +175,32 @@ func publishAccessControlMessage(ctx context.Context, rc commands.RunContext, in
 		},
 	}
 
-	// Resolve email → LFID username; skip the invitee tuple for unregistered emails.
-	// Mirrors the committee member and API-layer invite paths.
+	// Resolve email → LFID username. An errs.NotFound response means the invitee has no
+	// LFID yet — skip the tuple silently (auditor visibility still works). Any other error
+	// is a transient infrastructure failure: propagate it so the caller counts this invite
+	// as failed rather than silently omitting the invitee tuple.
 	if rc.UserReader != nil {
-		if username, err := rc.UserReader.UsernameByEmail(ctx, invite.InviteeEmail); err == nil && username != "" {
+		username, lookupErr := rc.UserReader.UsernameByEmail(ctx, invite.InviteeEmail)
+		if lookupErr != nil {
+			var notFound errs.NotFound
+			if errors.As(lookupErr, &notFound) {
+				slog.DebugContext(ctx, "invitee has no LFID yet, tuple skipped",
+					"invite_uid", invite.UID,
+				)
+			} else {
+				return fmt.Errorf("username lookup failed for invite %s: %w", invite.UID, lookupErr)
+			}
+		} else if username != "" {
 			data.Relations = map[string][]string{
 				constants.RelationInvitee: {username},
 			}
-		} else if err != nil {
-			slog.DebugContext(ctx, "username lookup failed, invitee tuple skipped",
-				"error", err,
-				"invite_uid", invite.UID,
-			)
 		}
+	}
+
+	// ExcludeRelations tells fga-sync not to touch the invitee relation when we have no
+	// username to write, preventing it from deleting an already-resolved invitee tuple.
+	if data.Relations == nil {
+		data.ExcludeRelations = []string{constants.RelationInvitee}
 	}
 
 	msg := fgatypes.GenericFGAMessage{

--- a/cmd/committee-cli/commands/sync/sync.go
+++ b/cmd/committee-cli/commands/sync/sync.go
@@ -20,6 +20,7 @@ func (c *command) Subcommands() map[string]commands.Subcommand {
 		"member-project-attribute":      &memberProjectAttributeSubcommand{},
 		"members-by-committee-index":    &membersByCommitteeIndexSubcommand{},
 		"members-by-organization-index": &membersByOrganizationIndexSubcommand{},
+		"reindex-invites":               &reindexInvitesSubcommand{},
 	}
 }
 

--- a/cmd/committee-cli/commands/sync/total_members_attribute_test.go
+++ b/cmd/committee-cli/commands/sync/total_members_attribute_test.go
@@ -72,6 +72,9 @@ func (r *mockReader) GetInvite(_ context.Context, _ string) (*model.CommitteeInv
 func (r *mockReader) ListInvites(_ context.Context, _ string) ([]*model.CommitteeInvite, error) {
 	return nil, nil
 }
+func (r *mockReader) ListAllInvites(_ context.Context) ([]*model.CommitteeInvite, error) {
+	return nil, nil
+}
 func (r *mockReader) GetApplication(_ context.Context, _ string) (*model.CommitteeApplication, uint64, error) {
 	return nil, 0, nil
 }

--- a/cmd/committee-cli/main.go
+++ b/cmd/committee-cli/main.go
@@ -96,19 +96,23 @@ func run() error {
 	defer func() { _ = client.Close() }()
 
 	storage := nats.NewStorage(client)
+	publisher := nats.NewMessagePublisher(client)
+	userReader := nats.NewUserRequest(client)
 
 	writerOrchestrator := usecaseSvc.NewCommitteeWriterOrchestrator(
 		usecaseSvc.WithCommitteeRetriever(storage),
 		usecaseSvc.WithCommitteeWriter(storage),
 		usecaseSvc.WithProjectRetriever(nats.NewMessageRequest(client)),
-		usecaseSvc.WithUserReader(nats.NewUserRequest(client)),
-		usecaseSvc.WithCommitteePublisher(nats.NewMessagePublisher(client)),
+		usecaseSvc.WithUserReader(userReader),
+		usecaseSvc.WithCommitteePublisher(publisher),
 	)
 
 	rc := commands.RunContext{
 		CommitteeReader:             storage,
 		CommitteeWriterOrchestrator: writerOrchestrator,
 		CommitteeMemberWriter:       storage,
+		Publisher:                   publisher,
+		UserReader:                  userReader,
 		Args:                        parsed.SubArgs,
 	}
 

--- a/internal/domain/port/committee_invite_reader.go
+++ b/internal/domain/port/committee_invite_reader.go
@@ -15,4 +15,7 @@ type CommitteeInviteReader interface {
 	GetInvite(ctx context.Context, uid string) (*model.CommitteeInvite, uint64, error)
 	// ListInvites retrieves all invites for a given committee UID
 	ListInvites(ctx context.Context, committeeUID string) ([]*model.CommitteeInvite, error)
+	// ListAllInvites retrieves every invite across all committees via a full bucket scan.
+	// Intended only for backfill/repair operations (e.g. the reindex-invites CLI subcommand).
+	ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite, error)
 }

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -805,6 +805,21 @@ func (m *MockRepository) ListInvites(ctx context.Context, committeeUID string) (
 	return invites, nil
 }
 
+// ListAllInvites retrieves every invite across all committees.
+func (m *MockRepository) ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite, error) {
+	slog.DebugContext(ctx, "mock repository: listing all committee invites")
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	invites := make([]*model.CommitteeInvite, 0, len(m.committeeInvites))
+	for _, invite := range m.committeeInvites {
+		inviteCopy := *invite
+		invites = append(invites, &inviteCopy)
+	}
+	return invites, nil
+}
+
 // ================== CommitteeApplicationReader implementation ==================
 
 // GetApplication retrieves a committee application by UID

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -428,6 +428,7 @@ func (s *storage) ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite,
 	}
 
 	var invites []*model.CommitteeInvite
+	failedReads := 0
 
 	for key := range keys.Keys() {
 		// Skip all secondary-index keys.
@@ -442,6 +443,7 @@ func (s *storage) ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite,
 				"key", key,
 				"error", errGet,
 			)
+			failedReads++
 			continue
 		}
 
@@ -450,8 +452,15 @@ func (s *storage) ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite,
 
 	slog.DebugContext(ctx, "retrieved all committee invites from NATS storage",
 		"invite_count", len(invites),
+		"failed_reads", failedReads,
 	)
 
+	if failedReads > 0 {
+		return invites, errs.NewUnexpected(
+			"failed to load one or more invites while listing all",
+			fmt.Errorf("failed_reads=%d", failedReads),
+		)
+	}
 	return invites, nil
 }
 

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -416,6 +416,45 @@ func (s *storage) ListAllMembers(ctx context.Context) ([]*model.CommitteeMember,
 	return members, nil
 }
 
+// ListAllInvites retrieves every invite across all committees via a full bucket scan.
+// It is intended only for backfill/repair operations (e.g. the reindex-invites CLI subcommand)
+// that need to read all invites without relying on a secondary index.
+func (s *storage) ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite, error) {
+	slog.DebugContext(ctx, "listing all committee invites from NATS storage")
+
+	keys, errKeys := s.client.kvStore[constants.KVBucketNameCommitteeInvites].ListKeys(ctx)
+	if errKeys != nil {
+		return nil, errs.NewUnexpected("failed to list keys from committee invites bucket", errKeys)
+	}
+
+	var invites []*model.CommitteeInvite
+
+	for key := range keys.Keys() {
+		// Skip all secondary-index keys.
+		if strings.HasPrefix(key, "lookup/") {
+			continue
+		}
+
+		invite := &model.CommitteeInvite{}
+		_, errGet := s.get(ctx, constants.KVBucketNameCommitteeInvites, key, invite, false)
+		if errGet != nil {
+			slog.WarnContext(ctx, "failed to get invite while listing all",
+				"key", key,
+				"error", errGet,
+			)
+			continue
+		}
+
+		invites = append(invites, invite)
+	}
+
+	slog.DebugContext(ctx, "retrieved all committee invites from NATS storage",
+		"invite_count", len(invites),
+	)
+
+	return invites, nil
+}
+
 // EachMember streams every committee member via a full bucket scan, invoking fn per member without
 // accumulating the whole set in memory (backfill/repair). Secondary-index keys are skipped; a
 // per-member read error is logged and skipped; the first error fn returns stops iteration.

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -334,6 +334,10 @@ func (r *TestMockCommitteeReader) ListInvites(ctx context.Context, committeeUID 
 	return []*model.CommitteeInvite{}, nil
 }
 
+func (r *TestMockCommitteeReader) ListAllInvites(_ context.Context) ([]*model.CommitteeInvite, error) {
+	return []*model.CommitteeInvite{}, nil
+}
+
 // Implement CommitteeApplicationReader interface
 func (r *TestMockCommitteeReader) GetApplication(ctx context.Context, uid string) (*model.CommitteeApplication, uint64, error) {
 	return nil, 0, errs.NewNotFound("not implemented for this test")

--- a/pkg/constants/access_control.go
+++ b/pkg/constants/access_control.go
@@ -14,4 +14,8 @@ const (
 	RelationAuditor = "auditor"
 	// RelationMember is the relation name for a member of an object.
 	RelationMember = "member"
+	// RelationCommittee is the relation name linking a child object to its parent committee.
+	RelationCommittee = "committee"
+	// RelationInvitee is the relation name for the invitee of a committee_invite.
+	RelationInvitee = "invitee"
 )


### PR DESCRIPTION
## Summary

- Repoint committee invite `AccessCheckObject` from `committee:<committeeUID>` to `committee_invite:<inviteUID>` (relation `viewer` unchanged)
- Add `publishInviteAccessControlMessage` to write OpenFGA tuples for `committee_invite` objects via fga-sync, enabling correct access scoping
- Call the new helper at all invite create/update/revoke/accept/decline sites
- Add `RelationCommittee` and `RelationInvitee` constants

## Problem

Invites were indexed with `AccessCheckObject = committee:<uid>`. The committee `viewer` relation is `[user:*] or member or auditor` — `user:*` makes invites visible to everyone. Worse, the invitee is not yet a committee viewer (they don't have an account or haven't been added as a member), so they couldn't specifically be targeted.

## How it works now

Each invite gets its own `committee_invite:<uid>` FGA object. fga-sync receives an `update_access` message and writes:

| Tuple | Enables |
|-------|---------|
| `committee_invite:<uid>#committee@committee:<committeeUID>` | committee auditors to see the invite via `auditor from committee` |
| `committee_invite:<uid>#invitee@user:<username>` | the invitee to see their own invite |

The invitee tuple is gated on email→LFID resolution (`userReader.UsernameByEmail`), mirroring the existing committee member path. Invites for unregistered emails skip the invitee tuple; it is written on accept when the user's LFID is known.

## Deploy ordering

⚠️ Requires the **lfx-v2-helm** PR (model v14, `committee_invite` type) to be deployed **first**. Access checks against `committee_invite` objects fail until that model version is live.

## Ticket

[LFXV2-2402](https://linuxfoundation.atlassian.net/browse/LFXV2-2402)

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./cmd/committee-api/service/... ./internal/service/... ./pkg/constants/...`
- [ ] In dev (after helm model v14 is deployed):
  - Create invite for email with existing LFID → confirm tuples `committee_invite:<uid>#committee@...` and `#invitee@user:<username>` exist in OpenFGA
  - `check(invitee, viewer, committee_invite:<uid>)` → allow; `check(auditor, viewer, ...)` → allow; random user → deny
  - Create invite for unregistered email → only `committee` tuple written; invitee tuple added on accept
  - Revoke invite → FGA tuples updated (auditor visibility retained)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2402]: https://linuxfoundation.atlassian.net/browse/LFXV2-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ