### PR TITLE
[LFXV2-1836] feat: add project allowlist gate for committee notification emails

### DIFF
--- a/charts/lfx-v2-committee-service/values.yaml
+++ b/charts/lfx-v2-committee-service/values.yaml
@@ -474,6 +474,11 @@ app:
     # JWT_AUDIENCE — mirrors .Values.app.audience (used by ruleset.yaml).
     JWT_AUDIENCE:
       value: lfx-v2-committee-service
+    # EMAIL_NOTIFICATION_PROJECT_ALLOWLIST restricts committee notification emails to
+    # a comma-separated list of project slugs (e.g. "aaif,test-project-group-it").
+    # Empty or unset means all projects receive notifications (no restriction).
+    EMAIL_NOTIFICATION_PROJECT_ALLOWLIST:
+      value: ""
     # EMAILS_ENABLED gates outbound role-notification emails to LFID users.
     EMAILS_ENABLED:
       value: "false"

--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -457,6 +458,23 @@ func InviteSenderImpl(ctx context.Context) port.InviteSender {
 	return nil
 }
 
+// NotificationProjectAllowlist parses EMAIL_NOTIFICATION_PROJECT_ALLOWLIST into a
+// normalised slice of project slugs. An empty or unset value returns nil (allow all).
+func NotificationProjectAllowlist() []string {
+	raw := os.Getenv("EMAIL_NOTIFICATION_PROJECT_ALLOWLIST")
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	slugs := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.ToLower(strings.TrimSpace(p)); s != "" {
+			slugs = append(slugs, s)
+		}
+	}
+	return slugs
+}
+
 // LFXSelfServeBaseURL derives the LFX Self-Serve base URL from environment variables.
 // LFX_SELF_SERVE_BASE_URL takes precedence; otherwise it falls back to LFX_ENVIRONMENT.
 // When LFX_ENVIRONMENT is unset, prod is assumed (safe default for deployed environments).
@@ -862,6 +880,7 @@ func QueueSubscriptions(ctx context.Context, committeeReader port.CommitteeReade
 			usecaseSvc.WithUserReaderForMessageHandler(UserReaderImpl(ctx)),
 			usecaseSvc.WithProjectReaderForMessageHandler(ProjectRetrieverImpl(ctx)),
 			usecaseSvc.WithLinkReaderForMessageHandler(CommitteeLinkReaderWriterImpl(ctx)),
+			usecaseSvc.WithNotificationProjectAllowlistForMessageHandler(NotificationProjectAllowlist()),
 		),
 	}
 

