### PR TITLE
[LFXV2-2404] feat: resolve invitee name via auth-service on invite send and accept

### DIFF
--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -791,7 +791,9 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 
 	// Resolve the invitee's display name via the auth service when they already have
 	// an LFID. Best-effort: lookup failures are logged and the invite still sends.
-	recipientName := s.resolveInviteeDisplayName(ctx, invite.InviteeEmail)
+	resolveCtx, resolveCancel := context.WithTimeout(ctx, inviteDispatchTimeout)
+	recipientName := s.resolveInviteeDisplayName(resolveCtx, invite.InviteeEmail)
+	resolveCancel()
 
 	sendCtx, cancel := context.WithTimeout(ctx, inviteDispatchTimeout)
 	defer cancel()

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -753,7 +753,15 @@ func (s *committeeServicesrvc) resolveInviteeDisplayName(ctx context.Context, em
 		return ""
 	}
 	username, err := s.userReader.UsernameByEmail(ctx, email)
-	if err != nil || username == "" {
+	if err != nil {
+		var notFound errors.NotFound
+		if !stderrors.As(err, &notFound) {
+			slog.WarnContext(ctx, "username lookup failed for invite recipient — sending without name",
+				"email", redaction.RedactEmail(email), "error", err)
+		}
+		return ""
+	}
+	if username == "" {
 		return ""
 	}
 	meta, err := s.userReader.UserMetadataByPrincipal(ctx, username)

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -773,10 +773,10 @@ func (s *committeeServicesrvc) resolveInviteeDisplayName(ctx context.Context, em
 	if meta == nil {
 		return ""
 	}
-	if name := strings.TrimSpace(meta.GivenName + " " + meta.FamilyName); name != "" {
+	if name := strings.TrimSpace(meta.Name); name != "" {
 		return name
 	}
-	return strings.TrimSpace(meta.Name)
+	return strings.TrimSpace(meta.GivenName + " " + meta.FamilyName)
 }
 
 // dispatchInviteEmail publishes a send-invite request to the invite service so the

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -740,6 +740,37 @@ func (s *committeeServicesrvc) CreateInvite(ctx context.Context, p *committeeser
 // (see internal/service/message_handler.go committeeNotificationTimeout).
 const inviteDispatchTimeout = 5 * time.Second
 
+// resolveInviteeDisplayName looks up a combined display name for the invitee via the
+// auth service when the invitee already has an LFID. Returns an empty string when the
+// invitee has no LFID yet or any lookup step fails — callers should treat an empty
+// return as "name unknown" and proceed without it.
+func (s *committeeServicesrvc) resolveInviteeDisplayName(ctx context.Context, email string) string {
+	if s.userReader == nil {
+		return ""
+	}
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return ""
+	}
+	username, err := s.userReader.UsernameByEmail(ctx, email)
+	if err != nil || username == "" {
+		return ""
+	}
+	meta, err := s.userReader.UserMetadataByPrincipal(ctx, username)
+	if err != nil {
+		slog.WarnContext(ctx, "user metadata lookup failed for invite recipient — sending without name",
+			"username", redaction.Redact(username), "error", err)
+		return ""
+	}
+	if meta == nil {
+		return ""
+	}
+	if name := strings.TrimSpace(meta.GivenName + " " + meta.FamilyName); name != "" {
+		return name
+	}
+	return strings.TrimSpace(meta.Name)
+}
+
 // dispatchInviteEmail publishes a send-invite request to the invite service so the
 // invitee receives an email. Best-effort: failures are logged and do not fail the
 // caller, since the invite record has already been persisted.
@@ -749,6 +780,10 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 			"committee_uid", committee.UID, "invite_uid", invite.UID)
 		return
 	}
+
+	// Resolve the invitee's display name via the auth service when they already have
+	// an LFID. Best-effort: lookup failures are logged and the invite still sends.
+	recipientName := s.resolveInviteeDisplayName(ctx, invite.InviteeEmail)
 
 	sendCtx, cancel := context.WithTimeout(ctx, inviteDispatchTimeout)
 	defer cancel()
