### PR TITLE
docs(LFXV2-2499): fix auth env vars in committee-api local-dev README

### DIFF
--- a/cmd/committee-api/README.md
+++ b/cmd/committee-api/README.md
@@ -246,9 +246,10 @@ The service relies on some resources and external services being spun up prior t
 |NATS_URL|the URL of the nats server instance|nats://localhost:4222|false|
 |LOG_LEVEL|the log level for outputted logs|info|false|
 |LOG_ADD_SOURCE|whether to add the source field to outputted logs|false|false|
-|JWKS_URL|the URL to the endpoint for verifying ID tokens and JWT access tokens||false|
-|AUDIENCE|the audience of the app that the JWT token should have set - for verification of the JWT token|lfx-v2-committee-service|false|
-|JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL|a mocked auth principal value for local development (to avoid needing a valid JWT token)||false|
+|AUTH_SOURCE|the authentication service implementation to use: `jwt` (verify real JWTs) or `mock` (bypass auth for local development)|jwt|false|
+|JWKS_URL|the URL to the endpoint for verifying ID tokens and JWT access tokens||required when `AUTH_SOURCE=jwt`|
+|JWT_AUDIENCE|the audience of the app that the JWT token should have set - for verification of the JWT token|lfx-v2-committee-service|required when `AUTH_SOURCE=jwt`|
+|JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL|a mocked auth principal value for local development (to avoid needing a valid JWT token); only takes effect when `AUTH_SOURCE=mock`||false|
 
 #### 4. Development Workflow
 


### PR DESCRIPTION
## Summary

- The local-dev env var table in `cmd/committee-api/README.md` documented `AUDIENCE` and omitted `AUTH_SOURCE`, but the service reads `JWT_AUDIENCE` and `AUTH_SOURCE` in `cmd/committee-api/service/providers.go`. Following the README crashes on startup with "JWT configuration incomplete: JWKS_URL and JWT_AUDIENCE are required"
- Added `AUTH_SOURCE` (values `jwt`/`mock`, default `jwt`) and renamed `AUDIENCE` → `JWT_AUDIENCE`, marking both `JWKS_URL` and `JWT_AUDIENCE` as required when `AUTH_SOURCE=jwt`
- Clarified that `JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL` only takes effect when `AUTH_SOURCE=mock`

### Ticket

[LFXV2-2499](https://linuxfoundation.atlassian.net/browse/LFXV2-2499?atlOrigin=eyJpIjoiZDYzZWVmNGQzOGY2NDk3ZDkyNTM0NDRjZGZhYjkxMGQiLCJwIjoiaiJ9)

[LFXV2-2499]: https://linuxfoundation.atlassian.net/browse/LFXV2-2499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