--- a/cmd/committee-api/service/providers_test.go
+++ b/cmd/committee-api/service/providers_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNotificationProjectAllowlist(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{name: "unset returns nil", value: "", want: nil},
+		{name: "single slug", value: "aaif", want: []string{"aaif"}},
+		{name: "multiple slugs", value: "aaif,pytorch", want: []string{"aaif", "pytorch"}},
+		{name: "whitespace trimmed", value: " aaif , pytorch ", want: []string{"aaif", "pytorch"}},
+		{name: "embedded empties dropped", value: "aaif,,pytorch,", want: []string{"aaif", "pytorch"}},
+		{name: "mixed-case normalized", value: "AAIF,PyTorch", want: []string{"aaif", "pytorch"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("EMAIL_NOTIFICATION_PROJECT_ALLOWLIST", tt.value)
+			assert.Equal(t, tt.want, NotificationProjectAllowlist())
+		})
+	}
+}
+
 func TestLFXSelfServeBaseURL(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/service/application_notification_handler.go
+++ b/internal/service/application_notification_handler.go
@@ -62,6 +62,13 @@ func (m *messageHandlerOrchestrator) HandleCommitteeApplicationSubmitted(ctx con
 		return nil, nil
 	}
 
+	// Project allowlist gate.
+	if !m.notificationsAllowedForProject(committee.ProjectSlug) {
+		slog.DebugContext(ctx, "skipping application submitted notification — project not in allowlist",
+			"committee_uid", application.CommitteeUID, "project_slug", committee.ProjectSlug)
+		return nil, nil
+	}
+
 	writers := m.collectCommitteeWriters(ctx, committee)
 	if len(writers) == 0 {
 		slog.DebugContext(ctx, "no LFID writers to notify for application submitted",
@@ -175,6 +182,13 @@ func (m *messageHandlerOrchestrator) HandleCommitteeApplicationUpdated(ctx conte
 	if err != nil {
 		slog.WarnContext(ctx, "failed to load committee for application updated notification",
 			"error", err, "committee_uid", application.CommitteeUID)
+		return nil, nil
+	}
+
+	// Project allowlist gate.
+	if !m.notificationsAllowedForProject(committee.ProjectSlug) {
+		slog.DebugContext(ctx, "skipping application updated notification — project not in allowlist",
+			"committee_uid", application.CommitteeUID, "project_slug", committee.ProjectSlug)
 		return nil, nil
 	}
 

--- a/internal/service/application_notification_handler_test.go
+++ b/internal/service/application_notification_handler_test.go
@@ -341,3 +341,90 @@ func TestHandleCommitteeApplicationUpdated(t *testing.T) {
 		require.NoError(t, err) // best-effort: error must not propagate
 	})
 }
+
+func TestApplicationNotificationsProjectAllowlist(t *testing.T) {
+	repoAllowlisted := mock.NewMockRepository()
+	repoAllowlisted.AddCommittee(&model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:         "committee-allow",
+			Name:        "TSC",
+			ProjectUID:  "project-allow",
+			ProjectName: "AAIF",
+			ProjectSlug: "aaif",
+		},
+		CommitteeSettings: &model.CommitteeSettings{
+			UID:     "committee-allow",
+			Writers: []model.CommitteeUser{{Username: "writer1", Email: "writer1@example.com", Name: "Writer One"}},
+		},
+	})
+
+	repoBlocked := mock.NewMockRepository()
+	repoBlocked.AddCommittee(&model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:         "committee-block",
+			Name:        "TSC",
+			ProjectUID:  "project-block",
+			ProjectName: "PyTorch",
+			ProjectSlug: "pytorch",
+		},
+		CommitteeSettings: &model.CommitteeSettings{
+			UID:     "committee-block",
+			Writers: []model.CommitteeUser{{Username: "writer1", Email: "writer1@example.com", Name: "Writer One"}},
+		},
+	})
+
+	readerAllow := NewCommitteeReaderOrchestrator(WithCommitteeReader(mock.NewMockCommitteeReader(repoAllowlisted)))
+	readerBlock := NewCommitteeReaderOrchestrator(WithCommitteeReader(mock.NewMockCommitteeReader(repoBlocked)))
+
+	t.Run("submitted — allowlisted project sends notification", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{committeeReader: readerAllow, emailSender: sender}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		app := &model.CommitteeApplication{CommitteeUID: "committee-allow", ApplicantEmail: "a@example.com"}
+		msg := newMockTransportMessenger(constants.CommitteeApplicationSubmittedSubject, buildApplicationSubmittedPayload(t, app))
+		_, err := h.HandleCommitteeApplicationSubmitted(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 1)
+	})
+
+	t.Run("submitted — non-allowlisted project suppressed", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{committeeReader: readerBlock, emailSender: sender}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		app := &model.CommitteeApplication{CommitteeUID: "committee-block", ApplicantEmail: "a@example.com"}
+		msg := newMockTransportMessenger(constants.CommitteeApplicationSubmittedSubject, buildApplicationSubmittedPayload(t, app))
+		_, err := h.HandleCommitteeApplicationSubmitted(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 0)
+	})
+
+	t.Run("updated approved — allowlisted project sends notification", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			committeeReader:     readerAllow,
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		app := &model.CommitteeApplication{CommitteeUID: "committee-allow", ApplicantEmail: "a@example.com", Status: "approved"}
+		msg := newMockTransportMessenger(constants.CommitteeApplicationUpdatedSubject, buildApplicationUpdatedPayload(t, app))
+		_, err := h.HandleCommitteeApplicationUpdated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 1)
+	})
+
+	t.Run("updated approved — non-allowlisted project suppressed", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			committeeReader:     readerBlock,
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		app := &model.CommitteeApplication{CommitteeUID: "committee-block", ApplicantEmail: "a@example.com", Status: "approved"}
+		msg := newMockTransportMessenger(constants.CommitteeApplicationUpdatedSubject, buildApplicationUpdatedPayload(t, app))
+		_, err := h.HandleCommitteeApplicationUpdated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 0)
+	})
+}

