### PR TITLE
feat(LFXV2-2521): add email→member secondary index and backfill

### DIFF
--- a/cmd/committee-cli/commands/sync/members_by_committee_index_test.go
+++ b/cmd/committee-cli/commands/sync/members_by_committee_index_test.go
@@ -18,16 +18,18 @@ import (
 )
 
 // mockMemberWriter is a full implementation of port.CommitteeMemberWriter shared
-// across the sync backfill tests (members-by-committee, members-by-organization, and
-// member-project-attribute). IndexMemberByCommittee, IndexMemberByOrganization, and
-// UpdateMember are exercised; call recording (indexed, orgIndexed, updated) and error
-// simulation (indexError, updateError) support those tests.
+// across the sync backfill tests (members-by-committee, members-by-organization,
+// members-by-email-index, and member-project-attribute). IndexMemberByCommittee,
+// IndexMemberByOrganization, IndexMemberByEmail, and UpdateMember are exercised; call
+// recording (indexed, orgIndexed, emailIndexed, updated) and error simulation
+// (indexError, updateError) support those tests.
 type mockMemberWriter struct {
-	indexed     []string                 // committee_uid+"."+member_uid keys that were written
-	orgIndexed  []string                 // org_sfid+"."+member_uid keys that were written
-	updated     []*model.CommitteeMember // members passed to UpdateMember (member-project-attribute repair)
-	indexError  error
-	updateError error
+	indexed      []string                 // committee_uid+"."+member_uid keys that were written
+	orgIndexed   []string                 // org_sfid+"."+member_uid keys that were written
+	emailIndexed []string                 // email_hash+"."+member_uid keys that were written
+	updated      []*model.CommitteeMember // members passed to UpdateMember (member-project-attribute repair)
+	indexError   error
+	updateError  error
 }
 
 func (w *mockMemberWriter) CreateMember(_ context.Context, _ *model.CommitteeMember) error {
@@ -62,6 +64,19 @@ func (w *mockMemberWriter) IndexMemberByOrganization(_ context.Context, m *model
 	}
 	key := fmt.Sprintf(constants.KVLookupMembersByOrganizationPrefix, orgSFID, m.UID)
 	w.orgIndexed = append(w.orgIndexed, key)
+	return key, nil
+}
+
+func (w *mockMemberWriter) IndexMemberByEmail(ctx context.Context, m *model.CommitteeMember) (string, error) {
+	if w.indexError != nil {
+		return "", w.indexError
+	}
+	hash := m.BuildEmailIndexKey(ctx)
+	if hash == "" {
+		return "", nil
+	}
+	key := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, hash, m.UID)
+	w.emailIndexed = append(w.emailIndexed, key)
 	return key, nil
 }
 

