### PR TITLE
[LFXV2-2402] feat(ruleset): gate GET committee invite on committee_invite FGA object

### DIFF
--- a/charts/lfx-v2-committee-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-committee-service/templates/ruleset.yaml
@@ -497,7 +497,7 @@ spec:
           config:
             values:
               relation: viewer
-              object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
+              object: "committee_invite:{{ "{{- .Request.URL.Captures.invite_uid -}}" }}"
         {{- else }}
         - authorizer: allow_all
         {{- end }}


### PR DESCRIPTION
## Summary

- The `committee_invite` type was added to the OpenFGA model in `lfx-v2-helm` v14.0.0
- The `GET /committees/:uid/invites/:invite_uid` rule was still checking `committee:{uid}#viewer`
- This PR switches it to check `committee_invite:{invite_uid}#viewer`, so access is correctly scoped to the invitee and committee auditors (per the `committee_invite#viewer` definition: `invitee or auditor from committee`)

## Ticket

[LFXV2-2402](https://linuxfoundation.atlassian.net/browse/LFXV2-2402)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2402]: https://linuxfoundation.atlassian.net/browse/LFXV2-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