--- a/internal/service/document_notification_handler.go
+++ b/internal/service/document_notification_handler.go
@@ -132,6 +132,12 @@ func (m *messageHandlerOrchestrator) handleContentCreated(ctx context.Context, i
 		return
 	}
 
+	if !m.notificationsAllowedForProject(committee.ProjectSlug) {
+		slog.DebugContext(ctx, "skipping content notification — project not in allowlist",
+			"committee_uid", item.committeeUID, "project_slug", committee.ProjectSlug)
+		return
+	}
+
 	recipients := m.collectCommitteeRecipients(ctx, item.committeeUID)
 	if len(recipients) == 0 {
 		slog.DebugContext(ctx, "no LFID recipients for content notification", "committee_uid", item.committeeUID)

--- a/internal/service/document_notification_handler_test.go
+++ b/internal/service/document_notification_handler_test.go
@@ -292,6 +292,71 @@ func TestHandleCommitteeLinkCreated(t *testing.T) {
 	})
 }
 
+func TestHandleContentCreatedProjectAllowlist(t *testing.T) {
+	buildRepo := func(committeeUID, projectSlug string) CommitteeReader {
+		r := mock.NewMockRepository()
+		r.AddCommittee(&model.Committee{
+			CommitteeBase: model.CommitteeBase{
+				UID:         committeeUID,
+				Name:        "Test Committee",
+				ProjectSlug: projectSlug,
+			},
+			CommitteeSettings: &model.CommitteeSettings{
+				UID: committeeUID,
+				Writers: []model.CommitteeUser{
+					{Username: "writer1", Email: "writer1@example.com", Name: "Writer One"},
+				},
+			},
+		})
+		return NewCommitteeReaderOrchestrator(WithCommitteeReader(mock.NewMockCommitteeReader(r)))
+	}
+
+	doc := func(committeeUID string) *model.CommitteeDocument {
+		return &model.CommitteeDocument{UID: "d1", CommitteeUID: committeeUID, Name: "Doc", FileName: "doc.pdf"}
+	}
+
+	t.Run("allowlisted project sends content notification", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			committeeReader:     buildRepo("c-allowed", "aaif"),
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		msg := newMockTransportMessenger(constants.CommitteeDocumentCreatedSubject, buildDocumentCreatedPayload(t, doc("c-allowed")))
+		_, err := h.HandleCommitteeDocumentCreated(context.Background(), msg)
+		assert.NoError(t, err)
+		assert.Len(t, sender.calls, 1, "allowlisted project should send notification")
+	})
+
+	t.Run("non-allowlisted project suppresses content notification", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			committeeReader:     buildRepo("c-blocked", "other-project"),
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		msg := newMockTransportMessenger(constants.CommitteeDocumentCreatedSubject, buildDocumentCreatedPayload(t, doc("c-blocked")))
+		_, err := h.HandleCommitteeDocumentCreated(context.Background(), msg)
+		assert.NoError(t, err)
+		assert.Empty(t, sender.calls, "non-allowlisted project should suppress notification")
+	})
+
+	t.Run("empty allowlist sends to all projects", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			committeeReader:     buildRepo("c-any", "any-project"),
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		msg := newMockTransportMessenger(constants.CommitteeDocumentCreatedSubject, buildDocumentCreatedPayload(t, doc("c-any")))
+		_, err := h.HandleCommitteeDocumentCreated(context.Background(), msg)
+		assert.NoError(t, err)
+		assert.Len(t, sender.calls, 1, "empty allowlist should send to all projects")
+	})
+}
+
 func TestIsSafeURL(t *testing.T) {
 	tests := []struct {
 		url  string

--- a/internal/service/document_notification_handler_test.go
+++ b/internal/service/document_notification_handler_test.go
@@ -315,46 +315,33 @@ func TestHandleContentCreatedProjectAllowlist(t *testing.T) {
 		return &model.CommitteeDocument{UID: "d1", CommitteeUID: committeeUID, Name: "Doc", FileName: "doc.pdf"}
 	}
 
-	t.Run("allowlisted project sends content notification", func(t *testing.T) {
-		sender := &mockEmailSender{}
-		h := &messageHandlerOrchestrator{
-			committeeReader:     buildRepo("c-allowed", "aaif"),
-			emailSender:         sender,
-			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
-		}
-		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
-		msg := newMockTransportMessenger(constants.CommitteeDocumentCreatedSubject, buildDocumentCreatedPayload(t, doc("c-allowed")))
-		_, err := h.HandleCommitteeDocumentCreated(context.Background(), msg)
-		assert.NoError(t, err)
-		assert.Len(t, sender.calls, 1, "allowlisted project should send notification")
-	})
+	tests := []struct {
+		name          string
+		committeeUID  string
+		projectSlug   string
+		allowlist     []string
+		expectedCalls int
+	}{
+		{"allowlisted project sends content notification", "c-allowed", "aaif", []string{"aaif"}, 1},
+		{"non-allowlisted project suppresses content notification", "c-blocked", "other-project", []string{"aaif"}, 0},
+		{"empty allowlist sends to all projects", "c-any", "any-project", nil, 1},
+	}
 
-	t.Run("non-allowlisted project suppresses content notification", func(t *testing.T) {
-		sender := &mockEmailSender{}
-		h := &messageHandlerOrchestrator{
-			committeeReader:     buildRepo("c-blocked", "other-project"),
-			emailSender:         sender,
-			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
-		}
-		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
-		msg := newMockTransportMessenger(constants.CommitteeDocumentCreatedSubject, buildDocumentCreatedPayload(t, doc("c-blocked")))
-		_, err := h.HandleCommitteeDocumentCreated(context.Background(), msg)
-		assert.NoError(t, err)
-		assert.Empty(t, sender.calls, "non-allowlisted project should suppress notification")
-	})
-
-	t.Run("empty allowlist sends to all projects", func(t *testing.T) {
-		sender := &mockEmailSender{}
-		h := &messageHandlerOrchestrator{
-			committeeReader:     buildRepo("c-any", "any-project"),
-			emailSender:         sender,
-			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
-		}
-		msg := newMockTransportMessenger(constants.CommitteeDocumentCreatedSubject, buildDocumentCreatedPayload(t, doc("c-any")))
-		_, err := h.HandleCommitteeDocumentCreated(context.Background(), msg)
-		assert.NoError(t, err)
-		assert.Len(t, sender.calls, 1, "empty allowlist should send to all projects")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sender := &mockEmailSender{}
+			h := &messageHandlerOrchestrator{
+				committeeReader:     buildRepo(tt.committeeUID, tt.projectSlug),
+				emailSender:         sender,
+				lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+			}
+			WithNotificationProjectAllowlistForMessageHandler(tt.allowlist)(h)
+			msg := newMockTransportMessenger(constants.CommitteeDocumentCreatedSubject, buildDocumentCreatedPayload(t, doc(tt.committeeUID)))
+			_, err := h.HandleCommitteeDocumentCreated(context.Background(), msg)
+			assert.NoError(t, err)
+			assert.Len(t, sender.calls, tt.expectedCalls)
+		})
+	}
 }
 
 func TestIsSafeURL(t *testing.T) {

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -42,6 +42,9 @@ type messageHandlerOrchestrator struct {
 	linkReader                  port.CommitteeLinkReader
 	lfxSelfServeBaseURL         string
 	weeklyBriefGenerator        GroupWeeklyBriefGenerator
+	// notificationProjectAllowlist, when non-empty, restricts committee notification
+	// emails to committees whose project slug is in this set. Empty means all projects.
+	notificationProjectAllowlist map[string]struct{}
 }
 
 // messageHandlerOrchestratorOption defines a function type for setting options
@@ -124,6 +127,32 @@ func WithGroupWeeklyBriefGeneratorForMessageHandler(generator GroupWeeklyBriefGe
 	return func(m *messageHandlerOrchestrator) {
 		m.weeklyBriefGenerator = generator
 	}
+}
+
+// WithNotificationProjectAllowlistForMessageHandler restricts committee notification
+// emails to the given project slugs. An empty slice means all projects are allowed
+// (preserving the default behaviour when the env var is unset).
+func WithNotificationProjectAllowlistForMessageHandler(slugs []string) messageHandlerOrchestratorOption {
+	return func(m *messageHandlerOrchestrator) {
+		if len(slugs) == 0 {
+			m.notificationProjectAllowlist = nil
+			return
+		}
+		m.notificationProjectAllowlist = make(map[string]struct{}, len(slugs))
+		for _, s := range slugs {
+			m.notificationProjectAllowlist[strings.ToLower(s)] = struct{}{}
+		}
+	}
+}
+
+// notificationsAllowedForProject reports whether committee notification emails may
+// be sent for the given project slug. An empty allowlist means all projects are allowed.
+func (m *messageHandlerOrchestrator) notificationsAllowedForProject(projectSlug string) bool {
+	if len(m.notificationProjectAllowlist) == 0 {
+		return true
+	}
+	_, ok := m.notificationProjectAllowlist[strings.ToLower(projectSlug)]
+	return ok
 }
 
 // HandleGenerateWeeklyBriefRequested reacts to generate-requested stream events.
@@ -608,6 +637,14 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberCreated(ctx context.Co
 		return nil, nil
 	}
 
+	// Project allowlist gate: when a slug allowlist is configured, only send
+	// notifications for committees belonging to those projects.
+	if !m.notificationsAllowedForProject(member.ProjectSlug) {
+		slog.DebugContext(ctx, "skipping member notification — project not in allowlist",
+			"committee_uid", member.CommitteeUID, "project_slug", member.ProjectSlug)
+		return nil, nil
+	}
+
 	if member.Email == "" {
 		slog.WarnContext(ctx, "skipping member notification — no email address",
 			"committee_uid", member.CommitteeUID, "username", redaction.Redact(member.Username))
@@ -736,6 +773,27 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 		slog.DebugContext(ctx, "no writer/auditor changes — skipping settings notification",
 			"committee_uid", data.CommitteeUID)
 		return nil, nil
+	}
+
+	// Project allowlist gate: when a slug allowlist is configured, load the committee
+	// to obtain its project slug and gate before sending any per-user notifications.
+	if len(m.notificationProjectAllowlist) > 0 {
+		if m.committeeReader == nil {
+			slog.DebugContext(ctx, "committee reader not configured — skipping settings notification",
+				"committee_uid", data.CommitteeUID)
+			return nil, nil
+		}
+		committee, _, err := m.committeeReader.GetBase(ctx, data.CommitteeUID)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to load committee for settings notification project gate",
+				"error", err, "committee_uid", data.CommitteeUID)
+			return nil, nil
+		}
+		if !m.notificationsAllowedForProject(committee.ProjectSlug) {
+			slog.DebugContext(ctx, "skipping settings notification — project not in allowlist",
+				"committee_uid", data.CommitteeUID, "project_slug", committee.ProjectSlug)
+			return nil, nil
+		}
 	}
 
 	committeeURL := buildCommitteeURL(m.lfxSelfServeBaseURL, data.CommitteeUID)

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -1441,6 +1441,12 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberDeleted(ctx context.Co
 		return nil, nil
 	}
 