--- a/cmd/committee-cli/commands/sync/members_by_email_index.go
+++ b/cmd/committee-cli/commands/sync/members_by_email_index.go
@@ -1,0 +1,123 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package sync
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/cmd/committee-cli/commands"
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
+)
+
+// membersByEmailIndexSubcommand backfills the secondary index
+// "lookup/committee-members-by-email/<email_hash>.<member_uid>" for all existing members that
+// carry an email address. Members without an email are skipped. Idempotent: re-running is safe.
+type membersByEmailIndexSubcommand struct{}
+
+func (s *membersByEmailIndexSubcommand) Name() string { return "members-by-email-index" }
+
+func (s *membersByEmailIndexSubcommand) Help() string {
+	return "backfill the email→member secondary index for existing members (LFXV2-2521)"
+}
+
+func (s *membersByEmailIndexSubcommand) Run(ctx context.Context, rc commands.RunContext) error {
+	slog.DebugContext(ctx, "starting subcommand", "subcommand", s.Name(), "args", rc.Args)
+
+	fs := flag.NewFlagSet("members-by-email-index", flag.ContinueOnError)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(fs.Output(), "usage: committee-cli sync members-by-email-index [flags]\n\nflags:\n")
+		fs.PrintDefaults()
+	}
+	sleep := fs.Duration("sleep", 0, "wait between each member write (e.g. 200ms, 1s)")
+	dryRun := fs.Bool("dry-run", true, "compute what would be written without actually writing (default true; pass --dry-run=false to write)")
+	if err := fs.Parse(rc.Args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+
+	rc.DryRun = *dryRun
+
+	if rc.CommitteeReader == nil {
+		return errors.NewUnexpected("CommitteeReader is not wired in RunContext")
+	}
+	if rc.CommitteeMemberWriter == nil {
+		return errors.NewUnexpected("CommitteeMemberWriter is not wired in RunContext")
+	}
+
+	ctx = context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
+
+	stats := commands.NewStats()
+	stats.DryRun = rc.DryRun
+
+	// Stream members one at a time (no full in-memory load) and index each as it is read, so the
+	// backfill scales to large buckets without holding the whole member set in memory.
+	errEach := rc.CommitteeReader.EachMember(ctx, func(member *model.CommitteeMember) error {
+		stats.Total++
+
+		// Use BuildEmailIndexKey so both dry-run and live paths agree on which members
+		// produce a writable key (empty string means no email after normalization).
+		if member.BuildEmailIndexKey(ctx) == "" {
+			stats.Skipped++
+			return nil
+		}
+
+		if rc.DryRun {
+			slog.DebugContext(ctx, "dry-run: would write email member index",
+				"member_uid", member.UID,
+			)
+			stats.Updated++
+			return nil
+		}
+
+		key, errIdx := rc.CommitteeMemberWriter.IndexMemberByEmail(ctx, member)
+		if errIdx != nil {
+			slog.WarnContext(ctx, "failed to index member by email",
+				"error", errIdx,
+				"member_uid", member.UID,
+			)
+			stats.Failed++
+			return nil
+		}
+		if key == "" {
+			stats.Skipped++
+			return nil
+		}
+
+		slog.DebugContext(ctx, "indexed member by email",
+			"member_uid", member.UID,
+		)
+		stats.Updated++
+
+		if *sleep > 0 {
+			timer := time.NewTimer(*sleep)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+		return nil
+	})
+	if errEach != nil {
+		return fmt.Errorf("failed to stream members: %w", errEach)
+	}
+
+	stats.Log(ctx, "sync members-by-email-index")
+
+	if stats.Failed > 0 {
+		return fmt.Errorf("%d member(s) failed to index", stats.Failed)
+	}
+	return nil
+}

--- a/cmd/committee-cli/commands/sync/members_by_email_index_test.go
+++ b/cmd/committee-cli/commands/sync/members_by_email_index_test.go
@@ -1,0 +1,82 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+)
+
+func emailBackfillMember(uid, email string) *model.CommitteeMember {
+	return &model.CommitteeMember{CommitteeMemberBase: model.CommitteeMemberBase{
+		UID:          uid,
+		CommitteeUID: "c1",
+		Email:        email,
+	}}
+}
+
+func TestMembersByEmailIndex_BackfillAll_SkipsMembersWithoutEmail(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {
+				emailBackfillMember("m1", "user@example.com"),
+				emailBackfillMember("m2", "other@example.com"),
+				emailBackfillMember("m3", ""), // no email → skipped
+			},
+		},
+	}
+	w := &mockMemberWriter{}
+
+	err := (&membersByEmailIndexSubcommand{}).Run(context.Background(), newBackfillRC(r, w, "--dry-run=false"))
+	require.NoError(t, err)
+	assert.Len(t, w.emailIndexed, 2, "only members with an email are indexed")
+}
+
+func TestMembersByEmailIndex_BackfillAll_SkipsWhitespaceOnlyEmail(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {
+				emailBackfillMember("m1", "user@example.com"),
+				emailBackfillMember("m2", "   "), // whitespace-only → skipped
+			},
+		},
+	}
+	w := &mockMemberWriter{}
+
+	err := (&membersByEmailIndexSubcommand{}).Run(context.Background(), newBackfillRC(r, w, "--dry-run=false"))
+	require.NoError(t, err)
+	assert.Len(t, w.emailIndexed, 1, "whitespace-only email must be skipped like empty email")
+}
+
+func TestMembersByEmailIndex_DryRun(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {emailBackfillMember("m1", "user@example.com")},
+		},
+	}
+	w := &mockMemberWriter{}
+
+	err := (&membersByEmailIndexSubcommand{}).Run(context.Background(), newBackfillRC(r, w, "--dry-run"))
+	require.NoError(t, err)
+	assert.Empty(t, w.emailIndexed, "dry-run must not write")
+}
+
+func TestMembersByEmailIndex_IndexError_ReturnsError(t *testing.T) {
+	r := &mockReader{
+		members: map[string][]*model.CommitteeMember{
+			"c1": {emailBackfillMember("m1", "user@example.com")},
+		},
+	}
+	w := &mockMemberWriter{indexError: fmt.Errorf("nats unavailable")}
+
+	err := (&membersByEmailIndexSubcommand{}).Run(context.Background(), newBackfillRC(r, w, "--dry-run=false"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to index")
+}

--- a/cmd/committee-cli/commands/sync/sync.go
+++ b/cmd/committee-cli/commands/sync/sync.go
@@ -21,6 +21,7 @@ func (c *command) Subcommands() map[string]commands.Subcommand {
 		"member-avatar-attribute":       &memberAvatarAttributeSubcommand{},
 		"members-by-committee-index":    &membersByCommitteeIndexSubcommand{},
 		"members-by-organization-index": &membersByOrganizationIndexSubcommand{},
+		"members-by-email-index":        &membersByEmailIndexSubcommand{},
 		"reindex-invites":               &reindexInvitesSubcommand{},
 	}
 }

--- a/cmd/committee-cli/commands/sync/total_members_attribute_test.go
+++ b/cmd/committee-cli/commands/sync/total_members_attribute_test.go
@@ -61,6 +61,10 @@ func (r *mockReader) ListMembersByOrganization(_ context.Context, _ string) ([]*
 	return nil, nil
 }
 
+func (r *mockReader) ListMembersByEmail(_ context.Context, _ string) ([]*model.CommitteeMember, error) {
+	return nil, nil
+}
+
 // Stub methods required to satisfy port.CommitteeReader.
 
 func (r *mockReader) GetMember(_ context.Context, uid string) (*model.CommitteeMember, uint64, error) {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/nats-io/nats.go v1.49.0
 	github.com/remychantenay/slog-otel v1.3.4
 	github.com/stretchr/testify v1.11.1
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.43.0
 	go.opentelemetry.io/otel v1.43.0
@@ -39,6 +40,7 @@ require (
 	goa.design/goa/v3 v3.22.6
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.37.0
 )
 
 require (
@@ -73,6 +75,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.devnw.com/structs v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
@@ -84,7 +87,6 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,10 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 go.devnw.com/structs v1.0.0 h1:FFkBoBOkapCdxFEIkpOZRmMOMr9b9hxjKTD3bJYl9lk=
 go.devnw.com/structs v1.0.0/go.mod h1:wHBkdQpNeazdQHszJ2sxwVEpd8zGTEsKkeywDLGbrmg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/domain/model/committee_member.go
+++ b/internal/domain/model/committee_member.go
@@ -101,6 +101,23 @@ func (cm *CommitteeMember) BuildIndexKey(ctx context.Context) string {
 	return key
 }
 
+// BuildEmailIndexKey returns the SHA-256 hex digest of the member's normalized email, used as the
+// dot-free email segment of the lookup/committee-members-by-email/<hash>.<member_uid> secondary
+// index. Returns "" when the member has no email (callers treat that as a no-op).
+func (cm *CommitteeMember) BuildEmailIndexKey(ctx context.Context) string {
+	email := strings.TrimSpace(strings.ToLower(cm.Email))
+	if email == "" {
+		return ""
+	}
+	hash := sha256.Sum256([]byte(email))
+	key := hex.EncodeToString(hash[:])
+	slog.DebugContext(ctx, "member email index key built",
+		"email", redaction.RedactEmail(cm.Email),
+		"key", key,
+	)
+	return key
+}
+
 // Tags generates a consistent set of tags for the committee member.
 // IMPORTANT: If you modify this method, please update the Committee Tags documentation in the README.md
 // to ensure consumers understand how to use these tags for searching.

--- a/internal/domain/port/committee_member_reader.go
+++ b/internal/domain/port/committee_member_reader.go
@@ -28,4 +28,8 @@ type CommitteeMemberReader interface {
 	// materializing the whole set in memory — for backfill/repair over large buckets. Per-member read
 	// errors are skipped (logged); iteration stops and returns the first error fn returns.
 	EachMember(ctx context.Context, fn func(*model.CommitteeMember) error) error
+	// ListMembersByEmail retrieves all committee members whose normalized email matches the given
+	// address, using the by-email secondary index. The email is normalized (TrimSpace+ToLower) and
+	// SHA-256-hashed before the scan.
+	ListMembersByEmail(ctx context.Context, email string) ([]*model.CommitteeMember, error)
 }

--- a/internal/domain/port/committee_member_writer.go
+++ b/internal/domain/port/committee_member_writer.go
@@ -34,4 +34,11 @@ type CommitteeMemberWriter interface {
 	// Returns the written key (for rollback tracking), or an empty key (no-op) when the member has
 	// no organization.id. Treats ErrKeyExists as idempotent success.
 	IndexMemberByOrganization(ctx context.Context, member *model.CommitteeMember) (string, error)
+
+	// IndexMemberByEmail writes the secondary index entry mapping the member's normalized email
+	// (SHA-256 hex of strings.TrimSpace+strings.ToLower) → member_uid into the committee-members
+	// bucket, so ListMembersByEmail can use a server-side filtered scan rather than a full bucket
+	// scan. Returns the written key (for rollback tracking), or an empty key (no-op) when the member
+	// has no email. Treats ErrKeyExists as idempotent success.
+	IndexMemberByEmail(ctx context.Context, member *model.CommitteeMember) (string, error)
 }

--- a/internal/infrastructure/mock/committee.go
+++ b/internal/infrastructure/mock/committee.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -442,6 +443,31 @@ func (m *MockRepository) EachMember(ctx context.Context, fn func(*model.Committe
 	return nil
 }
 
+// ListMembersByEmail retrieves all committee members whose normalized email matches the given
+// address, scanning all committees. Mirrors the real storage index behavior for tests.
+func (m *MockRepository) ListMembersByEmail(ctx context.Context, email string) ([]*model.CommitteeMember, error) {
+	slog.DebugContext(ctx, "mock repository: listing committee members by email")
+
+	normalized := strings.TrimSpace(strings.ToLower(email))
+	if normalized == "" {
+		return nil, errors.NewValidation("email cannot be empty")
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var members []*model.CommitteeMember
+	for _, committeeMembers := range m.committeeMembers {
+		for _, member := range committeeMembers {
+			if strings.TrimSpace(strings.ToLower(member.Email)) != normalized {
+				continue
+			}
+			memberCopy := *member
+			members = append(members, &memberCopy)
+		}
+	}
+	return members, nil
+}
+
 // MockCommitteeWriter implements CommitteeWriter interface
 type MockCommitteeWriter struct {
 	mock *MockRepository
@@ -760,6 +786,21 @@ func (w *MockCommitteeWriter) IndexMemberByOrganization(ctx context.Context, mem
 		return "", nil
 	}
 	key := fmt.Sprintf(constants.KVLookupMembersByOrganizationPrefix, orgSFID, member.UID)
+	return key, nil
+}
+
+// IndexMemberByEmail records the by-email secondary index entry. In the mock this is a no-op; it
+// returns the key the real storage would write (empty when the member has no email) so callers can
+// track it for rollback.
+func (w *MockCommitteeWriter) IndexMemberByEmail(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	slog.DebugContext(ctx, "mock committee writer: indexing member by email",
+		"member_uid", member.UID,
+	)
+	hash := member.BuildEmailIndexKey(ctx)
+	if hash == "" {
+		return "", nil
+	}
+	key := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, hash, member.UID)
 	return key, nil
 }
 

--- a/internal/infrastructure/nats/storage.go
+++ b/internal/infrastructure/nats/storage.go
@@ -729,6 +729,97 @@ func (s *storage) ListMembersByOrganization(ctx context.Context, orgSFID string)
 	return members, nil
 }
 
+// IndexMemberByEmail writes the secondary index entry
+// "lookup/committee-members-by-email/<email_hash>.<member_uid>" → <member_uid> into the
+// committee-members bucket, so ListMembersByEmail can use a server-side filtered scan rather than
+// a full bucket scan. The email segment is the SHA-256 hex of the normalized email
+// (strings.TrimSpace + strings.ToLower), matching model.CommitteeMember.BuildEmailIndexKey.
+//
+// Members without an email produce an empty hash and no index entry is written (returns "", nil).
+// jetstream.ErrKeyExists is treated as idempotent success.
+func (s *storage) IndexMemberByEmail(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	if member == nil {
+		return "", errs.NewValidation("committee member cannot be nil")
+	}
+	if member.UID == "" {
+		return "", errs.NewValidation("committee member UID must be non-empty")
+	}
+	hash := member.BuildEmailIndexKey(ctx)
+	if hash == "" {
+		return "", nil
+	}
+	key := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, hash, member.UID)
+	if _, err := s.client.kvStore[constants.KVBucketNameCommitteeMembers].Create(ctx, key, []byte(member.UID)); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return key, nil
+		}
+		return key, errs.NewUnexpected("failed to index member by email", err)
+	}
+	return key, nil
+}
+
+// ListMembersByEmail retrieves all committee members whose normalized email matches the given
+// address, using the by-email secondary index. It performs a server-side filtered scan of
+// "lookup/committee-members-by-email/<email_hash>.*" so only members with that email are fetched.
+// A defensive consistency re-check skips stale entries left by in-flight email-change cleanups.
+func (s *storage) ListMembersByEmail(ctx context.Context, email string) ([]*model.CommitteeMember, error) {
+	probe := &model.CommitteeMember{CommitteeMemberBase: model.CommitteeMemberBase{Email: email}}
+	emailHash := probe.BuildEmailIndexKey(ctx)
+	if emailHash == "" {
+		return nil, errs.NewValidation("email cannot be empty")
+	}
+
+	slog.DebugContext(ctx, "listing committee members by email from NATS storage")
+
+	filter := fmt.Sprintf(constants.KVLookupMembersByEmailFilter, emailHash)
+	keys, errKeys := s.client.kvStore[constants.KVBucketNameCommitteeMembers].ListKeysFiltered(ctx, filter)
+	if errKeys != nil {
+		return nil, errs.NewUnexpected("failed to list member index keys for email", errKeys)
+	}
+	defer func() { _ = keys.Stop() }()
+
+	var members []*model.CommitteeMember
+
+	// Each key is "lookup/committee-members-by-email/<email_hash>.<member_uid>".
+	// The member UID (a UUID, no dots) is the suffix after the last dot.
+	for key := range keys.Keys() {
+		dotIdx := strings.LastIndex(key, ".")
+		if dotIdx < 0 || dotIdx == len(key)-1 {
+			slog.WarnContext(ctx, "skipping malformed email member index key", "key", key)
+			continue
+		}
+		memberUID := key[dotIdx+1:]
+
+		member := &model.CommitteeMember{}
+		_, errGet := s.get(ctx, constants.KVBucketNameCommitteeMembers, memberUID, member, false)
+		if errGet != nil {
+			if errors.Is(errGet, jetstream.ErrKeyNotFound) {
+				// Stale index key: the member was deleted but the index entry lagged behind.
+				slog.WarnContext(ctx, "skipping stale email member index entry; member no longer exists",
+					"member_uid", memberUID)
+				continue
+			}
+			return nil, errs.NewUnexpected("failed to get member while listing by email", errGet)
+		}
+
+		// Defensive consistency check: email-change stale-key cleanup runs in a background goroutine,
+		// so a lagging cleanup can leave an index key pointing at a member whose email has since
+		// changed. Skip such entries.
+		if member.BuildEmailIndexKey(ctx) != emailHash {
+			slog.WarnContext(ctx, "skipping stale email member index entry; member email no longer matches",
+				"member_uid", memberUID, "index_email_hash", emailHash)
+			continue
+		}
+
+		members = append(members, member)
+	}
+
+	slog.DebugContext(ctx, "retrieved committee members by email from NATS storage",
+		"member_count", len(members))
+
+	return members, nil
+}
+
 // ================== CommitteeInviteReader implementation ==================
 
 // GetInvite retrieves a committee invite by invite UID