@@ -760,6 +795,7 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 	_, err := s.inviteSender.SendInvite(sendCtx, inviteapi.SendInviteRequest{
 		Recipient: &inviteapi.Recipient{
 			Email: strings.TrimSpace(invite.InviteeEmail),
+			Name:  recipientName,
 		},
 		Inviter: &inviteapi.Inviter{
 			Name: "A committee administrator",

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -735,10 +735,14 @@ func (s *committeeServicesrvc) CreateInvite(ctx context.Context, p *committeeser
 	return s.convertInviteDomainToResponse(invite), nil
 }
 
-// inviteDispatchTimeout bounds the best-effort send-invite request to the
-// invite service. Matches the timeout used by the message-handler invite path
-// (see internal/service/message_handler.go committeeNotificationTimeout).
+// inviteDispatchTimeout is the total budget for a single invite dispatch (name
+// lookup + send). The name-resolve sub-timeout below consumes a portion of this
+// budget, leaving the remainder for the actual SendInvite call.
 const inviteDispatchTimeout = 5 * time.Second
+
+// inviteNameResolveTimeout is the slice of the dispatch budget reserved for the
+// best-effort auth-service name lookup. Must be less than inviteDispatchTimeout.
+const inviteNameResolveTimeout = 2 * time.Second
 
 // resolveInviteeDisplayName looks up a combined display name for the invitee via the
 // auth service when the invitee already has an LFID. Returns an empty string when the
@@ -789,20 +793,23 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 		return
 	}
 
+	// Single budget for the whole dispatch: name lookup (sub-timeout) + SendInvite.
+	// Both operations share the same parent context so the total cannot exceed
+	// inviteDispatchTimeout even when both are slow.
+	dispatchCtx, dispatchCancel := context.WithTimeout(ctx, inviteDispatchTimeout)
+	defer dispatchCancel()
+
 	// Resolve the invitee's display name via the auth service when they already have
 	// an LFID. Best-effort: lookup failures are logged and the invite still sends.
-	resolveCtx, resolveCancel := context.WithTimeout(ctx, inviteDispatchTimeout)
+	resolveCtx, resolveCancel := context.WithTimeout(dispatchCtx, inviteNameResolveTimeout)
 	recipientName := s.resolveInviteeDisplayName(resolveCtx, invite.InviteeEmail)
 	resolveCancel()
-
-	sendCtx, cancel := context.WithTimeout(ctx, inviteDispatchTimeout)
-	defer cancel()
 	// Role on the invite record is the committee role applied after acceptance.
 	// The Role field on SendInviteRequest is the invite-service permission grant
 	// — its vocabulary is Manage/View/Member, not committee roles like "chair".
 	// Match the parallel "add committee member" path in message_handler.go
 	// sendMemberInvite and pass "Member".
-	_, err := s.inviteSender.SendInvite(sendCtx, inviteapi.SendInviteRequest{
+	_, err := s.inviteSender.SendInvite(dispatchCtx, inviteapi.SendInviteRequest{
 		Recipient: &inviteapi.Recipient{
 			Email: strings.TrimSpace(invite.InviteeEmail),
 			Name:  recipientName,

--- a/cmd/committee-api/service/committee_service_test.go
+++ b/cmd/committee-api/service/committee_service_test.go
@@ -913,6 +913,107 @@ func TestCreateInvite_NilInviteSenderSkipsDispatch(t *testing.T) {
 	assert.Equal(t, "pending", result.Status)
 }
 
+func TestCreateInvite_RecipientNameResolution(t *testing.T) {
+	// Each subtest uses a unique email to avoid uniqueness conflicts in the global mock repo.
+	const username = "knownuser"
+
+	t.Run("invitee has LFID — name from metadata GivenName+FamilyName", func(t *testing.T) {
+		const email = "name-givenname@example.com"
+		svc, _, _ := setupServiceTestWithRepo()
+		svc.userReader = newMockUserReader().
+			withUsernames(email, username).
+			withMetadata(username, &model.UserMetadata{GivenName: "Jane", FamilyName: "Smith"})
+
+		_, err := svc.CreateInvite(context.Background(), &committeeservice.CreateInvitePayload{
+			UID:          "committee-1",
+			InviteeEmail: email,
+		})
+		require.NoError(t, err)
+
+		sender := svc.inviteSender.(*mockInviteSender)
+		require.Len(t, sender.calls, 1)
+		require.NotNil(t, sender.calls[0].Recipient)
+		assert.Equal(t, "Jane Smith", sender.calls[0].Recipient.Name)
+	})
+
+	t.Run("invitee has LFID with only combined Name — falls back to meta.Name", func(t *testing.T) {
+		const email = "name-combined@example.com"
+		svc, _, _ := setupServiceTestWithRepo()
+		svc.userReader = newMockUserReader().
+			withUsernames(email, username).
+			withMetadata(username, &model.UserMetadata{Name: "Jane Smith"})
+
+		_, err := svc.CreateInvite(context.Background(), &committeeservice.CreateInvitePayload{
+			UID:          "committee-1",
+			InviteeEmail: email,
+		})
+		require.NoError(t, err)
+
+		sender := svc.inviteSender.(*mockInviteSender)
+		require.Len(t, sender.calls, 1)
+		assert.Equal(t, "Jane Smith", sender.calls[0].Recipient.Name)
+	})
+
+	t.Run("invitee has no LFID — Recipient.Name is empty, invite still sends", func(t *testing.T) {
+		svc, _, _ := setupServiceTestWithRepo()
+		// Default mockUserReader returns NotFound for any UsernameByEmail call.
+		svc.userReader = newMockUserReader()
+
+		_, err := svc.CreateInvite(context.Background(), &committeeservice.CreateInvitePayload{
+			UID:          "committee-1",
+			InviteeEmail: "name-nolfid@example.com",
+		})
+		require.NoError(t, err)
+
+		sender := svc.inviteSender.(*mockInviteSender)
+		require.Len(t, sender.calls, 1)
+		assert.Empty(t, sender.calls[0].Recipient.Name, "name should be blank when invitee has no LFID")
+	})
+
+	t.Run("metadata lookup error — Recipient.Name is empty, invite still sends", func(t *testing.T) {
+		const email = "name-metaerr@example.com"
+		svc, _, _ := setupServiceTestWithRepo()
+		svc.userReader = newMockUserReader().
+			withUsernames(email, username).
+			withMetadataErr(assert.AnError)
+
+		_, err := svc.CreateInvite(context.Background(), &committeeservice.CreateInvitePayload{
+			UID:          "committee-1",
+			InviteeEmail: email,
+		})
+		require.NoError(t, err)
+
+		sender := svc.inviteSender.(*mockInviteSender)
+		require.Len(t, sender.calls, 1)
+		assert.Empty(t, sender.calls[0].Recipient.Name, "name should be blank when metadata lookup errors")
+	})
+
+	t.Run("reinstated revoked invite also carries resolved name", func(t *testing.T) {
+		const email = "name-reinstate@example.com"
+		svc, _, repo := setupServiceTestWithRepo()
+		svc.userReader = newMockUserReader().
+			withUsernames(email, username).
+			withMetadata(username, &model.UserMetadata{GivenName: "Jane", FamilyName: "Smith"})
+		repo.AddCommitteeInvite(&model.CommitteeInvite{
+			UID:          "revoked-invite-name",
+			CommitteeUID: "committee-1",
+			InviteeEmail: email,
+			Status:       "revoked",
+			CreatedAt:    time.Now(),
+		})
+
+		_, err := svc.CreateInvite(context.Background(), &committeeservice.CreateInvitePayload{
+			UID:          "committee-1",
+			InviteeEmail: email,
+		})
+		require.NoError(t, err)
+
+		sender := svc.inviteSender.(*mockInviteSender)
+		require.Len(t, sender.calls, 1)
+		assert.Equal(t, "Jane Smith", sender.calls[0].Recipient.Name)
+	})
+}
+
 func TestCreateInvite_NonRevokedDuplicateRejected(t *testing.T) {
 	for _, status := range []string{"pending", "declined", "accepted"} {
 		t.Run(status, func(t *testing.T) {

--- a/cmd/committee-api/service/group_weekly_brief_test.go
+++ b/cmd/committee-api/service/group_weekly_brief_test.go
@@ -67,6 +67,10 @@ func (r *stubCommitteeReader) GetMemberRevision(_ context.Context, _ string) (ui
 	panic("not used")
 }
 
+func (r *stubCommitteeReader) ListInvites(_ context.Context, _ string) ([]*model.CommitteeInvite, error) {
+	panic("not used")
+}
+
 // ensure the stub satisfies the interface at compile time
 var _ internalsvc.CommitteeReader = (*stubCommitteeReader)(nil)
 

--- a/cmd/committee-api/service/group_weekly_brief_test.go
+++ b/cmd/committee-api/service/group_weekly_brief_test.go
@@ -71,6 +71,10 @@ func (r *stubCommitteeReader) ListInvites(_ context.Context, _ string) ([]*model
 	panic("not used")
 }
 
+func (r *stubCommitteeReader) ListAllInvites(_ context.Context) ([]*model.CommitteeInvite, error) {
+	panic("not used")
+}
+
 // ensure the stub satisfies the interface at compile time
 var _ internalsvc.CommitteeReader = (*stubCommitteeReader)(nil)
 

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -152,7 +152,7 @@ Published to `lfx.fga-sync.update_access` whenever a `committee_invite` object i
 |---|---|---|
 | `invitee` | LFID username resolved from `CommitteeInvite.InviteeEmail` | Only when email resolves to an LFID username |
 
-> When the invite is created and the invitee has no LFID yet, the `invitee` relation is omitted. `ExcludeRelations: ["invitee"]` is set so fga-sync does not delete a previously-written tuple on a transient auth-service outage. The tuple is written retroactively on `lfx.invite-service.invite_accepted` once the invitee creates an LFID — covering all pending invites for that email, not only the one the user clicked.
+> When the invite is created and the invitee has no LFID yet, the `invitee` relation is omitted. `ExcludeRelations: ["invitee"]` is set so fga-sync does not delete a previously-written tuple on a transient auth-service outage. The tuple is written retroactively on `lfx.invite-service.invite_accepted` once the invitee creates an LFID — covering all invites for that email regardless of status, so the user can see their full invite history.
 
 #### References
 
@@ -181,4 +181,4 @@ Published to `lfx.fga-sync.delete_access` when a committee invite is deleted. Re
 | Update committee invite | `committee_invite` | `lfx.fga-sync.update_access` | Same invitee-resolution logic as create |
 | Accept committee invite (HTTP) | `committee_invite` | `lfx.fga-sync.update_access` | Re-publishes to ensure `invitee` tuple is present after acceptance |
 | Delete committee invite | `committee_invite` | `lfx.fga-sync.delete_access` | Removes all tuples for the invite object |
-| LFID registered (`lfx.invite-service.invite_accepted`) | `committee_invite` | `lfx.fga-sync.update_access` | Publishes `invitee` relation for every pending `committee_invite` whose `InviteeEmail` matches the accepted email — grants visibility to invites created before the user had an LFID |
+| LFID registered (`lfx.invite-service.invite_accepted`) | `committee_invite` | `lfx.fga-sync.update_access` | Publishes `invitee` relation for every `committee_invite` (any status) whose `InviteeEmail` matches the accepted email — grants visibility to all invites, including already-accepted ones |

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -11,6 +11,7 @@ The full OpenFGA type definitions (relations, schema) for all object types are d
 ## Object Types
 
 - [Committee](#committee)
+- [Committee Invite](#committee-invite)
 
 ---
 
@@ -120,6 +121,51 @@ On delete, a `delete_access` message is sent to `lfx.fga-sync.delete_access` wit
 
 ---
 
+---
+
+## Committee Invite
+
+**Source struct:** `internal/domain/model/CommitteeInvite`
+
+**Synced on:** create/update of a committee invite (HTTP path), acceptance of a committee invite (HTTP path), and NATS `lfx.invite-service.invite_accepted` event (grants `invitee` relation to newly registered LFID users).
+
+### update_access (Create / Accept / LFID Registration)
+
+Published to `lfx.fga-sync.update_access` whenever a `committee_invite` object is created, updated, or when a previously-invited email address registers an LFID (via `HandleInviteAccepted`).
+
+#### Message Envelope
+
+| Field | Value |
+|---|---|
+| `object_type` | `committee_invite` |
+| `operation` | `update_access` |
+
+#### Data Fields
+
+| Field | Value |
+|---|---|
+| `uid` | `CommitteeInvite.UID` |
+
+#### Relations
+
+| Relation | Value | Condition |
+|---|---|---|
+| `invitee` | LFID username resolved from `CommitteeInvite.InviteeEmail` | Only when email resolves to an LFID username |
+
+> When the invite is created and the invitee has no LFID yet, the `invitee` relation is omitted. `ExcludeRelations: ["invitee"]` is set so fga-sync does not delete a previously-written tuple on a transient auth-service outage. The tuple is written retroactively on `lfx.invite-service.invite_accepted` once the invitee creates an LFID — covering all pending invites for that email, not only the one the user clicked.
+
+#### References
+
+| Reference | Value | Condition |
+|---|---|---|
+| `committee` | `CommitteeInvite.CommitteeUID` | Always |
+
+### delete_access (Delete)
+
+Published to `lfx.fga-sync.delete_access` when a committee invite is deleted. Removes all FGA tuples for the `committee_invite:{uid}` object.
+
+---
+
 ## Triggers
 
 | Operation | Object Type | Subject | Notes |
@@ -131,3 +177,8 @@ On delete, a `delete_access` message is sent to `lfx.fga-sync.delete_access` wit
 | Create committee member (with username) | `committee` | `lfx.fga-sync.member_put` | Skipped if `Username` is empty |
 | Update committee member (with username) | `committee` | `lfx.fga-sync.member_put` | Skipped if `Username` is empty |
 | Delete committee member (with username) | `committee` | `lfx.fga-sync.member_remove` | Skipped if `Username` is empty; empty relations removes all tuples for the user |
+| Create committee invite | `committee_invite` | `lfx.fga-sync.update_access` | `invitee` relation omitted when invitee has no LFID yet |
+| Update committee invite | `committee_invite` | `lfx.fga-sync.update_access` | Same invitee-resolution logic as create |
+| Accept committee invite (HTTP) | `committee_invite` | `lfx.fga-sync.update_access` | Re-publishes to ensure `invitee` tuple is present after acceptance |
+| Delete committee invite | `committee_invite` | `lfx.fga-sync.delete_access` | Removes all tuples for the invite object |
+| LFID registered (`lfx.invite-service.invite_accepted`) | `committee_invite` | `lfx.fga-sync.update_access` | Publishes `invitee` relation for every pending `committee_invite` whose `InviteeEmail` matches the accepted email — grants visibility to invites created before the user had an LFID |

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -150,7 +150,7 @@ Published to `lfx.fga-sync.update_access` whenever a `committee_invite` object i
 |---|---|---|
 | `invitee` | LFID username resolved from `CommitteeInvite.InviteeEmail` | Only when email resolves to an LFID username |
 
-> When the invite is created and the invitee has no LFID yet, the `invitee` relation is omitted. `ExcludeRelations: ["invitee"]` is set so fga-sync does not delete a previously-written tuple on a transient auth-service outage. The tuple is written retroactively on `lfx.invite-service.invite_accepted` once the invitee creates an LFID — covering all invites for that email regardless of status, so the user can see their full invite history.
+> When the invite is created and the invitee has no LFID yet, the `invitee` relation is omitted. `exclude_relations: ["invitee"]` is set so fga-sync does not delete a previously-written tuple on a transient auth-service outage. The tuple is written retroactively on `lfx.invite-service.invite_accepted` once the invitee creates an LFID — covering all invites for that email regardless of status, so the user can see their full invite history.
 
 #### References
 

--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -121,8 +121,6 @@ On delete, a `delete_access` message is sent to `lfx.fga-sync.delete_access` wit
 
 ---
 
----
-
 ## Committee Invite
 
 **Source struct:** `internal/domain/model/CommitteeInvite`

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -32,6 +32,9 @@ type CommitteeDataReader interface {
 	ListAllUIDs(ctx context.Context) ([]string, error)
 	// ListInvites retrieves all invites for a given committee UID
 	ListInvites(ctx context.Context, committeeUID string) ([]*model.CommitteeInvite, error)
+	// ListAllInvites retrieves every invite across all committees via a full bucket scan.
+	// Callers should prefer this over repeated ListInvites calls when iterating all committees.
+	ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite, error)
 }
 
 // CommitteeMemberDataReader defines the interface for committee member read operations
@@ -117,6 +120,11 @@ func (rc *committeeReaderOrchestrator) ListAllUIDs(ctx context.Context) ([]strin
 // ListInvites retrieves all invites for a given committee UID
 func (rc *committeeReaderOrchestrator) ListInvites(ctx context.Context, committeeUID string) ([]*model.CommitteeInvite, error) {
 	return rc.committeeReader.ListInvites(ctx, committeeUID)
+}
+
+// ListAllInvites retrieves every invite across all committees via a full bucket scan.
+func (rc *committeeReaderOrchestrator) ListAllInvites(ctx context.Context) ([]*model.CommitteeInvite, error) {
+	return rc.committeeReader.ListAllInvites(ctx)
 }
 
 // GetAttributeValue retrieves an attribute value by UID and returns the revision

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -30,6 +30,8 @@ type CommitteeDataReader interface {
 	GetBaseAttributeValue(ctx context.Context, uid string, attributeName string) (any, error)
 	// ListAllUIDs returns all active committee UIDs
 	ListAllUIDs(ctx context.Context) ([]string, error)
+	// ListInvites retrieves all invites for a given committee UID
+	ListInvites(ctx context.Context, committeeUID string) ([]*model.CommitteeInvite, error)
 }
 
 // CommitteeMemberDataReader defines the interface for committee member read operations
@@ -110,6 +112,11 @@ func (rc *committeeReaderOrchestrator) GetSettings(ctx context.Context, uid stri
 // ListAllUIDs returns all active committee UIDs
 func (rc *committeeReaderOrchestrator) ListAllUIDs(ctx context.Context) ([]string, error) {
 	return rc.committeeReader.ListAllUIDs(ctx)
+}
+
+// ListInvites retrieves all invites for a given committee UID
+func (rc *committeeReaderOrchestrator) ListInvites(ctx context.Context, committeeUID string) ([]*model.CommitteeInvite, error) {
+	return rc.committeeReader.ListInvites(ctx, committeeUID)
 }
 
 // GetAttributeValue retrieves an attribute value by UID and returns the revision

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -902,7 +902,11 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 	// Pre-fetch all invites once and filter to the accepting email. This avoids an O(committees × invites)
 	// full-bucket scan that would result from calling ListInvites per committee inside the loop.
 	// The result is partitioned per committee inside publishInviteeFGAForCommittee.
-	invitesByCommittee := m.fetchInvitesByEmail(ctx, normalizedEmail)
+	// Guard: skip the scan entirely when FGA publishing is disabled (committeePublisher == nil).
+	var invitesByCommittee map[string][]*model.CommitteeInvite
+	if m.committeePublisher != nil {
+		invitesByCommittee = m.fetchInvitesByEmail(ctx, normalizedEmail)
+	}
 
 	for _, committeeUID := range allUIDs {
 		m.enrichInvitedUserInCommittee(ctx, inviteAcceptedEnrichment{
@@ -940,8 +944,8 @@ type inviteAcceptedEnrichment struct {
 // enrichInvitedUserInCommittee enriches every email-only Writers, Auditors, and Members record
 // for e.normalizedEmail in the given committee. Invite role is ignored — acceptance always
 // reconciles all resource data for the recipient email. It also publishes the FGA invitee
-// relation for every pending committee invite that matches the recipient email, so the newly
-// created LFID user can see their outstanding invites.
+// relation for every committee invite (any status) that matches the recipient email, so the
+// newly created LFID user can see their full invite history.
 func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx context.Context, e inviteAcceptedEnrichment) {
 	m.enrichInvitedUserInCommitteeSettings(ctx, e)
 	m.enrichInvitedUserInCommitteeMembers(ctx, e)
@@ -949,13 +953,17 @@ func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx context.Co
 }
 
 // fetchInvitesByEmail calls ListAllInvites once and returns a map of committeeUID → invites
-// for invites whose InviteeEmail matches normalizedEmail. Returns nil on error (already logged).
+// for invites whose InviteeEmail matches normalizedEmail. When the storage layer returns a
+// partial result alongside a non-nil error (e.g. some individual reads failed), the successfully
+// loaded invites are still used — only a total failure (nil slice) causes an early return.
 func (m *messageHandlerOrchestrator) fetchInvitesByEmail(ctx context.Context, normalizedEmail string) map[string][]*model.CommitteeInvite {
 	all, err := m.committeeReader.ListAllInvites(ctx)
 	if err != nil {
-		slog.WarnContext(ctx, "failed to list all committee invites for FGA invitee grant — skipping FGA publish",
+		slog.WarnContext(ctx, "partial or total failure listing committee invites for FGA invitee grant",
 			"error", err)
-		return nil
+		if len(all) == 0 {
+			return nil
+		}
 	}
 	result := make(map[string][]*model.CommitteeInvite)
 	for _, invite := range all {

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -1065,9 +1065,10 @@ func enrichCommitteeUserIfEmailOnly(user *model.CommitteeUser, normalizedEmail, 
 
 // resolveInvitedName returns (firstName, lastName, fullName) for the accepted invitee.
 // It first looks up the accepting principal via the auth-service user_metadata.read NATS
-// subject (UserMetadataByPrincipal). If the lookup succeeds and supplies a name, those values
-// are used. Otherwise it falls back to payloadName (Recipient.Name from the invite-accepted
-// event), splitting it on the first space into first/last.
+// subject (UserMetadataByPrincipal). If the lookup succeeds and supplies any name, those
+// values are returned exclusively — the payload is never mixed in. When only a combined
+// Name is present (no GivenName/FamilyName), first/last are derived by splitting it.
+// The payload (Recipient.Name) is used only when metadata is unavailable or nil.
 // All lookups are best-effort: a transport error logs a warning and triggers the fallback
 // so the caller is never blocked.
 func (m *messageHandlerOrchestrator) resolveInvitedName(ctx context.Context, principal, payloadName string) (firstName, lastName, fullName string) {
@@ -1077,22 +1078,25 @@ func (m *messageHandlerOrchestrator) resolveInvitedName(ctx context.Context, pri
 			slog.WarnContext(ctx, "user metadata lookup failed during invite acceptance — falling back to payload name",
 				"principal", redaction.Redact(principal), "error", err)
 		} else if meta != nil {
+			// Metadata available — use it exclusively; never mix with payload names.
 			firstName = meta.GivenName
 			lastName = meta.FamilyName
 			fullName = meta.Name
 			if fullName == "" {
 				fullName = strings.TrimSpace(meta.GivenName + " " + meta.FamilyName)
 			}
+			// When only a combined name is present, derive first/last from it
+			// rather than falling through to the payload.
+			if firstName == "" && lastName == "" && fullName != "" {
+				firstName, lastName = splitName(fullName)
+			}
+			return firstName, lastName, fullName
 		}
 	}
 
-	// Fall back to the payload name only when the metadata supplied nothing.
-	if firstName == "" && lastName == "" {
-		firstName, lastName = splitName(payloadName)
-	}
-	if fullName == "" {
-		fullName = strings.TrimSpace(payloadName)
-	}
+	// Metadata unavailable (lookup failed or returned nil) — fall back to payload.
+	firstName, lastName = splitName(payloadName)
+	fullName = strings.TrimSpace(payloadName)
 	return firstName, lastName, fullName
 }
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -894,21 +894,27 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 	}
 
 	// Resolve the invitee's name once — avoids one round-trip per committee in the full scan.
-	// Precedence: auth-service user_metadata.read (GivenName/FamilyName) → Recipient.Name from payload.
+	// Precedence: auth-service user_metadata.read (meta.Name, or GivenName+FamilyName) → Recipient.Name from payload.
 	resolveCtx, resolveCancel := context.WithTimeout(ctx, committeeNotificationTimeout)
 	firstName, lastName, fullName := m.resolveInvitedName(resolveCtx, event.AcceptedBy, event.Recipient.Name)
 	resolveCancel()
 
+	// Pre-fetch all invites once and filter to the accepting email. This avoids an O(committees × invites)
+	// full-bucket scan that would result from calling ListInvites per committee inside the loop.
+	// The result is partitioned per committee inside publishInviteeFGAForCommittee.
+	invitesByCommittee := m.fetchInvitesByEmail(ctx, normalizedEmail)
+
 	for _, committeeUID := range allUIDs {
 		m.enrichInvitedUserInCommittee(ctx, inviteAcceptedEnrichment{
-			writeCtx:        writeCtx,
-			committeeUID:    committeeUID,
-			normalizedEmail: normalizedEmail,
-			username:        event.AcceptedBy,
-			inviteUID:       event.UID,
-			firstName:       firstName,
-			lastName:        lastName,
-			fullName:        fullName,
+			writeCtx:           writeCtx,
+			committeeUID:       committeeUID,
+			normalizedEmail:    normalizedEmail,
+			username:           event.AcceptedBy,
+			inviteUID:          event.UID,
+			firstName:          firstName,
+			lastName:           lastName,
+			fullName:           fullName,
+			invitesByCommittee: invitesByCommittee,
 		})
 	}
 
@@ -917,15 +923,18 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 
 // inviteAcceptedEnrichment holds the per-event context threaded through the invite-accepted
 // enrichment chain. committeeUID is set per-iteration of the full-committee scan.
+// invitesByCommittee is keyed by committeeUID and contains only invites for the accepting email,
+// pre-fetched once before the loop to avoid repeated full-bucket scans.
 type inviteAcceptedEnrichment struct {
-	writeCtx        context.Context
-	committeeUID    string
-	normalizedEmail string
-	username        string
-	inviteUID       string
-	firstName       string
-	lastName        string
-	fullName        string
+	writeCtx           context.Context
+	committeeUID       string
+	normalizedEmail    string
+	username           string
+	inviteUID          string
+	firstName          string
+	lastName           string
+	fullName           string
+	invitesByCommittee map[string][]*model.CommitteeInvite
 }
 
 // enrichInvitedUserInCommittee enriches every email-only Writers, Auditors, and Members record
@@ -939,26 +948,37 @@ func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx context.Co
 	m.publishInviteeFGAForCommittee(ctx, e)
 }
 
-// publishInviteeFGAForCommittee lists all committee invites for the committee and
-// publishes an FGA update_access message for every invite whose invitee email matches the
-// accepting user, regardless of invite status. This grants the newly registered LFID user
-// the invitee relation on every committee_invite object for their email — including already-
-// accepted invites — so the user can always see their own invite history.
+// fetchInvitesByEmail calls ListAllInvites once and returns a map of committeeUID → invites
+// for invites whose InviteeEmail matches normalizedEmail. Returns nil on error (already logged).
+func (m *messageHandlerOrchestrator) fetchInvitesByEmail(ctx context.Context, normalizedEmail string) map[string][]*model.CommitteeInvite {
+	all, err := m.committeeReader.ListAllInvites(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to list all committee invites for FGA invitee grant — skipping FGA publish",
+			"error", err)
+		return nil
+	}
+	result := make(map[string][]*model.CommitteeInvite)
+	for _, invite := range all {
+		if invite == nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(invite.InviteeEmail)) != normalizedEmail {
+			continue
+		}
+		result[invite.CommitteeUID] = append(result[invite.CommitteeUID], invite)
+	}
+	return result
+}
+
+// publishInviteeFGAForCommittee publishes an FGA update_access message for every committee_invite
+// for the accepting email in the given committee, regardless of invite status. Uses the pre-fetched
+// invitesByCommittee map to avoid per-committee full-bucket scans.
 func (m *messageHandlerOrchestrator) publishInviteeFGAForCommittee(ctx context.Context, e inviteAcceptedEnrichment) {
 	if m.committeePublisher == nil {
 		return
 	}
-	invites, err := m.committeeReader.ListInvites(ctx, e.committeeUID)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to list committee invites for FGA invitee grant",
-			"committee_uid", e.committeeUID, "error", err)
-		return
-	}
-	for _, invite := range invites {
+	for _, invite := range e.invitesByCommittee[e.committeeUID] {
 		if invite == nil {
-			continue
-		}
-		if strings.ToLower(strings.TrimSpace(invite.InviteeEmail)) != e.normalizedEmail {
 			continue
 		}
 		msg := fgatypes.GenericFGAMessage{

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -896,41 +896,63 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 	firstName, lastName, fullName := m.resolveInvitedName(ctx, event.AcceptedBy, event.Recipient.Name)
 
 	for _, committeeUID := range allUIDs {
-		m.enrichInvitedUserInCommittee(ctx, writeCtx, committeeUID, normalizedEmail, event.AcceptedBy, event.UID, firstName, lastName, fullName)
+		m.enrichInvitedUserInCommittee(ctx, inviteAcceptedEnrichment{
+			writeCtx:        writeCtx,
+			committeeUID:    committeeUID,
+			normalizedEmail: normalizedEmail,
+			username:        event.AcceptedBy,
+			inviteUID:       event.UID,
+			firstName:       firstName,
+			lastName:        lastName,
+			fullName:        fullName,
+		})
 	}
 
 	return nil, nil
 }
 
+// inviteAcceptedEnrichment holds the per-event context threaded through the invite-accepted
+// enrichment chain. committeeUID is set per-iteration of the full-committee scan.
+type inviteAcceptedEnrichment struct {
+	writeCtx        context.Context
+	committeeUID    string
+	normalizedEmail string
+	username        string
+	inviteUID       string
+	firstName       string
+	lastName        string
+	fullName        string
+}
+
 // enrichInvitedUserInCommittee enriches every email-only Writers, Auditors, and Members record
-// for normalizedEmail in the given committee. Invite role is ignored — acceptance always
+// for e.normalizedEmail in the given committee. Invite role is ignored — acceptance always
 // reconciles all resource data for the recipient email.
-func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID, firstName, lastName, fullName string) {
-	m.enrichInvitedUserInCommitteeSettings(ctx, writeCtx, committeeUID, normalizedEmail, username, inviteUID, fullName)
-	m.enrichInvitedUserInCommitteeMembers(ctx, writeCtx, committeeUID, normalizedEmail, username, inviteUID, firstName, lastName)
+func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx context.Context, e inviteAcceptedEnrichment) {
+	m.enrichInvitedUserInCommitteeSettings(ctx, e)
+	m.enrichInvitedUserInCommitteeMembers(ctx, e)
 }
 
 // enrichInvitedUserInCommitteeSettings enriches all email-only Writers and Auditors matching
-// normalizedEmail in the given committee's settings with the accepted LFID and display name.
+// e.normalizedEmail in the given committee's settings with the accepted LFID and display name.
 // It retries on revision conflicts.
-func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeSettings(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID, fullName string) {
+func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeSettings(ctx context.Context, e inviteAcceptedEnrichment) {
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		settings, revision, err := m.committeeReader.GetSettings(ctx, committeeUID)
+		settings, revision, err := m.committeeReader.GetSettings(ctx, e.committeeUID)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to get settings for invite enrichment",
-				"error", err, "committee_uid", committeeUID, "invite_uid", inviteUID)
+				"error", err, "committee_uid", e.committeeUID, "invite_uid", e.inviteUID)
 			return
 		}
 
 		enriched := false
 		for i := range settings.Writers {
-			if enrichCommitteeUserIfEmailOnly(&settings.Writers[i], normalizedEmail, username, fullName) {
+			if enrichCommitteeUserIfEmailOnly(&settings.Writers[i], e.normalizedEmail, e.username, e.fullName) {
 				enriched = true
 			}
 		}
 		for i := range settings.Auditors {
-			if enrichCommitteeUserIfEmailOnly(&settings.Auditors[i], normalizedEmail, username, fullName) {
+			if enrichCommitteeUserIfEmailOnly(&settings.Auditors[i], e.normalizedEmail, e.username, e.fullName) {
 				enriched = true
 			}
 		}
@@ -939,87 +961,88 @@ func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeSettings(ctx, w
 			return
 		}
 
-		if _, writeErr := m.committeeWriterOrchestrator.UpdateSettings(writeCtx, settings, revision, false); writeErr != nil {
+		if _, writeErr := m.committeeWriterOrchestrator.UpdateSettings(e.writeCtx, settings, revision, false); writeErr != nil {
 			var conflictErr errors.Conflict
 			if stderrors.As(writeErr, &conflictErr) && attempt < maxRetries-1 {
 				slog.DebugContext(ctx, "revision conflict enriching invite — retrying",
-					"attempt", attempt+1, "committee_uid", committeeUID, "invite_uid", inviteUID)
+					"attempt", attempt+1, "committee_uid", e.committeeUID, "invite_uid", e.inviteUID)
 				continue
 			}
 			slog.ErrorContext(ctx, "failed to update settings after invite acceptance",
-				"error", writeErr, "committee_uid", committeeUID, "invite_uid", inviteUID)
+				"error", writeErr, "committee_uid", e.committeeUID, "invite_uid", e.inviteUID)
 			return
 		}
 
 		slog.DebugContext(ctx, "invite accepted — enriched email-only Writers/Auditors with LFID",
-			"committee_uid", committeeUID, "invite_uid", inviteUID, "username", redaction.Redact(username))
+			"committee_uid", e.committeeUID, "invite_uid", e.inviteUID, "username", redaction.Redact(e.username))
 		return
 	}
 }
 
 // enrichInvitedUserInCommitteeMembers enriches all email-only committee members matching
-// normalizedEmail in the given committee with the accepted LFID and name.
-func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeMembers(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID, firstName, lastName string) {
-	members, err := m.committeeReader.ListMembersByCommittee(ctx, committeeUID)
+// e.normalizedEmail in the given committee with the accepted LFID and name.
+func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeMembers(ctx context.Context, e inviteAcceptedEnrichment) {
+	members, err := m.committeeReader.ListMembersByCommittee(ctx, e.committeeUID)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to list members for invite enrichment",
-			"error", err, "committee_uid", committeeUID, "invite_uid", inviteUID)
+			"error", err, "committee_uid", e.committeeUID, "invite_uid", e.inviteUID)
 		return
 	}
 
 	for _, member := range members {
-		if member.Username != "" || strings.ToLower(strings.TrimSpace(member.Email)) != normalizedEmail {
+		if member.Username != "" || strings.ToLower(strings.TrimSpace(member.Email)) != e.normalizedEmail {
 			continue
 		}
-		m.enrichInvitedCommitteeMember(ctx, writeCtx, committeeUID, member.UID, normalizedEmail, username, inviteUID, firstName, lastName)
+		m.enrichInvitedCommitteeMember(ctx, e, member.UID)
 	}
 }
 
 // enrichInvitedCommitteeMember enriches a single email-only member with the accepted LFID and name.
 // Revision-conflict retries are handled here, not in enrichInvitedUserInCommitteeMembers.
-func (m *messageHandlerOrchestrator) enrichInvitedCommitteeMember(ctx, writeCtx context.Context, committeeUID, memberUID, normalizedEmail, username, inviteUID, firstName, lastName string) {
+// memberUID identifies the specific member within e.committeeUID.
+func (m *messageHandlerOrchestrator) enrichInvitedCommitteeMember(ctx context.Context, e inviteAcceptedEnrichment, memberUID string) {
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		member, revision, err := m.committeeReader.GetMember(ctx, committeeUID, memberUID)
+		member, revision, err := m.committeeReader.GetMember(ctx, e.committeeUID, memberUID)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to get member for invite enrichment",
-				"error", err, "committee_uid", committeeUID, "member_uid", memberUID, "invite_uid", inviteUID)
+				"error", err, "committee_uid", e.committeeUID, "member_uid", memberUID, "invite_uid", e.inviteUID)
 			return
 		}
 
-		if member.Username != "" || strings.ToLower(strings.TrimSpace(member.Email)) != normalizedEmail {
+		if member.Username != "" || strings.ToLower(strings.TrimSpace(member.Email)) != e.normalizedEmail {
 			return
 		}
 
-		member.Username = username
+		member.Username = e.username
 		// Only fill name fields that are not already set — preserves any name stored at invite creation.
-		if member.FirstName == "" && firstName != "" {
-			member.FirstName = firstName
+		if member.FirstName == "" && e.firstName != "" {
+			member.FirstName = e.firstName
 		}
-		if member.LastName == "" && lastName != "" {
-			member.LastName = lastName
+		if member.LastName == "" && e.lastName != "" {
+			member.LastName = e.lastName
 		}
 
-		inviteCtx := contextWithSkipMemberUsernameEmailResolution(writeCtx)
+		inviteCtx := contextWithSkipMemberUsernameEmailResolution(e.writeCtx)
 		updated, writeErr := m.committeeWriterOrchestrator.UpdateMember(inviteCtx, member, revision, false)
 		if writeErr != nil {
 			var conflictErr errors.Conflict
 			if stderrors.As(writeErr, &conflictErr) && attempt < maxRetries-1 {
 				slog.DebugContext(ctx, "revision conflict enriching member — retrying",
-					"attempt", attempt+1, "committee_uid", committeeUID, "member_uid", memberUID, "invite_uid", inviteUID)
+					"attempt", attempt+1, "committee_uid", e.committeeUID, "member_uid", memberUID, "invite_uid", e.inviteUID)
 				continue
 			}
 			slog.ErrorContext(ctx, "failed to update member after invite acceptance",
-				"error", writeErr, "committee_uid", committeeUID, "member_uid", memberUID, "invite_uid", inviteUID)
+				"error", writeErr, "committee_uid", e.committeeUID, "member_uid", memberUID, "invite_uid", e.inviteUID)
 			return
 		}
 
-		persistedUsername := username
+		persistedUsername := e.username
 		if updated != nil {
 			persistedUsername = updated.Username
 		}
 		slog.DebugContext(ctx, "invite accepted — enriched email-only member with LFID",
-			"committee_uid", committeeUID, "member_uid", memberUID, "invite_uid", inviteUID,
+			"committee_uid", e.committeeUID, "member_uid", memberUID, "invite_uid", e.inviteUID,
 			"username", redaction.Redact(persistedUsername))
 		return
 	}

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -22,6 +22,8 @@ import (
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/fields"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/redaction"
 	emailapi "github.com/linuxfoundation/lfx-v2-email-service/pkg/api"
+	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
+	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 	"golang.org/x/sync/errgroup"
 )
@@ -928,10 +930,63 @@ type inviteAcceptedEnrichment struct {
 
 // enrichInvitedUserInCommittee enriches every email-only Writers, Auditors, and Members record
 // for e.normalizedEmail in the given committee. Invite role is ignored — acceptance always
-// reconciles all resource data for the recipient email.
+// reconciles all resource data for the recipient email. It also publishes the FGA invitee
+// relation for every pending committee invite that matches the recipient email, so the newly
+// created LFID user can see their outstanding invites.
 func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx context.Context, e inviteAcceptedEnrichment) {
 	m.enrichInvitedUserInCommitteeSettings(ctx, e)
 	m.enrichInvitedUserInCommitteeMembers(ctx, e)
+	m.publishInviteeFGAForCommittee(ctx, e)
+}
+
+// publishInviteeFGAForCommittee lists all pending committee invites for the committee and
+// publishes an FGA update_access message for every invite whose invitee email matches the
+// accepting user. This grants the newly registered LFID user the invitee relation on any
+// committee_invite object that was created before they had an LFID, making those invites
+// visible to them in the access-check layer.
+func (m *messageHandlerOrchestrator) publishInviteeFGAForCommittee(ctx context.Context, e inviteAcceptedEnrichment) {
+	if m.committeePublisher == nil {
+		return
+	}
+	invites, err := m.committeeReader.ListInvites(ctx, e.committeeUID)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to list committee invites for FGA invitee grant",
+			"committee_uid", e.committeeUID, "error", err)
+		return
+	}
+	for _, invite := range invites {
+		if invite == nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(invite.InviteeEmail)) != e.normalizedEmail {
+			continue
+		}
+		if invite.Status != string(inviteapi.InviteStatusPending) {
+			continue
+		}
+		msg := fgatypes.GenericFGAMessage{
+			ObjectType: "committee_invite",
+			Operation:  "update_access",
+			Data: fgatypes.GenericAccessData{
+				UID: invite.UID,
+				References: map[string][]string{
+					constants.RelationCommittee: {invite.CommitteeUID},
+				},
+				Relations: map[string][]string{
+					constants.RelationInvitee: {e.username},
+				},
+			},
+		}
+		if pubErr := m.committeePublisher.Access(ctx, fgaconstants.GenericUpdateAccessSubject, msg, false); pubErr != nil {
+			slog.WarnContext(ctx, "failed to publish FGA invitee grant for committee invite",
+				"invite_uid", invite.UID, "committee_uid", e.committeeUID,
+				"username", redaction.Redact(e.username), "error", pubErr)
+		} else {
+			slog.DebugContext(ctx, "published FGA invitee grant for committee invite",
+				"invite_uid", invite.UID, "committee_uid", e.committeeUID,
+				"username", redaction.Redact(e.username))
+		}
+	}
 }
 
 // enrichInvitedUserInCommitteeSettings enriches all email-only Writers and Auditors matching

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -891,8 +891,12 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 		return nil, nil
 	}
 
+	// Resolve the invitee's name once — avoids one round-trip per committee in the full scan.
+	// Precedence: auth-service user_metadata.read (GivenName/FamilyName) → Recipient.Name from payload.
+	firstName, lastName, fullName := m.resolveInvitedName(ctx, event.AcceptedBy, event.Recipient.Name)
+
 	for _, committeeUID := range allUIDs {
-		m.enrichInvitedUserInCommittee(ctx, writeCtx, committeeUID, normalizedEmail, event.AcceptedBy, event.UID)
+		m.enrichInvitedUserInCommittee(ctx, writeCtx, committeeUID, normalizedEmail, event.AcceptedBy, event.UID, firstName, lastName, fullName)
 	}
 
 	return nil, nil
@@ -901,15 +905,15 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 // enrichInvitedUserInCommittee enriches every email-only Writers, Auditors, and Members record
 // for normalizedEmail in the given committee. Invite role is ignored — acceptance always
 // reconciles all resource data for the recipient email.
-func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID string) {
-	m.enrichInvitedUserInCommitteeSettings(ctx, writeCtx, committeeUID, normalizedEmail, username, inviteUID)
-	m.enrichInvitedUserInCommitteeMembers(ctx, writeCtx, committeeUID, normalizedEmail, username, inviteUID)
+func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID, firstName, lastName, fullName string) {
+	m.enrichInvitedUserInCommitteeSettings(ctx, writeCtx, committeeUID, normalizedEmail, username, inviteUID, fullName)
+	m.enrichInvitedUserInCommitteeMembers(ctx, writeCtx, committeeUID, normalizedEmail, username, inviteUID, firstName, lastName)
 }
 
 // enrichInvitedUserInCommitteeSettings enriches all email-only Writers and Auditors matching
-// normalizedEmail in the given committee's settings with the accepted LFID. It retries on
-// revision conflicts.
-func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeSettings(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID string) {
+// normalizedEmail in the given committee's settings with the accepted LFID and display name.
+// It retries on revision conflicts.
+func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeSettings(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID, fullName string) {
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		settings, revision, err := m.committeeReader.GetSettings(ctx, committeeUID)
@@ -921,12 +925,12 @@ func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeSettings(ctx, w
 
 		enriched := false
 		for i := range settings.Writers {
-			if enrichCommitteeUserIfEmailOnly(&settings.Writers[i], normalizedEmail, username) {
+			if enrichCommitteeUserIfEmailOnly(&settings.Writers[i], normalizedEmail, username, fullName) {
 				enriched = true
 			}
 		}
 		for i := range settings.Auditors {
-			if enrichCommitteeUserIfEmailOnly(&settings.Auditors[i], normalizedEmail, username) {
+			if enrichCommitteeUserIfEmailOnly(&settings.Auditors[i], normalizedEmail, username, fullName) {
 				enriched = true
 			}
 		}
@@ -954,8 +958,8 @@ func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeSettings(ctx, w
 }
 
 // enrichInvitedUserInCommitteeMembers enriches all email-only committee members matching
-// normalizedEmail in the given committee with the accepted LFID.
-func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeMembers(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID string) {
+// normalizedEmail in the given committee with the accepted LFID and name.
+func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeMembers(ctx, writeCtx context.Context, committeeUID, normalizedEmail, username, inviteUID, firstName, lastName string) {
 	members, err := m.committeeReader.ListMembersByCommittee(ctx, committeeUID)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to list members for invite enrichment",
@@ -967,13 +971,13 @@ func (m *messageHandlerOrchestrator) enrichInvitedUserInCommitteeMembers(ctx, wr
 		if member.Username != "" || strings.ToLower(strings.TrimSpace(member.Email)) != normalizedEmail {
 			continue
 		}
-		m.enrichInvitedCommitteeMember(ctx, writeCtx, committeeUID, member.UID, normalizedEmail, username, inviteUID)
+		m.enrichInvitedCommitteeMember(ctx, writeCtx, committeeUID, member.UID, normalizedEmail, username, inviteUID, firstName, lastName)
 	}
 }
 
-// enrichInvitedCommitteeMember enriches a single email-only member with the accepted LFID.
+// enrichInvitedCommitteeMember enriches a single email-only member with the accepted LFID and name.
 // Revision-conflict retries are handled here, not in enrichInvitedUserInCommitteeMembers.
-func (m *messageHandlerOrchestrator) enrichInvitedCommitteeMember(ctx, writeCtx context.Context, committeeUID, memberUID, normalizedEmail, username, inviteUID string) {
+func (m *messageHandlerOrchestrator) enrichInvitedCommitteeMember(ctx, writeCtx context.Context, committeeUID, memberUID, normalizedEmail, username, inviteUID, firstName, lastName string) {
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		member, revision, err := m.committeeReader.GetMember(ctx, committeeUID, memberUID)
@@ -988,6 +992,13 @@ func (m *messageHandlerOrchestrator) enrichInvitedCommitteeMember(ctx, writeCtx 
 		}
 
 		member.Username = username
+		// Only fill name fields that are not already set — preserves any name stored at invite creation.
+		if member.FirstName == "" && firstName != "" {
+			member.FirstName = firstName
+		}
+		if member.LastName == "" && lastName != "" {
+			member.LastName = lastName
+		}
 
 		inviteCtx := contextWithSkipMemberUsernameEmailResolution(writeCtx)
 		updated, writeErr := m.committeeWriterOrchestrator.UpdateMember(inviteCtx, member, revision, false)
@@ -1014,14 +1025,67 @@ func (m *messageHandlerOrchestrator) enrichInvitedCommitteeMember(ctx, writeCtx 
 	}
 }
 
-// enrichCommitteeUserIfEmailOnly sets username on a settings user when the entry is email-only
-// and matches normalizedEmail. Returns true when the user was enriched.
-func enrichCommitteeUserIfEmailOnly(user *model.CommitteeUser, normalizedEmail, username string) bool {
+// enrichCommitteeUserIfEmailOnly sets username (and name when not already set) on a settings
+// user when the entry is email-only and matches normalizedEmail. Returns true when the user
+// was enriched.
+func enrichCommitteeUserIfEmailOnly(user *model.CommitteeUser, normalizedEmail, username, fullName string) bool {
 	if user.Username != "" || strings.ToLower(strings.TrimSpace(user.Email)) != normalizedEmail {
 		return false
 	}
 	user.Username = username
+	// Only fill the name when the record has none — preserves any name stored at invite creation.
+	if user.Name == "" && fullName != "" {
+		user.Name = fullName
+	}
 	return true
+}
+
+// resolveInvitedName returns (firstName, lastName, fullName) for the accepted invitee.
+// It first looks up the accepting principal via the auth-service user_metadata.read NATS
+// subject (UserMetadataByPrincipal). If the lookup succeeds and supplies a name, those values
+// are used. Otherwise it falls back to payloadName (Recipient.Name from the invite-accepted
+// event), splitting it on the first space into first/last.
+// All lookups are best-effort: a transport error logs a warning and triggers the fallback
+// so the caller is never blocked.
+func (m *messageHandlerOrchestrator) resolveInvitedName(ctx context.Context, principal, payloadName string) (firstName, lastName, fullName string) {
+	if m.userReader != nil && principal != "" {
+		meta, err := m.userReader.UserMetadataByPrincipal(ctx, principal)
+		if err != nil {
+			slog.WarnContext(ctx, "user metadata lookup failed during invite acceptance — falling back to payload name",
+				"principal", redaction.Redact(principal), "error", err)
+		} else if meta != nil {
+			firstName = meta.GivenName
+			lastName = meta.FamilyName
+			fullName = meta.Name
+			if fullName == "" {
+				fullName = strings.TrimSpace(meta.GivenName + " " + meta.FamilyName)
+			}
+		}
+	}
+
+	// Fall back to the payload name only when the metadata supplied nothing.
+	if firstName == "" && lastName == "" {
+		firstName, lastName = splitName(payloadName)
+	}
+	if fullName == "" {
+		fullName = strings.TrimSpace(payloadName)
+	}
+	return firstName, lastName, fullName
+}
+
+// splitName splits a combined display name on the first space, returning (first, rest).
+// Leading/trailing whitespace is trimmed from both parts.
+func splitName(name string) (first, last string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(name, " ", 2)
+	first = strings.TrimSpace(parts[0])
+	if len(parts) == 2 {
+		last = strings.TrimSpace(parts[1])
+	}
+	return first, last
 }
 
 // mapRoleToInviteRole converts a committee settings role string to the invite

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -893,7 +893,9 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 
 	// Resolve the invitee's name once — avoids one round-trip per committee in the full scan.
 	// Precedence: auth-service user_metadata.read (GivenName/FamilyName) → Recipient.Name from payload.
-	firstName, lastName, fullName := m.resolveInvitedName(ctx, event.AcceptedBy, event.Recipient.Name)
+	resolveCtx, resolveCancel := context.WithTimeout(ctx, committeeNotificationTimeout)
+	firstName, lastName, fullName := m.resolveInvitedName(resolveCtx, event.AcceptedBy, event.Recipient.Name)
+	resolveCancel()
 
 	for _, committeeUID := range allUIDs {
 		m.enrichInvitedUserInCommittee(ctx, inviteAcceptedEnrichment{

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -1066,13 +1066,10 @@ func enrichCommitteeUserIfEmailOnly(user *model.CommitteeUser, normalizedEmail, 
 }
 
 // resolveInvitedName returns (firstName, lastName, fullName) for the accepted invitee.
-// It first looks up the accepting principal via the auth-service user_metadata.read NATS
-// subject (UserMetadataByPrincipal). If the lookup succeeds and supplies any name, those
-// values are returned exclusively — the payload is never mixed in. When only a combined
-// Name is present (no GivenName/FamilyName), first/last are derived by splitting it.
-// The payload (Recipient.Name) is used only when metadata is unavailable or nil.
-// All lookups are best-effort: a transport error logs a warning and triggers the fallback
-// so the caller is never blocked.
+// Precedence: auth-service UserMetadataByPrincipal result (when it supplies any name) →
+// payload Recipient.Name fallback. The payload is also used when metadata is non-nil but
+// carries no name fields. All lookups are best-effort: a transport error logs a warning
+// and triggers the fallback so the caller is never blocked.
 func (m *messageHandlerOrchestrator) resolveInvitedName(ctx context.Context, principal, payloadName string) (firstName, lastName, fullName string) {
 	if m.userReader != nil && principal != "" {
 		meta, err := m.userReader.UserMetadataByPrincipal(ctx, principal)
@@ -1080,19 +1077,21 @@ func (m *messageHandlerOrchestrator) resolveInvitedName(ctx context.Context, pri
 			slog.WarnContext(ctx, "user metadata lookup failed during invite acceptance — falling back to payload name",
 				"principal", redaction.Redact(principal), "error", err)
 		} else if meta != nil {
-			// Metadata available — use it exclusively; never mix with payload names.
 			firstName = meta.GivenName
 			lastName = meta.FamilyName
 			fullName = meta.Name
 			if fullName == "" {
 				fullName = strings.TrimSpace(meta.GivenName + " " + meta.FamilyName)
 			}
-			// When only a combined name is present, derive first/last from it
-			// rather than falling through to the payload.
 			if firstName == "" && lastName == "" && fullName != "" {
 				firstName, lastName = splitName(fullName)
 			}
-			return firstName, lastName, fullName
+			// Only return metadata-derived names when metadata actually supplied
+			// at least one — a non-nil record with all empty fields falls through
+			// to the payload fallback below.
+			if firstName != "" || lastName != "" || fullName != "" {
+				return firstName, lastName, fullName
+			}
 		}
 	}
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -939,11 +939,11 @@ func (m *messageHandlerOrchestrator) enrichInvitedUserInCommittee(ctx context.Co
 	m.publishInviteeFGAForCommittee(ctx, e)
 }
 
-// publishInviteeFGAForCommittee lists all pending committee invites for the committee and
+// publishInviteeFGAForCommittee lists all committee invites for the committee and
 // publishes an FGA update_access message for every invite whose invitee email matches the
-// accepting user. This grants the newly registered LFID user the invitee relation on any
-// committee_invite object that was created before they had an LFID, making those invites
-// visible to them in the access-check layer.
+// accepting user, regardless of invite status. This grants the newly registered LFID user
+// the invitee relation on every committee_invite object for their email — including already-
+// accepted invites — so the user can always see their own invite history.
 func (m *messageHandlerOrchestrator) publishInviteeFGAForCommittee(ctx context.Context, e inviteAcceptedEnrichment) {
 	if m.committeePublisher == nil {
 		return
@@ -959,9 +959,6 @@ func (m *messageHandlerOrchestrator) publishInviteeFGAForCommittee(ctx context.C
 			continue
 		}
 		if strings.ToLower(strings.TrimSpace(invite.InviteeEmail)) != e.normalizedEmail {
-			continue
-		}
-		if invite.Status != string(inviteapi.InviteStatusPending) {
 			continue
 		}
 		msg := fgatypes.GenericFGAMessage{

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
 	errs "github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
 	emailapi "github.com/linuxfoundation/lfx-v2-email-service/pkg/api"
+	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 )
 
@@ -505,6 +506,10 @@ func TestMessageHandlerOrchestratorIntegration(t *testing.T) {
 type spyCommitteePublisher struct {
 	indexerCallCount int
 	lastSubject      string
+	// capturedAccessSubjects records the NATS subject for each Access call.
+	capturedAccessSubjects []string
+	// capturedAccessMsgs records the raw message value for each Access call.
+	capturedAccessMsgs []any
 }
 
 func (s *spyCommitteePublisher) Indexer(_ context.Context, subject string, _ any, _ bool) error {
@@ -512,7 +517,9 @@ func (s *spyCommitteePublisher) Indexer(_ context.Context, subject string, _ any
 	s.lastSubject = subject
 	return nil
 }
-func (s *spyCommitteePublisher) Access(_ context.Context, _ string, _ any, _ bool) error {
+func (s *spyCommitteePublisher) Access(_ context.Context, subject string, msg any, _ bool) error {
+	s.capturedAccessSubjects = append(s.capturedAccessSubjects, subject)
+	s.capturedAccessMsgs = append(s.capturedAccessMsgs, msg)
 	return nil
 }
 func (s *spyCommitteePublisher) Event(_ context.Context, _ string, _ any, _ bool) error {
@@ -1953,13 +1960,17 @@ func TestHandleInviteAccepted(t *testing.T) {
 		}
 	}
 
-	makeHandler := func(repo *mock.MockRepository, spy *spyCommitteeWriterOrchestrator) *messageHandlerOrchestrator {
-		h := NewMessageHandlerOrchestrator(
+	makeHandler := func(repo *mock.MockRepository, spy *spyCommitteeWriterOrchestrator, pub *spyCommitteePublisher) *messageHandlerOrchestrator {
+		opts := []messageHandlerOrchestratorOption{
 			WithCommitteeReaderForMessageHandler(
 				NewCommitteeReaderOrchestrator(WithCommitteeReader(repo)),
 			),
 			WithCommitteeWriterOrchestratorForMessageHandler(spy),
-		)
+		}
+		if pub != nil {
+			opts = append(opts, WithCommitteePublisherForMessageHandler(pub))
+		}
+		h := NewMessageHandlerOrchestrator(opts...)
 		return h.(*messageHandlerOrchestrator)
 	}
 
@@ -1976,6 +1987,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 		wantUpdateMemberCalls int
 		validateSettings      func(*testing.T, []*model.CommitteeSettings)
 		validateMembers       func(*testing.T, []*model.CommitteeMember)
+		validatePublisher     func(*testing.T, *spyCommitteePublisher)
 	}{
 		{
 			name: "malformed payload — no update called",
@@ -2381,6 +2393,88 @@ func TestHandleInviteAccepted(t *testing.T) {
 				assert.Equal(t, "Set", captured[0].LastName, "existing last name must not be overwritten")
 			},
 		},
+		// ---- FGA invitee grant tests ----
+		{
+			name: "pending invite for matching email — FGA invitee relation published",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID}))
+				r.AddCommitteeInvite(&model.CommitteeInvite{
+					UID:          "pending-invite-1",
+					CommitteeUID: committee1UID,
+					InviteeEmail: writerEmail,
+					Status:       string(inviteapi.InviteStatusPending),
+				})
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+			validatePublisher: func(t *testing.T, pub *spyCommitteePublisher) {
+				require.Len(t, pub.capturedAccessSubjects, 1, "expected one FGA access publish for the pending invite")
+				assert.Equal(t, fgaconstants.GenericUpdateAccessSubject, pub.capturedAccessSubjects[0])
+			},
+		},
+		{
+			name: "two pending invites across two committees — FGA published for both",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID}))
+				r.AddCommittee(makeCommitteeWithSettings(committee2UID,
+					&model.CommitteeSettings{UID: committee2UID}))
+				r.AddCommitteeInvite(&model.CommitteeInvite{
+					UID:          "pending-invite-c1",
+					CommitteeUID: committee1UID,
+					InviteeEmail: writerEmail,
+					Status:       string(inviteapi.InviteStatusPending),
+				})
+				r.AddCommitteeInvite(&model.CommitteeInvite{
+					UID:          "pending-invite-c2",
+					CommitteeUID: committee2UID,
+					InviteeEmail: writerEmail,
+					Status:       string(inviteapi.InviteStatusPending),
+				})
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+			validatePublisher: func(t *testing.T, pub *spyCommitteePublisher) {
+				assert.Len(t, pub.capturedAccessSubjects, 2, "expected one FGA publish per pending invite")
+			},
+		},
+		{
+			name: "accepted invite — FGA not re-published",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID}))
+				r.AddCommitteeInvite(&model.CommitteeInvite{
+					UID:          "accepted-invite-1",
+					CommitteeUID: committee1UID,
+					InviteeEmail: writerEmail,
+					Status:       string(inviteapi.InviteStatusAccepted),
+				})
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+			validatePublisher: func(t *testing.T, pub *spyCommitteePublisher) {
+				assert.Empty(t, pub.capturedAccessSubjects, "accepted invite must not trigger FGA re-publish")
+			},
+		},
+		{
+			name: "invite for different email — FGA not published",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
+					&model.CommitteeSettings{UID: committee1UID}))
+				r.AddCommitteeInvite(&model.CommitteeInvite{
+					UID:          "other-invite-1",
+					CommitteeUID: committee1UID,
+					InviteeEmail: "other@example.com",
+					Status:       string(inviteapi.InviteStatusPending),
+				})
+			},
+			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls: 0,
+			validatePublisher: func(t *testing.T, pub *spyCommitteePublisher) {
+				assert.Empty(t, pub.capturedAccessSubjects, "invite for different email must not trigger FGA publish")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2395,7 +2489,8 @@ func TestHandleInviteAccepted(t *testing.T) {
 				updateMemberErr:    tt.spyMemberErr,
 				updateMemberErrs:   tt.spyMemberErrs,
 			}
-			handler := makeHandler(mockRepo, spy)
+			pub := &spyCommitteePublisher{}
+			handler := makeHandler(mockRepo, spy, pub)
 			if tt.userReader != nil {
 				handler.userReader = tt.userReader
 			}
@@ -2412,6 +2507,9 @@ func TestHandleInviteAccepted(t *testing.T) {
 			}
 			if tt.validateMembers != nil && len(spy.updatedMembers) > 0 {
 				tt.validateMembers(t, spy.updatedMembers)
+			}
+			if tt.validatePublisher != nil {
+				tt.validatePublisher(t, pub)
 			}
 		})
 	}

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2440,7 +2440,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 			},
 		},
 		{
-			name: "accepted invite — FGA not re-published",
+			name: "accepted invite — FGA still published so user can see their own invite history",
 			setupRepo: func(r *mock.MockRepository) {
 				r.AddCommittee(makeCommitteeWithSettings(committee1UID,
 					&model.CommitteeSettings{UID: committee1UID}))
@@ -2454,7 +2454,8 @@ func TestHandleInviteAccepted(t *testing.T) {
 			msgData:         makeEvent(inviteUID, username, writerEmail, string(inviteapi.InviteRoleManage)),
 			wantUpdateCalls: 0,
 			validatePublisher: func(t *testing.T, pub *spyCommitteePublisher) {
-				assert.Empty(t, pub.capturedAccessSubjects, "accepted invite must not trigger FGA re-publish")
+				require.Len(t, pub.capturedAccessSubjects, 1, "accepted invite should still get FGA invitee grant")
+				assert.Equal(t, fgaconstants.GenericUpdateAccessSubject, pub.capturedAccessSubjects[0])
 			},
 		},
 		{

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -1935,6 +1935,17 @@ func TestHandleInviteAccepted(t *testing.T) {
 		return b
 	}
 
+	makeEventWithName := func(invUID, acceptedBy, recipientEmail, recipientName, role string) []byte {
+		event := inviteapi.InviteServiceAcceptedEvent{Invite: inviteapi.Invite{
+			UID:        invUID,
+			AcceptedBy: acceptedBy,
+			Role:       role,
+			Recipient:  inviteapi.Recipient{Email: recipientEmail, Name: recipientName},
+		}}
+		b, _ := json.Marshal(event)
+		return b
+	}
+
 	makeCommitteeWithSettings := func(uid string, settings *model.CommitteeSettings) *model.Committee {
 		return &model.Committee{
 			CommitteeBase:     model.CommitteeBase{UID: uid, ProjectUID: "proj-1", Name: "Test Committee"},
@@ -1955,6 +1966,7 @@ func TestHandleInviteAccepted(t *testing.T) {
 	tests := []struct {
 		name                  string
 		setupRepo             func(*mock.MockRepository)
+		userReader            *mockUserReader // optional; wired into handler when non-nil
 		spyErr                error
 		spyErrs               []error // per-call error queue; takes precedence over spyErr when non-nil
 		spyMemberErr          error
@@ -2198,6 +2210,145 @@ func TestHandleInviteAccepted(t *testing.T) {
 				assert.Equal(t, username, captured[len(captured)-1].Username)
 			},
 		},
+		// ---- Name resolution tests ----
+		{
+			name: "name from user_metadata.read — member and settings user get metadata name",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{
+					UID:     committee1UID,
+					Writers: []model.CommitteeUser{{Email: writerEmail}},
+				}))
+				r.AddCommitteeMember(committee1UID, &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-name-meta",
+						CommitteeUID: committee1UID,
+						Email:        writerEmail,
+					},
+				})
+			},
+			// Metadata supplies structured names; payload name should be ignored.
+			userReader: &mockUserReader{meta: &model.UserMetadata{
+				Name:       "Jane Smith",
+				GivenName:  "Jane",
+				FamilyName: "Smith",
+			}},
+			msgData:               makeEventWithName(inviteUID, username, writerEmail, "Payload Name Ignored", string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls:       1,
+			wantUpdateMemberCalls: 1,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				require.Len(t, captured, 1)
+				require.Len(t, captured[0].Writers, 1)
+				assert.Equal(t, username, captured[0].Writers[0].Username)
+				assert.Equal(t, "Jane Smith", captured[0].Writers[0].Name, "settings user name should come from metadata")
+			},
+			validateMembers: func(t *testing.T, captured []*model.CommitteeMember) {
+				require.Len(t, captured, 1)
+				assert.Equal(t, username, captured[0].Username)
+				assert.Equal(t, "Jane", captured[0].FirstName, "member first name should come from metadata GivenName")
+				assert.Equal(t, "Smith", captured[0].LastName, "member last name should come from metadata FamilyName")
+			},
+		},
+		{
+			name: "name fallback to payload — member and settings user get payload name when metadata unavailable",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{
+					UID:     committee1UID,
+					Writers: []model.CommitteeUser{{Email: writerEmail}},
+				}))
+				r.AddCommitteeMember(committee1UID, &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-name-payload",
+						CommitteeUID: committee1UID,
+						Email:        writerEmail,
+					},
+				})
+			},
+			// Metadata lookup returns nil (no metadata) — must fall back to Recipient.Name.
+			userReader:            &mockUserReader{meta: nil},
+			msgData:               makeEventWithName(inviteUID, username, writerEmail, "Alice Wonderland", string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls:       1,
+			wantUpdateMemberCalls: 1,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				require.Len(t, captured, 1)
+				require.Len(t, captured[0].Writers, 1)
+				assert.Equal(t, "Alice Wonderland", captured[0].Writers[0].Name, "settings user name should come from payload fallback")
+			},
+			validateMembers: func(t *testing.T, captured []*model.CommitteeMember) {
+				require.Len(t, captured, 1)
+				assert.Equal(t, "Alice", captured[0].FirstName, "first name should be split from payload Recipient.Name")
+				assert.Equal(t, "Wonderland", captured[0].LastName, "last name should be split from payload Recipient.Name")
+			},
+		},
+		{
+			name: "no name from either source — username enriched but name fields left blank",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{
+					UID:     committee1UID,
+					Writers: []model.CommitteeUser{{Email: writerEmail}},
+				}))
+				r.AddCommitteeMember(committee1UID, &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-name-none",
+						CommitteeUID: committee1UID,
+						Email:        writerEmail,
+					},
+				})
+			},
+			// No metadata, no payload name — only LFID should be enriched.
+			userReader:            &mockUserReader{meta: nil},
+			msgData:               makeEventWithName(inviteUID, username, writerEmail, "", string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls:       1,
+			wantUpdateMemberCalls: 1,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				require.Len(t, captured, 1)
+				require.Len(t, captured[0].Writers, 1)
+				assert.Equal(t, username, captured[0].Writers[0].Username, "username should still be enriched")
+				assert.Empty(t, captured[0].Writers[0].Name, "name should be blank when no source supplies it")
+			},
+			validateMembers: func(t *testing.T, captured []*model.CommitteeMember) {
+				require.Len(t, captured, 1)
+				assert.Equal(t, username, captured[0].Username, "username should still be enriched")
+				assert.Empty(t, captured[0].FirstName, "first name should be blank when no source supplies it")
+				assert.Empty(t, captured[0].LastName, "last name should be blank when no source supplies it")
+			},
+		},
+		{
+			name: "existing name on record preserved — not overwritten by metadata",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{
+					UID:     committee1UID,
+					Writers: []model.CommitteeUser{{Email: writerEmail, Name: "Already Set"}},
+				}))
+				r.AddCommitteeMember(committee1UID, &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-name-existing",
+						CommitteeUID: committee1UID,
+						Email:        writerEmail,
+						FirstName:    "Already",
+						LastName:     "Set",
+					},
+				})
+			},
+			// Metadata would supply a different name — existing values must be preserved.
+			userReader: &mockUserReader{meta: &model.UserMetadata{
+				Name:       "New Name",
+				GivenName:  "New",
+				FamilyName: "Name",
+			}},
+			msgData:               makeEventWithName(inviteUID, username, writerEmail, "Payload Name", string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls:       1,
+			wantUpdateMemberCalls: 1,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				require.Len(t, captured, 1)
+				require.Len(t, captured[0].Writers, 1)
+				assert.Equal(t, "Already Set", captured[0].Writers[0].Name, "existing settings user name must not be overwritten")
+			},
+			validateMembers: func(t *testing.T, captured []*model.CommitteeMember) {
+				require.Len(t, captured, 1)
+				assert.Equal(t, "Already", captured[0].FirstName, "existing first name must not be overwritten")
+				assert.Equal(t, "Set", captured[0].LastName, "existing last name must not be overwritten")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2213,6 +2364,9 @@ func TestHandleInviteAccepted(t *testing.T) {
 				updateMemberErrs:   tt.spyMemberErrs,
 			}
 			handler := makeHandler(mockRepo, spy)
+			if tt.userReader != nil {
+				handler.userReader = tt.userReader
+			}
 
 			msg := newMockTransportMessenger(inviteapi.InviteServiceAcceptedSubject, tt.msgData)
 			_, err := handler.HandleInviteAccepted(ctx, msg)

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2249,6 +2249,38 @@ func TestHandleInviteAccepted(t *testing.T) {
 			},
 		},
 		{
+			name: "name from metadata combined Name only — first/last split from meta.Name, payload ignored",
+			setupRepo: func(r *mock.MockRepository) {
+				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{
+					UID:     committee1UID,
+					Writers: []model.CommitteeUser{{Email: writerEmail}},
+				}))
+				r.AddCommitteeMember(committee1UID, &model.CommitteeMember{
+					CommitteeMemberBase: model.CommitteeMemberBase{
+						UID:          "member-name-meta-only",
+						CommitteeUID: committee1UID,
+						Email:        writerEmail,
+					},
+				})
+			},
+			// Metadata has only a combined Name (no GivenName/FamilyName); first/last must be
+			// derived from meta.Name — payload must not bleed through.
+			userReader:            &mockUserReader{meta: &model.UserMetadata{Name: "Meta Only"}},
+			msgData:               makeEventWithName(inviteUID, username, writerEmail, "Payload Ignored", string(inviteapi.InviteRoleManage)),
+			wantUpdateCalls:       1,
+			wantUpdateMemberCalls: 1,
+			validateSettings: func(t *testing.T, captured []*model.CommitteeSettings) {
+				require.Len(t, captured, 1)
+				require.Len(t, captured[0].Writers, 1)
+				assert.Equal(t, "Meta Only", captured[0].Writers[0].Name, "settings name must come from metadata, not payload")
+			},
+			validateMembers: func(t *testing.T, captured []*model.CommitteeMember) {
+				require.Len(t, captured, 1)
+				assert.Equal(t, "Meta", captured[0].FirstName, "first name must be split from meta.Name, not payload")
+				assert.Equal(t, "Only", captured[0].LastName, "last name must be split from meta.Name, not payload")
+			},
+		},
+		{
 			name: "name fallback to payload — member and settings user get payload name when metadata unavailable",
 			setupRepo: func(r *mock.MockRepository) {
 				r.AddCommittee(makeCommitteeWithSettings(committee1UID, &model.CommitteeSettings{


### PR DESCRIPTION
## Summary

- When sending a committee invite via \`CreateInvite\`, look up the invitee's display name via \`lfx.auth-service.user_metadata.read\` (\`UsernameByEmail\` → \`UserMetadataByPrincipal\`) and populate \`Recipient.Name\` in the \`SendInviteRequest\` so the invite-service email can address the recipient by name when they already have an LFID.
- When consuming a NATS \`invite-accepted\` event (\`HandleInviteAccepted\`), resolve the accepting user's name from auth-service (keyed on \`AcceptedBy\`) and persist it on the reconciled \`CommitteeMember\` (\`FirstName\`/\`LastName\`) and \`CommitteeUser\` (\`Name\`) records. Falls back to splitting \`Recipient.Name\` from the invite-accepted payload when the metadata lookup returns nothing. Existing names on records are never overwritten.
- When a NATS \`invite-accepted\` event fires (i.e. the invitee creates an LFID), publish an FGA \`update_access\` message for every \`committee_invite\` record whose \`InviteeEmail\` matches the accepting email — regardless of invite status — so the newly registered LFID user receives the \`invitee\` relation on all their committee invites and can see them in the access-check layer. Invites created before the user had an LFID would otherwise have no \`invitee\` FGA tuple.
- All lookups are best-effort: transport errors are logged and the operation proceeds without a name rather than failing.

## Ticket

[LFXV2-2404](https://linuxfoundation.atlassian.net/browse/LFXV2-2404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2404]: https://linuxfoundation.atlassian.net/browse/LFXV2-2404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