+	if !m.notificationsAllowedForProject(member.ProjectSlug) {
+		slog.DebugContext(ctx, "skipping member-deleted notification — project not in allowlist",
+			"committee_uid", member.CommitteeUID, "project_slug", member.ProjectSlug)
+		return nil, nil
+	}
+
 	if m.emailSender == nil {
 		slog.DebugContext(ctx, "email sender not configured — skipping member-deleted notification")
 		return nil, nil

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2627,3 +2627,176 @@ func mustMarshalGetProjectJSON(t *testing.T, v interface{}) []byte {
 	require.NoError(t, err)
 	return b
 }
+
+func TestNotificationsAllowedForProject(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowlist   []string
+		projectSlug string
+		want        bool
+	}{
+		{"empty allowlist allows all", nil, "any-slug", true},
+		{"empty allowlist allows empty slug", nil, "", true},
+		{"exact match allowed", []string{"aaif"}, "aaif", true},
+		{"multiple slugs match", []string{"aaif", "test-project-group-it"}, "test-project-group-it", true},
+		{"slug not in list suppressed", []string{"aaif"}, "pytorch", false},
+		{"empty slug not in non-empty list suppressed", []string{"aaif"}, "", false},
+		{"case insensitive match", []string{"aaif"}, "AAIF", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &messageHandlerOrchestrator{}
+			WithNotificationProjectAllowlistForMessageHandler(tt.allowlist)(h)
+			assert.Equal(t, tt.want, h.notificationsAllowedForProject(tt.projectSlug))
+		})
+	}
+}
+
+func TestHandleCommitteeMemberCreatedProjectAllowlist(t *testing.T) {
+	memberInAllowlist := &model.CommitteeMember{
+		CommitteeMemberBase: model.CommitteeMemberBase{
+			UID:           "m-1",
+			Username:      "alice",
+			Email:         "alice@example.com",
+			FirstName:     "Alice",
+			CommitteeUID:  "c-1",
+			CommitteeName: "TSC",
+			ProjectSlug:   "aaif",
+		},
+	}
+	memberOutsideAllowlist := &model.CommitteeMember{
+		CommitteeMemberBase: model.CommitteeMemberBase{
+			UID:           "m-2",
+			Username:      "bob",
+			Email:         "bob@example.com",
+			FirstName:     "Bob",
+			CommitteeUID:  "c-2",
+			CommitteeName: "TSC",
+			ProjectSlug:   "pytorch",
+		},
+	}
+
+	t.Run("allowlisted project slug — email sent", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		msg := newMockTransportMessenger(constants.CommitteeMemberCreatedSubject, buildMemberCreatedPayload(t, memberInAllowlist))
+		_, err := h.HandleCommitteeMemberCreated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 1, "email should be sent for allowlisted project")
+	})
+
+	t.Run("project slug not in allowlist — email suppressed", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		msg := newMockTransportMessenger(constants.CommitteeMemberCreatedSubject, buildMemberCreatedPayload(t, memberOutsideAllowlist))
+		_, err := h.HandleCommitteeMemberCreated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 0, "email should be suppressed for non-allowlisted project")
+	})
+
+	t.Run("empty allowlist — email sent for any project", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		// no allowlist set
+		msg := newMockTransportMessenger(constants.CommitteeMemberCreatedSubject, buildMemberCreatedPayload(t, memberOutsideAllowlist))
+		_, err := h.HandleCommitteeMemberCreated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 1, "email should be sent when allowlist is empty")
+	})
+
+	t.Run("allowlist case-insensitive match", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"AAIF"})(h)
+		msg := newMockTransportMessenger(constants.CommitteeMemberCreatedSubject, buildMemberCreatedPayload(t, memberInAllowlist))
+		_, err := h.HandleCommitteeMemberCreated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 1, "allowlist matching should be case-insensitive")
+	})
+}
+
+func TestHandleCommitteeSettingsUpdatedProjectAllowlist(t *testing.T) {
+	alice := model.CommitteeUser{Username: "alice", Email: "alice@example.com", Name: "Alice"}
+
+	buildPayloadWithUID := func(t *testing.T, committeeUID string, writers []model.CommitteeUser) []byte {
+		t.Helper()
+		return buildSettingsUpdatedPayload(t, &model.CommitteeSettingsUpdateEventData{
+			CommitteeUID:  committeeUID,
+			CommitteeName: "TSC",
+			Settings:      &model.CommitteeSettings{Writers: writers},
+			OldSettings:   &model.CommitteeSettings{},
+		})
+	}
+
+	repo := mock.NewMockRepository()
+	repo.AddCommittee(&model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:         "c-allowlisted",
+			Name:        "TSC",
+			ProjectSlug: "aaif",
+		},
+	})
+	repo.AddCommittee(&model.Committee{
+		CommitteeBase: model.CommitteeBase{
+			UID:         "c-blocked",
+			Name:        "TSC",
+			ProjectSlug: "pytorch",
+		},
+	})
+	reader := NewCommitteeReaderOrchestrator(WithCommitteeReader(mock.NewMockCommitteeReader(repo)))
+
+	t.Run("allowlisted project — email sent", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			emailSender:         sender,
+			committeeReader:     reader,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		msg := newMockTransportMessenger(constants.CommitteeSettingsUpdatedSubject, buildPayloadWithUID(t, "c-allowlisted", []model.CommitteeUser{alice}))
+		_, err := h.HandleCommitteeSettingsUpdated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 1, "email should be sent for allowlisted project")
+	})
+
+	t.Run("project not in allowlist — email suppressed", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			emailSender:         sender,
+			committeeReader:     reader,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		WithNotificationProjectAllowlistForMessageHandler([]string{"aaif"})(h)
+		msg := newMockTransportMessenger(constants.CommitteeSettingsUpdatedSubject, buildPayloadWithUID(t, "c-blocked", []model.CommitteeUser{alice}))
+		_, err := h.HandleCommitteeSettingsUpdated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 0, "email should be suppressed for non-allowlisted project")
+	})
+
+	t.Run("empty allowlist — email sent for any project", func(t *testing.T) {
+		sender := &mockEmailSender{}
+		h := &messageHandlerOrchestrator{
+			emailSender:         sender,
+			lfxSelfServeBaseURL: "https://app.dev.lfx.dev",
+		}
+		// no allowlist — no committeeReader needed; gate is skipped entirely
+		msg := newMockTransportMessenger(constants.CommitteeSettingsUpdatedSubject, buildPayloadWithUID(t, "c-blocked", []model.CommitteeUser{alice}))
+		_, err := h.HandleCommitteeSettingsUpdated(context.Background(), msg)
+		require.NoError(t, err)
+		assert.Len(t, sender.calls, 1, "email should be sent when allowlist is empty")
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `EMAIL_NOTIFICATION_PROJECT_ALLOWLIST` env var (comma-separated project slugs). When set, all committee notification emails (member added, settings updated, application submitted/updated) are restricted to the listed projects. Empty or unset = allow all (preserves current behaviour in dev/test).
- Applied consistently across all four notification handlers: `HandleCommitteeMemberCreated`, `HandleCommitteeSettingsUpdated`, `HandleCommitteeApplicationSubmitted`, `HandleCommitteeApplicationUpdated`.
- Actual slug values (`aaif`, `test-project-group-it`) to be configured per-environment in `lfx-v2-argocd` — the `values.yaml` default is empty (allow all).

## Ticket

[LFXV2-1836](https://linuxfoundation.atlassian.net/browse/LFXV2-1836)

## Context

Users added to a committee in PCC (V1 UI) were receiving LFX Self-Serve notification emails. Per product decision (Slack C092UM0JHS9), committee emails should be restricted to specific allowlisted projects until wider GA (Q3/Q4).

This is Part A of a two-PR fix. Part B (suppressing emails for V1/PCC-synced member adds via `skip_notification`) is in `lfx-v1-sync-helper`.

## Net behaviour after this change

| Origin | Project allowlisted | Email sent? |
|---|---|---|
| V2 Self-Serve member add | yes | ✅ yes |
| V2 Self-Serve member add | no | ❌ no (project gate) |
| V1/PCC sync member add | yes | ❌ no (see Part B PR) |
| V1/PCC sync member add | no | ❌ no (both gates) |

At GA: clear `EMAIL_NOTIFICATION_PROJECT_ALLOWLIST` in argocd to send to all projects.

## Protected file callout

- `charts/lfx-v2-committee-service/values.yaml`: adds `EMAIL_NOTIFICATION_PROJECT_ALLOWLIST` with empty default. Actual values set in `lfx-v2-argocd` per environment.

## Test plan

- [ ] `make fmt && make lint && make test` — new table-driven gate tests pass
- [ ] `make build && make build-cli`
- [ ] With `EMAIL_NOTIFICATION_PROJECT_ALLOWLIST` unset → emails send for all projects (no regression)
- [ ] With `EMAIL_NOTIFICATION_PROJECT_ALLOWLIST=aaif` → only `aaif` committees send; others suppress
- [ ] Member-created event with `skip_notification=true` suppresses regardless of project

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1836]: https://linuxfoundation.atlassian.net/browse/LFXV2-1836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