--- a/internal/infrastructure/nats/storage_email_index_test.go
+++ b/internal/infrastructure/nats/storage_email_index_test.go
@@ -1,0 +1,152 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/model"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
+)
+
+func emailMember(uid, email string) *model.CommitteeMember {
+	return &model.CommitteeMember{CommitteeMemberBase: model.CommitteeMemberBase{
+		UID:   uid,
+		Email: email,
+	}}
+}
+
+// TestStorage_IndexMemberByEmail_Idempotent verifies that a duplicate index write
+// (jetstream.ErrKeyExists) is treated as success — the entry already exists.
+func TestStorage_IndexMemberByEmail_Idempotent(t *testing.T) {
+	s := newTestStorageWithKV(&mockKV{createErr: jetstream.ErrKeyExists})
+
+	key, err := s.IndexMemberByEmail(context.Background(), emailMember("m-1", "user@example.com"))
+	require.NoError(t, err, "ErrKeyExists must be treated as idempotent success")
+	assert.NotEmpty(t, key)
+}
+
+// TestStorage_IndexMemberByEmail_CreateErrorPropagates verifies that a non-ErrKeyExists error
+// from Create is wrapped and returned (with the key still returned for rollback).
+func TestStorage_IndexMemberByEmail_CreateErrorPropagates(t *testing.T) {
+	s := newTestStorageWithKV(&mockKV{createErr: errors.New("kv create boom")})
+
+	key, err := s.IndexMemberByEmail(context.Background(), emailMember("m-1", "user@example.com"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kv create boom", "underlying Create error must be surfaced")
+	assert.NotEmpty(t, key, "the index key is returned even on failure so callers can roll it back")
+}
+
+// TestStorage_IndexMemberByEmail_NoEmailIsNoOp verifies that a member without an email writes
+// no index entry and returns an empty key (not an error).
+func TestStorage_IndexMemberByEmail_NoEmailIsNoOp(t *testing.T) {
+	// createErr is set but must never be hit because no Create happens for an email-less member.
+	s := newTestStorageWithKV(&mockKV{createErr: errors.New("should not be called")})
+
+	key, err := s.IndexMemberByEmail(context.Background(), emailMember("m-1", ""))
+	require.NoError(t, err)
+	assert.Empty(t, key)
+}
+
+// TestStorage_ListMembersByEmail_EmptyEmailIsValidationError verifies the empty-email guard.
+func TestStorage_ListMembersByEmail_EmptyEmailIsValidationError(t *testing.T) {
+	s := newTestStorageWithKV(&mockKV{})
+	_, err := s.ListMembersByEmail(context.Background(), "   ")
+	require.Error(t, err)
+}
+
+// TestStorage_ListMembersByEmail_ListKeysErrorPropagates verifies that an error from
+// ListKeysFiltered is wrapped and returned.
+func TestStorage_ListMembersByEmail_ListKeysErrorPropagates(t *testing.T) {
+	s := newTestStorageWithKV(&mockKV{listErr: errors.New("list keys boom")})
+
+	members, err := s.ListMembersByEmail(context.Background(), "user@example.com")
+	require.Error(t, err)
+	assert.Nil(t, members)
+	assert.Contains(t, err.Error(), "list keys boom")
+}
+
+// TestStorage_ListMembersByEmail_PerKeyGetErrorPropagates verifies that a genuine read error
+// (not a not-found / stale-key) is propagated rather than silently swallowed.
+func TestStorage_ListMembersByEmail_PerKeyGetErrorPropagates(t *testing.T) {
+	const email = "user@example.com"
+	ctx := context.Background()
+	emailHash := emailMember("", email).BuildEmailIndexKey(ctx)
+
+	badKey := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, emailHash, "m-bad")
+
+	s := newTestStorageWithKV(&mockKV{
+		listKeys: []string{badKey},
+		getErrs:  map[string]error{"m-bad": errors.New("nats: connection closed")},
+	})
+
+	_, err := s.ListMembersByEmail(ctx, email)
+	require.Error(t, err, "a genuine read error must be propagated")
+	assert.Contains(t, err.Error(), "nats: connection closed")
+}
+
+// TestStorage_ListMembersByEmail_DeletedMemberSkipped verifies that a not-found Get (stale index
+// key pointing at a member that was deleted) is silently skipped, not returned as an error.
+func TestStorage_ListMembersByEmail_DeletedMemberSkipped(t *testing.T) {
+	const email = "user@example.com"
+	ctx := context.Background()
+	emailHash := emailMember("", email).BuildEmailIndexKey(ctx)
+
+	goodKey := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, emailHash, "m-good")
+	deletedKey := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, emailHash, "m-deleted")
+
+	goodBytes, err := json.Marshal(emailMember("m-good", email))
+	require.NoError(t, err)
+
+	s := newTestStorageWithKV(&mockKV{
+		listKeys:   []string{goodKey, deletedKey},
+		getEntries: map[string]jetstream.KeyValueEntry{"m-good": &mockEntry{value: goodBytes, rev: 1}},
+		getErrs:    map[string]error{"m-deleted": jetstream.ErrKeyNotFound},
+	})
+
+	members, err := s.ListMembersByEmail(ctx, email)
+	require.NoError(t, err, "a not-found (deleted member) must be silently skipped")
+	require.Len(t, members, 1)
+	assert.Equal(t, "m-good", members[0].UID)
+}
+
+// TestStorage_ListMembersByEmail_StaleIndexEntrySkipped verifies the defensive post-read check:
+// when a stale index key (email-change cleanup lagged/failed) points at a member whose email no
+// longer matches the query, that member is skipped. A member whose email still matches is returned.
+func TestStorage_ListMembersByEmail_StaleIndexEntrySkipped(t *testing.T) {
+	const queryEmail = "current@example.com"
+	const staleEmail = "old@example.com"
+	ctx := context.Background()
+	emailHash := emailMember("", queryEmail).BuildEmailIndexKey(ctx)
+
+	matchKey := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, emailHash, "m-match")
+	staleKey := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, emailHash, "m-stale")
+
+	matchBytes, err := json.Marshal(emailMember("m-match", queryEmail))
+	require.NoError(t, err)
+	// The stale member's record now has a DIFFERENT email than the index key it is listed under.
+	staleBytes, err := json.Marshal(emailMember("m-stale", staleEmail))
+	require.NoError(t, err)
+
+	s := newTestStorageWithKV(&mockKV{
+		listKeys: []string{matchKey, staleKey},
+		getEntries: map[string]jetstream.KeyValueEntry{
+			"m-match": &mockEntry{value: matchBytes, rev: 1},
+			"m-stale": &mockEntry{value: staleBytes, rev: 1},
+		},
+	})
+
+	members, err := s.ListMembersByEmail(ctx, queryEmail)
+	require.NoError(t, err)
+	require.Len(t, members, 1, "the stale cross-email entry must be skipped")
+	assert.Equal(t, "m-match", members[0].UID)
+}

--- a/internal/service/committee_member_writer.go
+++ b/internal/service/committee_member_writer.go
@@ -293,6 +293,22 @@ func (uc *committeeWriterOrchestrator) CreateMember(ctx context.Context, member 
 		return nil, errOrgIndex
 	}
 
+	// Step 8d: Write the email→member secondary index so v1-sync-helper can find all committee seats
+	// for a given email via a server-side filtered scan rather than a full bucket scan.
+	// No-op (empty key) for members with no email.
+	emailIndexKey, errEmailIndex := uc.committeeWriter.IndexMemberByEmail(ctx, member)
+	if emailIndexKey != "" {
+		keys = append(keys, emailIndexKey)
+	}
+	if errEmailIndex != nil {
+		slog.ErrorContext(ctx, "failed to write committee member email index",
+			"error", errEmailIndex,
+			"member_uid", member.UID,
+		)
+		rollbackRequired = true
+		return nil, errEmailIndex
+	}
+
 	slog.DebugContext(ctx, "committee member created successfully",
 		"committee_uid", member.CommitteeUID,
 		"member_uid", member.UID,
@@ -461,7 +477,9 @@ func (uc *committeeWriterOrchestrator) UpdateMember(ctx context.Context, member 
 	}
 
 	// Step 4: Handle email changes - validate corporate domain and manage lookup keys
-	emailChanged := existing.Email != member.Email
+	oldEmailHash := existing.BuildEmailIndexKey(ctx)
+	newEmailHash := member.BuildEmailIndexKey(ctx)
+	emailChanged := oldEmailHash != newEmailHash
 	if emailChanged {
 		slog.DebugContext(ctx, "email change detected",
 			"old_email", redaction.RedactEmail(existing.Email),
@@ -480,7 +498,9 @@ func (uc *committeeWriterOrchestrator) UpdateMember(ctx context.Context, member 
 			}
 		}
 
-		// Check if new email already exists in committee (uniqueness check)
+		// Check if new email already exists in committee (uniqueness check).
+		// emailChanged is hash-based so case-only changes never reach this block,
+		// preventing write+stale-delete of identical uniqueness keys.
 		newLookupKey, errMemberExists := uc.committeeWriter.UniqueMember(ctx, member)
 		if errMemberExists != nil {
 			slog.WarnContext(ctx, "member with new email already exists in committee",
@@ -492,9 +512,24 @@ func (uc *committeeWriterOrchestrator) UpdateMember(ctx context.Context, member 
 		}
 		newKeys = append(newKeys, newLookupKey)
 
-		// Mark old lookup key for cleanup
-		oldLookupKey := fmt.Sprintf(constants.KVLookupMemberPrefix, existing.BuildIndexKey(ctx))
-		staleKeys = append(staleKeys, oldLookupKey)
+		// Mark old uniqueness and email-index keys for cleanup.
+		staleKeys = append(staleKeys, fmt.Sprintf(constants.KVLookupMemberPrefix, existing.BuildIndexKey(ctx)))
+
+		newEmailIndexKey, errEmailIndex := uc.committeeWriter.IndexMemberByEmail(ctx, member)
+		if newEmailIndexKey != "" {
+			newKeys = append(newKeys, newEmailIndexKey)
+		}
+		if errEmailIndex != nil {
+			slog.ErrorContext(ctx, "failed to write email index during member update",
+				"error", errEmailIndex,
+				"member_uid", member.UID,
+			)
+			rollbackRequired = true
+			return nil, errEmailIndex
+		}
+		if oldEmailHash != "" {
+			staleKeys = append(staleKeys, fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, oldEmailHash, existing.UID))
+		}
 	}
 
 	// Resolve username from email when auth can map the email to an LFID.
@@ -727,6 +762,11 @@ func (uc *committeeWriterOrchestrator) DeleteMember(ctx context.Context, uid str
 	// delete. Only present when the member had an organization.id; normalized to match the write side.
 	if orgSFID := utils.NormalizeAccountSFID(existing.Organization.ID); orgSFID != "" {
 		indicesToDelete = append(indicesToDelete, fmt.Sprintf(constants.KVLookupMembersByOrganizationPrefix, orgSFID, existing.UID))
+	}
+
+	// Build email→member secondary index key so it is cleaned up on delete.
+	if emailHash := existing.BuildEmailIndexKey(ctx); emailHash != "" {
+		indicesToDelete = append(indicesToDelete, fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, emailHash, existing.UID))
 	}
 
 	slog.DebugContext(ctx, "secondary indices identified for member deletion",

--- a/internal/service/committee_member_writer_test.go
+++ b/internal/service/committee_member_writer_test.go
@@ -25,11 +25,12 @@ import (
 // TestMockCommitteeMemberWriter implements the full CommitteeWriter interface for testing
 type TestMockCommitteeMemberWriter struct {
 	*mock.MockRepository
-	members         map[string]*model.CommitteeMember
-	keys            map[string]string // uniqueness keys
-	customRevisions map[string]uint64 // for testing revision conflicts
-	indexedKeys     []string          // keys written by IndexMemberByCommittee
-	orgIndexErr     error             // when set, IndexMemberByOrganization returns (key, orgIndexErr)
+	members           map[string]*model.CommitteeMember
+	keys              map[string]string // uniqueness keys
+	customRevisions   map[string]uint64 // for testing revision conflicts
+	indexedKeys       []string          // keys written by IndexMemberByCommittee
+	orgIndexErr       error             // when set, IndexMemberByOrganization returns (key, orgIndexErr)
+	uniqueMemberCalls int               // incremented on every UniqueMember call
 
 	mu          sync.Mutex // guards deletedKeys (DeleteMember may run in a background cleanup goroutine)
 	deletedKeys []string   // keys passed to DeleteMember (for asserting rollback / async stale cleanup)
@@ -145,6 +146,7 @@ func (w *TestMockCommitteeMemberWriter) DeleteMember(ctx context.Context, uid st
 }
 
 func (w *TestMockCommitteeMemberWriter) UniqueMember(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	w.uniqueMemberCalls++
 	key := member.BuildIndexKey(ctx)
 
 	// Check if this key already exists
@@ -175,6 +177,16 @@ func (w *TestMockCommitteeMemberWriter) IndexMemberByOrganization(_ context.Cont
 		// before checking the error, so this exercises the rollback cleanup of a partial write.
 		return key, w.orgIndexErr
 	}
+	return key, nil
+}
+
+func (w *TestMockCommitteeMemberWriter) IndexMemberByEmail(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	hash := member.BuildEmailIndexKey(ctx)
+	if hash == "" {
+		return "", nil
+	}
+	key := fmt.Sprintf(constants.KVLookupMembersByEmailPrefix, hash, member.UID)
+	w.indexedKeys = append(w.indexedKeys, key)
 	return key, nil
 }
 
@@ -305,6 +317,10 @@ func (r *TestMockCommitteeReader) ListMembersByCommittee(ctx context.Context, co
 }
 
 func (r *TestMockCommitteeReader) ListMembersByOrganization(_ context.Context, _ string) ([]*model.CommitteeMember, error) {
+	return []*model.CommitteeMember{}, nil
+}
+
+func (r *TestMockCommitteeReader) ListMembersByEmail(_ context.Context, _ string) ([]*model.CommitteeMember, error) {
 	return []*model.CommitteeMember{}, nil
 }
 
@@ -753,11 +769,12 @@ func TestCreateMember_IndexKeyTracked(t *testing.T) {
 	assert.NotEmpty(t, result.UID)
 	assert.Equal(t, "committee-index-test", result.CommitteeUID)
 
-	// IndexMemberByCommittee must have been called exactly once, and the recorded
-	// key must match the expected committee→member index key format.
-	require.Len(t, memberWriter.indexedKeys, 1)
-	expectedKey := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", result.CommitteeUID, result.UID)
-	assert.Equal(t, expectedKey, memberWriter.indexedKeys[0])
+	// IndexMemberByCommittee and IndexMemberByEmail must both have been called; the first indexed key
+	// must be the committee→member key (appended before the email key in CreateMember).
+	require.Len(t, memberWriter.indexedKeys, 2)
+	expectedCommitteeKey := fmt.Sprintf("lookup/committee-members-by-committee/%s.%s", result.CommitteeUID, result.UID)
+	assert.Equal(t, expectedCommitteeKey, memberWriter.indexedKeys[0])
+	assert.Contains(t, memberWriter.indexedKeys[1], "lookup/committee-members-by-email/")
 }
 
 // TestDeleteMember_IndexKeyIncluded verifies that DeleteMember enqueues the
@@ -1009,11 +1026,68 @@ func TestCommitteeWriterOrchestrator_UpdateMember_OrgRemovalCleansUp(t *testing.
 	require.NotNil(t, result)
 
 	// No new organization index entry is written when the member loses its org.
-	assert.Empty(t, memberWriter.indexedKeys, "no organization index entry should be written when the org is removed")
+	// (An email-index entry IS written because the email changed in this scenario — that is correct.)
+	for _, k := range memberWriter.indexedKeys {
+		assert.NotContains(t, k, "lookup/committee-members-by-organization",
+			"no organization index entry should be written when the org is removed")
+	}
 
 	// The old org index entry must still be cleaned up by the background goroutine.
 	assert.Eventually(t, func() bool { return memberWriter.wasDeleted(oldKey) }, 2*time.Second, 10*time.Millisecond,
 		"stale old-organization index entry must be cleaned up after org removal")
+}
+
+// TestCommitteeWriterOrchestrator_UpdateMember_CaseOnlyEmailChange verifies that a case-only
+// email change (same normalized hash) does not write or delete any uniqueness/index keys.
+// Writing a new key identical to the old one and then marking it stale would silently delete the
+// valid entry, breaking the uniqueness invariant.
+func TestCommitteeWriterOrchestrator_UpdateMember_CaseOnlyEmailChange(t *testing.T) {
+	orchestrator, mockRepo, memberWriter := setupMemberWriterTest()
+	orchestrator.userReader = &writerTestUserReader{usernames: map[string]string{"user@example.com": "theuser"}}
+	orchestrator.committeeReader = memberWriter
+
+	committee := &model.Committee{
+		CommitteeBase:     model.CommitteeBase{UID: "committee-123", Name: "Test Committee", Category: "Technical"},
+		CommitteeSettings: &model.CommitteeSettings{BusinessEmailRequired: false},
+	}
+	mockRepo.AddCommittee(committee)
+
+	existing := &model.CommitteeMember{CommitteeMemberBase: model.CommitteeMemberBase{
+		UID: "member-123", CommitteeUID: "committee-123", Email: "user@example.com",
+		FirstName: "Test", LastName: "User",
+		CreatedAt: time.Now().Add(-time.Hour), UpdatedAt: time.Now().Add(-time.Hour),
+	}}
+	mockRepo.AddCommitteeMember("committee-123", existing)
+	memberWriter.members["member-123"] = existing
+	memberWriter.customRevisions["member-123"] = 1
+
+	// Pre-seed the uniqueness key so that a duplicate write would be detected as a conflict.
+	existingIndexKey := existing.BuildIndexKey(context.Background())
+	memberWriter.keys[existingIndexKey] = existing.UID
+
+	// Update with a case-only email change (same normalized form).
+	updated := &model.CommitteeMember{CommitteeMemberBase: model.CommitteeMemberBase{
+		UID: "member-123", CommitteeUID: "committee-123", Email: "USER@EXAMPLE.COM",
+		FirstName: "Test", LastName: "User",
+	}}
+
+	result, err := orchestrator.UpdateMember(context.Background(), updated, 1, false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// UniqueMember must not be called at all for a case-only email change.
+	assert.Equal(t, 0, memberWriter.uniqueMemberCalls,
+		"UniqueMember must not be called for a case-only email change")
+
+	// No new index key should have been written, and the pre-seeded uniqueness key must remain.
+	for _, k := range memberWriter.indexedKeys {
+		assert.NotContains(t, k, "lookup/committee-members/",
+			"case-only email change must not write a new uniqueness key")
+		assert.NotContains(t, k, "lookup/committee-members-by-email/",
+			"case-only email change must not write a new email-index key")
+	}
+	assert.Equal(t, existing.UID, memberWriter.keys[existingIndexKey],
+		"pre-existing uniqueness key must not be deleted by a case-only email change")
 }
 
 func TestCommitteeWriterOrchestrator_validateCorporateEmailDomain(t *testing.T) {

--- a/internal/service/committee_writer_test.go
+++ b/internal/service/committee_writer_test.go
@@ -163,6 +163,11 @@ func (w *TestMockCommitteeWriter) IndexMemberByOrganization(ctx context.Context,
 	return mockWriter.IndexMemberByOrganization(ctx, member)
 }
 
+func (w *TestMockCommitteeWriter) IndexMemberByEmail(ctx context.Context, member *model.CommitteeMember) (string, error) {
+	mockWriter := mock.NewMockCommitteeWriter(w.mock)
+	return mockWriter.IndexMemberByEmail(ctx, member)
+}
+
 // Implement CommitteeInviteWriter interface
 func (w *TestMockCommitteeWriter) CreateInvite(ctx context.Context, invite *model.CommitteeInvite) error {
 	mockWriter := mock.NewMockCommitteeWriter(w.mock)

--- a/pkg/constants/storage.go
+++ b/pkg/constants/storage.go
@@ -49,6 +49,21 @@ const (
 	// one organization: "lookup/committee-members-by-organization/<org_sfid>.*"
 	KVLookupMembersByOrganizationFilter = "lookup/committee-members-by-organization/%s.*"
 
+	// KVLookupMembersByEmailPrefix is the secondary index that maps a member's email address to each
+	// committee membership held by that email. Key pattern:
+	// "lookup/committee-members-by-email/<email_hash>.<member_uid>", Value: <member_uid>.
+	// The email segment is the lowercase SHA-256 hex digest of the normalized email
+	// (strings.TrimSpace + strings.ToLower), making it dot-free and key-safe without exposing the
+	// raw address. The dot-separated suffix is the member UID (a UUID, which never contains dots),
+	// allowing server-side filtered scans via ListKeysFiltered with an "<email_hash>.*" wildcard.
+	// This enables efficient lookups of all committee seats held by an email — used by the
+	// v1-sync-helper to react to alternate-email additions and user merges without a full bucket scan.
+	KVLookupMembersByEmailPrefix = "lookup/committee-members-by-email/%s.%s"
+
+	// KVLookupMembersByEmailFilter is the ListKeysFiltered subject filter for all members with a
+	// given email: "lookup/committee-members-by-email/<email_hash>.*"
+	KVLookupMembersByEmailFilter = "lookup/committee-members-by-email/%s.*"
+
 	// KVLookupInvitePrefix is the prefix for invite lookup keys in the KV store.
 	KVLookupInvitePrefix = "lookup/committee-invites/%s"
 

--- a/scripts/audit-member-usernames/main.go
+++ b/scripts/audit-member-usernames/main.go
@@ -1,0 +1,453 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// audit-member-usernames scans every entry in the committee-members NATS KV
+// bucket and validates each member's stored username against the expected value
+// derived from the v1-mappings and v1-objects secondary indexes.
+//
+// Validation logic mirrors the current v1-sync-helper flow: the expected
+// username is the plain LFX username (username__c) from v1-objects — not the
+// auth0|{id} sub format that older sync-helper code wrote.
+//
+//  1. Look up the member's email in the v1-user.email.* index (v1-mappings bucket)
+//     to resolve a v1 user SFID.
+//  2. Look up the salesforce-merged_user.{sfid} record (v1-objects bucket) to
+//     get the canonical username__c field.
+//  3. Compare with the username currently stored on the committee member.
+//
+// Members written by older sync-helper code may still store an auth0|{username}
+// value. Those are flagged as wrong_username so they can be corrected.
+//
+// This read-only audit surfaces three bug classes introduced by the v1-sync-helper
+// not re-syncing members when:
+//   - A username goes from unset to set on the v1 user record.
+//   - An alternate email is added to v1-objects/v1-mappings linking an email to a user.
+//   - A user merge happens upstream and propagates into v1-objects/v1-mappings.
+//
+// The script makes NO changes. It only reports counts and (with -verbose) details.
+//
+// Usage:
+//
+//	go run ./scripts/audit-member-usernames/main.go [flags]
+//
+// Flags:
+//
+//	-nats-url    NATS server URL (default: $NATS_URL or nats://localhost:4222)
+//	-debug       Enable debug-level logging
+//	-verbose     Print one log line per finding (needs_username / wrong_username)
+//	-limit       Stop after processing this many primary member records (0 = no limit)
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/vmihailenco/msgpack/v5"
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/redaction"
+)
+
+// ── v1-mappings KV key prefixes (must match lfx-v1-sync-helper exactly) ──────
+
+const (
+	kvKeyEmailPrefix   = "v1-user.email."
+	v1MergedUserPrefix = "salesforce-merged_user."
+	tombstoneMarker    = "!del"
+)
+
+// ── NATS KV key normalization (mirrors handlers_users.go in v1-sync-helper) ──
+
+// toKVKey normalises s with TrimSpace → ToLower → NFC, then returns
+// URL-safe base64 (no padding) for use as a NATS KV key segment.
+func toKVKey(s string) string {
+	s = norm.NFC.String(strings.ToLower(strings.TrimSpace(s)))
+	if s == "" {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(s))
+}
+
+// ── Domain types ──────────────────────────────────────────────────────────────
+
+// committeeMember mirrors the fields we care about from CommitteeMemberBase.
+type committeeMember struct {
+	UID           string `json:"uid"`
+	Username      string `json:"username"`
+	Email         string `json:"email"`
+	CommitteeUID  string `json:"committee_uid"`
+	CommitteeName string `json:"committee_name"`
+	FirstName     string `json:"first_name"`
+	LastName      string `json:"last_name"`
+}
+
+// auditStats collects counts for the final report.
+type auditStats struct {
+	Total int // primary member records examined (lookup/* skipped)
+
+	OK               int // username matches expected
+	NeedsUsername    int // should have a username, doesn't
+	WrongUsername    int // has a username but it's wrong
+	StaleHasUsername int // v1 user has no username but member does (stale)
+
+	UserNoV1Username int // v1 user found but has no username; member.Username correctly empty
+	EmailNotInV1     int // no v1 email mapping; can't validate
+
+	NoEmail         int // no email field; skipped
+	LookupKeySkip   int // lookup/* / secondary-index keys; skipped
+	UnmarshalFailed int // failed to decode the committee member record
+	V1LookupFailed  int // failed to read or decode v1-objects for the user's SFID
+}
+
+// ── Flags ──────────────────────────────────────────────────────────────────────
+
+var (
+	natsURL = flag.String("nats-url", getEnvOrDefault("NATS_URL", "nats://localhost:4222"), "NATS server URL")
+	debug   = flag.Bool("debug", false, "Enable debug-level logging")
+	verbose = flag.Bool("verbose", false, "Print one log line per needs_username / wrong_username finding")
+	limit   = flag.Int("limit", 0, "Stop after this many primary member records (0 = no limit, useful for testing)")
+)
+
+// ── Entry point ────────────────────────────────────────────────────────────────
+
+func main() {
+	flag.Parse()
+
+	logLevel := slog.LevelInfo
+	if *debug {
+		logLevel = slog.LevelDebug
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
+	slog.SetDefault(logger)
+
+	if err := run(); err != nil {
+		log.Fatalf("audit failed: %v", err)
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	// ── Connect to NATS ────────────────────────────────────────────────────────
+	slog.InfoContext(ctx, "connecting to NATS")
+	nc, err := nats.Connect(*natsURL,
+		nats.Timeout(10*time.Second),
+		nats.MaxReconnects(3),
+		nats.ReconnectWait(2*time.Second),
+	)
+	if err != nil {
+		return fmt.Errorf("connect to NATS: %w", err)
+	}
+	defer nc.Close()
+	slog.InfoContext(ctx, "connected to NATS")
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return fmt.Errorf("create JetStream context: %w", err)
+	}
+
+	// ── Open KV buckets ────────────────────────────────────────────────────────
+	membersKV, err := js.KeyValue(ctx, constants.KVBucketNameCommitteeMembers)
+	if err != nil {
+		return fmt.Errorf("open %s KV bucket: %w", constants.KVBucketNameCommitteeMembers, err)
+	}
+
+	mappingsKV, err := js.KeyValue(ctx, "v1-mappings")
+	if err != nil {
+		return fmt.Errorf("open v1-mappings KV bucket: %w", err)
+	}
+
+	v1KV, err := js.KeyValue(ctx, "v1-objects")
+	if err != nil {
+		return fmt.Errorf("open v1-objects KV bucket: %w", err)
+	}
+
+	slog.InfoContext(ctx, "opened KV buckets",
+		"members", constants.KVBucketNameCommitteeMembers,
+		"v1-mappings", "v1-mappings",
+		"v1-objects", "v1-objects",
+	)
+
+	// ── List all committee-member keys ─────────────────────────────────────────
+	slog.InfoContext(ctx, "listing committee-member keys…")
+	lister, err := membersKV.ListKeys(ctx)
+	if err != nil {
+		return fmt.Errorf("list committee-member keys: %w", err)
+	}
+	defer func() {
+		if err := lister.Stop(); err != nil {
+			slog.WarnContext(ctx, "error stopping key lister", "error", err)
+		}
+	}()
+
+	// ── Audit loop ─────────────────────────────────────────────────────────────
+	var s auditStats
+
+	for key := range lister.Keys() {
+		// Skip secondary-index / lookup entries.
+		if strings.HasPrefix(key, "lookup/") {
+			s.LookupKeySkip++
+			continue
+		}
+
+		// Apply -limit (only counts primary records, not lookup keys).
+		if *limit > 0 && s.Total >= *limit {
+			break
+		}
+		s.Total++
+
+		// Fetch and decode the committee member record.
+		entry, err := membersKV.Get(ctx, key)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to get member entry", "key", key, "error", err)
+			s.UnmarshalFailed++
+			continue
+		}
+
+		var m committeeMember
+		if err := json.Unmarshal(entry.Value(), &m); err != nil {
+			slog.WarnContext(ctx, "failed to unmarshal member", "key", key, "error", err)
+			s.UnmarshalFailed++
+			continue
+		}
+
+		if s.Total%1000 == 0 {
+			slog.InfoContext(ctx, "audit progress",
+				"examined", s.Total,
+				"needs_username", s.NeedsUsername,
+				"wrong_username", s.WrongUsername,
+			)
+		}
+
+		slog.DebugContext(ctx, "examining member",
+			"uid", m.UID,
+			"email", redaction.RedactEmail(m.Email),
+			"stored_username", redaction.Redact(m.Username),
+		)
+
+		// Members without an email cannot be resolved via the email index.
+		if m.Email == "" {
+			s.NoEmail++
+			slog.DebugContext(ctx, "skipping member: no email", "uid", m.UID)
+			continue
+		}
+
+		// ── Step 1: email → v1 user SFID via v1-mappings ──────────────────────
+		sfid, err := resolveEmailToSFID(ctx, mappingsKV, m.Email)
+		if err != nil {
+			slog.WarnContext(ctx, "error resolving email in v1-mappings",
+				"uid", m.UID, "error", err)
+			s.V1LookupFailed++
+			continue
+		}
+		if sfid == "" {
+			slog.DebugContext(ctx, "email not found in v1-mappings", "uid", m.UID)
+			s.EmailNotInV1++
+			continue
+		}
+
+		// ── Step 2: SFID → username__c via v1-objects ─────────────────────────
+		v1Username, err := resolveV1Username(ctx, v1KV, sfid)
+		if err != nil {
+			slog.WarnContext(ctx, "error reading v1-objects for user",
+				"uid", m.UID, "sfid", sfid, "error", err)
+			s.V1LookupFailed++
+			continue
+		}
+
+		// ── Step 3: compare ───────────────────────────────────────────────────
+		switch {
+		case v1Username == "" && m.Username == "":
+			s.UserNoV1Username++
+			slog.DebugContext(ctx, "v1 user has no username; member correctly empty",
+				"uid", m.UID, "sfid", sfid)
+
+		case v1Username == "" && m.Username != "":
+			s.StaleHasUsername++
+			if *verbose {
+				slog.InfoContext(ctx, "STALE_HAS_USERNAME",
+					"uid", m.UID,
+					"email", redaction.RedactEmail(m.Email),
+					"committee_uid", m.CommitteeUID,
+					"committee_name", m.CommitteeName,
+					"stored_username", redaction.Redact(m.Username),
+					"expected_username", "",
+				)
+			}
+
+		case v1Username != "" && m.Username == "":
+			s.NeedsUsername++
+			if *verbose {
+				slog.InfoContext(ctx, "NEEDS_USERNAME",
+					"uid", m.UID,
+					"email", redaction.RedactEmail(m.Email),
+					"committee_uid", m.CommitteeUID,
+					"committee_name", m.CommitteeName,
+					"stored_username", "",
+					"expected_username", redaction.Redact(v1Username),
+				)
+			}
+
+		case !strings.EqualFold(m.Username, v1Username):
+			s.WrongUsername++
+			if *verbose {
+				slog.InfoContext(ctx, "WRONG_USERNAME",
+					"uid", m.UID,
+					"email", redaction.RedactEmail(m.Email),
+					"committee_uid", m.CommitteeUID,
+					"committee_name", m.CommitteeName,
+					"stored_username", redaction.Redact(m.Username),
+					"expected_username", redaction.Redact(v1Username),
+				)
+			}
+
+		default:
+			s.OK++
+			slog.DebugContext(ctx, "username ok", "uid", m.UID, "username", redaction.Redact(m.Username))
+		}
+	}
+
+	// ── Final report ──────────────────────────────────────────────────────────
+	slog.InfoContext(ctx, "─── AUDIT COMPLETE ───────────────────────────────────────────────")
+	slog.InfoContext(ctx, "primary records examined", "count", s.Total)
+	slog.InfoContext(ctx, "lookup/* keys skipped", "count", s.LookupKeySkip)
+	slog.InfoContext(ctx, "")
+	slog.InfoContext(ctx, "USERNAME CORRECT (ok)", "count", s.OK)
+	slog.InfoContext(ctx, "")
+	slog.InfoContext(ctx, "=== NEEDS FIXING ===")
+	slog.InfoContext(ctx, "NEEDS_USERNAME  (has email→v1 user with username, member.username empty)",
+		"count", s.NeedsUsername)
+	slog.InfoContext(ctx, "WRONG_USERNAME  (member.username doesn't match plain v1 username)",
+		"count", s.WrongUsername)
+	slog.InfoContext(ctx, "STALE_HAS_USERNAME (v1 user has no username, member.username non-empty)",
+		"count", s.StaleHasUsername)
+	slog.InfoContext(ctx, "")
+	slog.InfoContext(ctx, "=== INFORMATIONAL ===")
+	slog.InfoContext(ctx, "USER_NO_V1_USERNAME (v1 user found, but has no username; member.username correctly empty)",
+		"count", s.UserNoV1Username)
+	slog.InfoContext(ctx, "EMAIL_NOT_IN_V1     (no v1-mappings entry for member email; cannot validate)",
+		"count", s.EmailNotInV1)
+	slog.InfoContext(ctx, "NO_EMAIL            (member has no email field; skipped)",
+		"count", s.NoEmail)
+	slog.InfoContext(ctx, "V1_LOOKUP_FAILED    (v1-objects fetch or decode error; skipped)",
+		"count", s.V1LookupFailed)
+	slog.InfoContext(ctx, "UNMARSHAL_FAILED    (committee-member record decode error; skipped)",
+		"count", s.UnmarshalFailed)
+	slog.InfoContext(ctx, "")
+
+	// Machine-readable summary line for easy grep/CI assertion.
+	slog.InfoContext(ctx, "SUMMARY",
+		"total", s.Total,
+		"ok", s.OK,
+		"needs_username", s.NeedsUsername,
+		"wrong_username", s.WrongUsername,
+		"stale_has_username", s.StaleHasUsername,
+		"user_no_v1_username", s.UserNoV1Username,
+		"email_not_in_v1", s.EmailNotInV1,
+		"no_email", s.NoEmail,
+		"v1_lookup_failed", s.V1LookupFailed,
+		"unmarshal_failed", s.UnmarshalFailed,
+	)
+
+	if s.NeedsUsername > 0 || s.WrongUsername > 0 || s.StaleHasUsername > 0 {
+		slog.InfoContext(ctx, "audit found members needing username correction (see counts above); re-run with -verbose for per-member details")
+	} else {
+		slog.InfoContext(ctx, "audit found no username discrepancies in validated members")
+	}
+
+	return nil
+}
+
+// ── v1 lookup helpers ─────────────────────────────────────────────────────────
+
+// resolveEmailToSFID looks up a member email in the v1-user.email.* secondary
+// index (v1-mappings bucket) and returns the user SFID, or "" on miss.
+//
+// The index stores the SFID as a plain string value. Tombstoned entries ("!del")
+// are treated as misses.
+func resolveEmailToSFID(ctx context.Context, mappingsKV jetstream.KeyValue, email string) (string, error) {
+	encoded := toKVKey(email)
+	if encoded == "" {
+		return "", nil
+	}
+	entry, err := mappingsKV.Get(ctx, kvKeyEmailPrefix+encoded)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get email index key: %w", err)
+	}
+	if string(entry.Value()) == tombstoneMarker {
+		return "", nil // tombstoned → treat as miss
+	}
+	return string(entry.Value()), nil
+}
+
+// resolveV1Username fetches the salesforce-merged_user.{sfid} record from the
+// v1-objects bucket and returns the username__c field (raw, as stored in v1).
+//
+// Returns ("", nil) when the user record doesn't exist, is deleted, or has an
+// empty username__c — callers treat that as "no username in v1".
+//
+// v1-objects records are written by Meltano; the vast majority are JSON. A small
+// number of older records may be msgpack-encoded — those are decoded via a msgpack
+// fallback after JSON fails. Only records that fail both decoders are returned as
+// an error and counted as V1LookupFailed in the caller.
+func resolveV1Username(ctx context.Context, v1KV jetstream.KeyValue, sfid string) (string, error) {
+	key := v1MergedUserPrefix + sfid
+	entry, err := v1KV.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get v1-objects entry %q: %w", key, err)
+	}
+
+	// Tombstone check (mirrors isTombstonedMapping in v1-sync-helper).
+	if string(entry.Value()) == tombstoneMarker {
+		return "", nil
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(entry.Value(), &data); err != nil {
+		if msgpackErr := msgpack.Unmarshal(entry.Value(), &data); msgpackErr != nil {
+			return "", fmt.Errorf("decode v1-objects entry %q (json: %w, msgpack: %w)", key, err, msgpackErr)
+		}
+	}
+
+	// Hard-delete flag.
+	if del, ok := data["isdeleted"].(bool); ok && del {
+		return "", nil
+	}
+
+	// WAL soft-delete: _sdc_deleted_at set to a non-empty string or non-nil value.
+	if deletedAt, ok := data["_sdc_deleted_at"]; ok {
+		if s, isStr := deletedAt.(string); (isStr && strings.TrimSpace(s) != "") || (!isStr && deletedAt != nil) {
+			return "", nil
+		}
+	}
+
+	username, _ := data["username__c"].(string)
+	return username, nil
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+func getEnvOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}


### PR DESCRIPTION
## Summary

- Adds `lookup/committee-members-by-email/<sha256(email)>.<member_uid>` as a new secondary index in the `committee-members` KV bucket, enabling efficient lookup of all committee seats held by a given email address via a server-side filtered scan
- Wires the index into the create/update/delete service paths (with email-hash-change guard on update to avoid deleting valid entries on case-only changes) and adds defensive stale-entry consistency checks on reads
- Adds `committee-cli sync members-by-email-index` backfill subcommand (`--dry-run=true` default) to populate the index for existing members

This unblocks the v1-sync-helper fix for the bug where alternate-email additions and user merges fail to update committee member usernames — previously requiring a full bucket scan to find affected members.

Also included: `scripts/audit-member-usernames` (read-only audit script from Phase A), msgpack dependency for v1-objects decoding.

Fixes: LFXV2-2521

🤖 Generated with [Claude Code](https://claude.com/claude-code)