### PR TITLE
WIP: feat(LFXV2-2521): add user-email event consumer and alternate_email_added handler

### DIFF
--- a/.claude/skills/committee-service-dev/references/nats-messaging.md
+++ b/.claude/skills/committee-service-dev/references/nats-messaging.md
@@ -26,6 +26,7 @@ Repo-local inventory of NATS subjects, queue groups, KV buckets, Object Stores, 
 ```go
 "lfx.mailing-list-api.committee_mailing_list.changed" // handled by internal/service/message_handler.go (updates has_mailing_list + re-index)
 "lfx.invite-service.invite_accepted"                  // published by the invite service after it processes a self-serve acceptance (enriched event embedding the invite record); handled by HandleInviteAccepted (owned by lfx-v2-invite-service: inviteapi.InviteServiceAcceptedSubject)
+"lfx.user-email.changed"                              // consumed via durable JetStream (user-email-events stream, consumer committee-service-user-email-sync); payload: model.UserEmailEvent {type, email, timestamp}; producers: lfx-v1-sync-helper and others; alternate_email_added → promotes all email-only seats matching the address to the resolved LFID username (ListMembersByEmail + UsernameByEmail + UpdateMember); other event types are no-ops pending defined semantics
 ```
 
 ### Self-consumed event subjects
@@ -124,6 +125,17 @@ split and per-sub-resource bucketing follow the native service pattern.
   `committee-service-weekly-brief-generate` durable consumer
   (`ConsumerNameWeeklyBriefGenerate`), which runs the async brief generation
   (source gather → LLM → finalize) after a generate is requested.
+- `user-email-events` (constant `StreamNameUserEmailEvents`): durable stream that
+  captures `lfx.user-email.*`. Consumed by the `committee-service-user-email-sync`
+  durable consumer (`ConsumerNameUserEmailSync`). Payload: `model.UserEmailEvent`.
+  Provisioned by this chart; publishers include lfx-v1-sync-helper. Handler:
+  `HandleUserEmailChanged` → `reconcileUsernamesForEmail` in
+  `internal/service/message_handler.go`. For `alternate_email_added`: uses the
+  by-email secondary index (`ListMembersByEmail`) to find email-only seats, resolves
+  the LFID username once via `UsernameByEmail`, and promotes each seat via
+  `UpdateMember` (with `contextWithSkipMemberUsernameEmailResolution` + conflict
+  retry — mirrors `enrichInvitedCommitteeMember`). Other event types are no-ops
+  pending defined teardown semantics.
 
 See `charts/lfx-v2-committee-service/templates/nats-streams.yaml` and
 `charts/lfx-v2-committee-service/values.yaml` for chart wiring.

--- a/charts/lfx-v2-committee-service/templates/nats-streams.yaml
+++ b/charts/lfx-v2-committee-service/templates/nats-streams.yaml
@@ -29,6 +29,34 @@ spec:
   duplicateWindow: 2m
 {{- end }}
 ---
+{{- if .Values.nats.stream_user_email_events.creation }}
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: {{ .Values.nats.stream_user_email_events.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.nats.stream_user_email_events.keep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+spec:
+  name: {{ .Values.nats.stream_user_email_events.name }}
+  subjects:
+  {{- range .Values.nats.stream_user_email_events.subjects }}
+    - {{ . }}
+  {{- end }}
+  storage: {{ .Values.nats.stream_user_email_events.storage }}
+  retention: {{ .Values.nats.stream_user_email_events.retention }}
+  maxAge: {{ .Values.nats.stream_user_email_events.maxAge }}
+  maxBytes: {{ .Values.nats.stream_user_email_events.maxBytes }}
+  maxMsgs: {{ .Values.nats.stream_user_email_events.maxMsgs }}
+  replicas: {{ .Values.nats.stream_user_email_events.replicas }}
+  compression: {{ .Values.nats.stream_user_email_events.compression }}
+  duplicateWindow: 2m
+{{- end }}
+---
 {{- if .Values.nats.stream_weekly_brief_events.creation }}
 apiVersion: jetstream.nats.io/v1beta2
 kind: Stream

--- a/charts/lfx-v2-committee-service/values.yaml
+++ b/charts/lfx-v2-committee-service/values.yaml
@@ -391,6 +391,35 @@ nats:
     # compression reduces storage cost for JSON payloads
     compression: s2
 
+  # stream_user_email_events is the JetStream stream for upstream user-email change events.
+  # Subjects capture identity changes (alternate email added/removed, LFID user created/deleted)
+  # published by lfx-v1-sync-helper and other identity producers. The committee service
+  # consumes this stream to trigger username re-resolution for affected member seats.
+  stream_user_email_events:
+    # creation controls whether the stream CRD is provisioned by this chart
+    creation: true
+    # keep preserves the stream during helm uninstall to avoid event loss
+    keep: true
+    # name is the NATS stream name
+    name: user-email-events
+    # subjects captures all user-email change events from identity producers
+    subjects:
+      - lfx.user-email.*
+    # storage is the storage backend for the stream
+    storage: file
+    # retention keeps messages up to maxAge; they are not accumulated indefinitely
+    retention: limits
+    # maxAge is the maximum age of a message before it is removed
+    maxAge: 24h
+    # maxBytes is unlimited; maxAge is the primary eviction mechanism
+    maxBytes: -1
+    # maxMsgs is unlimited; maxAge is the primary eviction mechanism
+    maxMsgs: -1
+    # replicas matches the NATS cluster size for durability
+    replicas: 3
+    # compression reduces storage cost for JSON payloads
+    compression: s2
+
   # object_store_committee_documents is the configuration for the Object Store for storing committee document files
   object_store_committee_documents:
     # creation is a boolean to determine if the Object Store should be created via the helm chart.

--- a/cmd/committee-api/service/group_weekly_brief_test.go
+++ b/cmd/committee-api/service/group_weekly_brief_test.go
@@ -75,6 +75,10 @@ func (r *stubCommitteeReader) ListAllInvites(_ context.Context) ([]*model.Commit
 	panic("not used")
 }
 
+func (r *stubCommitteeReader) ListMembersByEmail(_ context.Context, _ string) ([]*model.CommitteeMember, error) {
+	panic("not used")
+}
+
 // ensure the stub satisfies the interface at compile time
 var _ internalsvc.CommitteeReader = (*stubCommitteeReader)(nil)
 

--- a/cmd/committee-api/service/providers.go
+++ b/cmd/committee-api/service/providers.go
@@ -918,6 +918,13 @@ func QueueSubscriptions(ctx context.Context, committeeReader port.CommitteeReade
 		return fmt.Errorf("failed to start weekly-brief generate consumer: %w", err)
 	}
 
+	// Start the durable consumer that reacts to upstream user-email change events.
+	slog.InfoContext(ctx, "starting stream consumer", "consumer", constants.ConsumerNameUserEmailSync)
+	if _, err := natsClient.StartUserEmailConsumer(ctx, messageHandlerService.messageHandler.HandleUserEmailChanged); err != nil {
+		slog.ErrorContext(ctx, "failed to start user-email sync consumer", "error", err)
+		return fmt.Errorf("failed to start user-email sync consumer: %w", err)
+	}
+
 	slog.InfoContext(ctx, "NATS subscriptions started successfully")
 	return nil
 }

--- a/internal/domain/model/user_email_event.go
+++ b/internal/domain/model/user_email_event.go
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package model
+
+import "time"
+
+// UserEmailEventType identifies the kind of identity change that triggered a user-email event.
+type UserEmailEventType string
+
+const (
+	// UserEmailEventAlternateEmailAdded is emitted when an alternate email is added to a user account.
+	UserEmailEventAlternateEmailAdded UserEmailEventType = "alternate_email_added"
+	// UserEmailEventAlternateEmailRemoved is emitted when an alternate email is removed from a user account.
+	UserEmailEventAlternateEmailRemoved UserEmailEventType = "alternate_email_removed"
+	// UserEmailEventLFIDUserCreated is emitted when a new LFID (LF Identity) account is created.
+	UserEmailEventLFIDUserCreated UserEmailEventType = "lfid_user_created"
+	// UserEmailEventLFIDUserDeleted is emitted when an LFID account is deleted.
+	UserEmailEventLFIDUserDeleted UserEmailEventType = "lfid_user_deleted"
+)
+
+// UserEmailEvent is the inbound payload published by lfx-v1-sync-helper and other identity
+// producers on the lfx.user-email.changed subject. It signals that the committee service
+// should re-resolve the username for any committee member seats associated with Email.
+type UserEmailEvent struct {
+	Type      UserEmailEventType `json:"type"`
+	Email     string             `json:"email"`
+	Timestamp time.Time          `json:"timestamp"`
+}

--- a/internal/domain/port/message_handler.go
+++ b/internal/domain/port/message_handler.go
@@ -68,6 +68,14 @@ type WeeklyBriefGenerateHandler interface {
 	HandleGenerateWeeklyBriefRequested(ctx context.Context, msg StreamMessenger) error
 }
 
+// UserEmailSyncHandler reacts to upstream user-email change events that may require
+// re-resolving the username of affected committee members.
+type UserEmailSyncHandler interface {
+	// HandleUserEmailChanged reacts to a user-email change event from the durable
+	// user-email-events stream. The caller (infrastructure layer) owns ACK/NAK.
+	HandleUserEmailChanged(ctx context.Context, msg StreamMessenger) error
+}
+
 // MessageHandler is the aggregate interface for all inbound NATS message handlers.
 type MessageHandler interface {
 	CommitteeAttributeHandler
@@ -75,4 +83,5 @@ type MessageHandler interface {
 	CommitteeMailingListHandler
 	CommitteeNotificationHandler
 	WeeklyBriefGenerateHandler
+	UserEmailSyncHandler
 }

--- a/internal/infrastructure/nats/stream_consumer.go
+++ b/internal/infrastructure/nats/stream_consumer.go
@@ -153,6 +153,31 @@ func (c *NATSClient) StartWeeklyBriefGenerateConsumer(
 	return consumeCtx.Stop, nil
 }
 
+// StartUserEmailConsumer binds the durable consumer for the user-email-events stream and
+// starts delivering user-email change events to handler. It returns a stop function the
+// caller must invoke on shutdown. Events signal that a user's email or LFID identity changed
+// and that affected committee member seats may need their username re-resolved.
+func (c *NATSClient) StartUserEmailConsumer(
+	ctx context.Context,
+	handler func(ctx context.Context, msg port.StreamMessenger) error,
+) (func(), error) {
+	cfg := jetstream.ConsumerConfig{
+		Name:           constants.ConsumerNameUserEmailSync,
+		Durable:        constants.ConsumerNameUserEmailSync,
+		FilterSubjects: []string{constants.UserEmailChangedSubject},
+		AckPolicy:      jetstream.AckExplicitPolicy,
+		MaxDeliver:     3,
+		AckWait:        30 * time.Second,
+	}
+
+	consumeCtx, err := c.ConsumeWithJetStream(ctx, constants.StreamNameUserEmailEvents, cfg, handler)
+	if err != nil {
+		return nil, err
+	}
+
+	return consumeCtx.Stop, nil
+}
+
 // nakDelay returns an exponential backoff duration with full jitter based on the message
 // delivery attempt count. Full jitter (random in [0, cap]) prevents correlated retries
 // across concurrent service replicas.

--- a/internal/service/committee_reader.go
+++ b/internal/service/committee_reader.go
@@ -45,6 +45,9 @@ type CommitteeMemberDataReader interface {
 	GetMemberRevision(ctx context.Context, memberUID string) (uint64, error)
 	// ListMembersByCommittee retrieves all members for a given committee UID
 	ListMembersByCommittee(ctx context.Context, committeeUID string) ([]*model.CommitteeMember, error)
+	// ListMembersByEmail retrieves all committee members whose normalized email matches the given
+	// address, using the by-email secondary index.
+	ListMembersByEmail(ctx context.Context, email string) ([]*model.CommitteeMember, error)
 }
 
 // committeeReaderOrchestratorOption defines a function type for setting options
@@ -215,6 +218,28 @@ func (rc *committeeReaderOrchestrator) ListMembersByCommittee(ctx context.Contex
 
 	slog.DebugContext(ctx, "committee members retrieved successfully",
 		"committee_uid", committeeUID,
+		"member_count", len(members),
+	)
+
+	return members, nil
+}
+
+// ListMembersByEmail retrieves all committee members whose normalized email matches the given
+// address, using the by-email secondary index.
+func (rc *committeeReaderOrchestrator) ListMembersByEmail(ctx context.Context, email string) ([]*model.CommitteeMember, error) {
+	slog.DebugContext(ctx, "executing list committee members by email use case",
+		"email_provided", email != "",
+	)
+
+	members, err := rc.committeeReader.ListMembersByEmail(ctx, email)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to list committee members by email",
+			"error", err,
+		)
+		return nil, err
+	}
+
+	slog.DebugContext(ctx, "committee members by email retrieved successfully",
 		"member_count", len(members),
 	)
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -1562,6 +1562,194 @@ func effectiveRoleUnchanged(oldRoles, newRoles []string) bool {
 
 // highestRole returns the single highest-privilege role from a slice.
 // "Writer" is considered higher than "Auditor" (maps to InviteRoleManage).
+// HandleUserEmailChanged reacts to a user-email change event from the durable user-email-events
+// stream. For alternate_email_added events it promotes all email-only committee member seats
+// associated with the address to the resolved LFID username via reconcileUsernamesForEmail.
+// Other event types are logged and ACKed; the same helper can be wired to them as the
+// corresponding teardown semantics are defined. The caller (infrastructure layer) owns ACK/NAK.
+func (m *messageHandlerOrchestrator) HandleUserEmailChanged(ctx context.Context, msg port.StreamMessenger) error {
+	subject := msg.Subject()
+
+	if subject != constants.UserEmailChangedSubject {
+		slog.DebugContext(ctx, "stream message subject not relevant for user-email sync — skipping",
+			"subject", subject,
+		)
+		return nil
+	}
+
+	var event model.UserEmailEvent
+	if err := json.Unmarshal(msg.Data(), &event); err != nil {
+		slog.WarnContext(ctx, "user-email event has malformed payload — discarding",
+			"error", err,
+			"subject", subject,
+		)
+		return nil
+	}
+
+	if event.Email == "" {
+		slog.WarnContext(ctx, "user-email event missing email — discarding",
+			"subject", subject,
+			"event_type", event.Type,
+		)
+		return nil
+	}
+
+	slog.InfoContext(ctx, "received user-email change event",
+		"event_type", event.Type,
+		"email", redaction.RedactEmail(event.Email),
+		"timestamp", event.Timestamp,
+	)
+
+	switch event.Type {
+	case model.UserEmailEventAlternateEmailAdded:
+		return m.reconcileUsernamesForEmail(ctx, event.Email)
+	default:
+		slog.DebugContext(ctx, "user-email event type not yet handled — skipping",
+			"event_type", event.Type,
+		)
+		return nil
+	}
+}
+
+// reconcileUsernamesForEmail looks up all email-only committee member seats matching email,
+// resolves the LFID username once via the auth service, and promotes each seat via UpdateMember.
+// It is called for event types where an email gains a resolvable username (e.g. alternate_email_added).
+func (m *messageHandlerOrchestrator) reconcileUsernamesForEmail(ctx context.Context, email string) error {
+	if m.committeeReader == nil || m.userReader == nil || m.committeeWriterOrchestrator == nil {
+		return errors.NewValidation("committeeReader, userReader, and committeeWriterOrchestrator are required for user-email sync")
+	}
+
+	// Cheap index lookup first — avoids a needless auth round-trip when no seats match.
+	members, err := m.committeeReader.ListMembersByEmail(ctx, email)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to list committee members by email for user-email sync",
+			"email", redaction.RedactEmail(email),
+			"error", err,
+		)
+		return err
+	}
+
+	var emailOnlySeats []*model.CommitteeMember
+	for _, member := range members {
+		if member.Username == "" {
+			emailOnlySeats = append(emailOnlySeats, member)
+		}
+	}
+
+	if len(emailOnlySeats) == 0 {
+		slog.DebugContext(ctx, "no email-only committee seats found for email — skipping",
+			"email", redaction.RedactEmail(email),
+		)
+		return nil
+	}
+
+	username, err := m.userReader.UsernameByEmail(ctx, email)
+	if err != nil {
+		var notFound errors.NotFound
+		if stderrors.As(err, &notFound) {
+			slog.DebugContext(ctx, "email not resolvable to an LFID yet — leaving seats email-only",
+				"email", redaction.RedactEmail(email),
+			)
+			return nil
+		}
+		slog.ErrorContext(ctx, "failed to resolve username by email during user-email sync",
+			"email", redaction.RedactEmail(email),
+			"error", err,
+		)
+		return err
+	}
+
+	if username == "" {
+		slog.DebugContext(ctx, "email not resolvable to an LFID yet — leaving seats email-only",
+			"email", redaction.RedactEmail(email),
+		)
+		return nil
+	}
+
+	writeCtx := context.WithValue(ctx, constants.AuthorizationContextID, "Bearer lfx-v2-committee-service")
+
+	var syncErrors []error
+	for _, seat := range emailOnlySeats {
+		if promoteErr := m.promoteEmailOnlyMemberUsername(writeCtx, seat.CommitteeUID, seat.UID, username, email); promoteErr != nil {
+			syncErrors = append(syncErrors, promoteErr)
+		}
+	}
+
+	if len(syncErrors) > 0 {
+		slog.ErrorContext(ctx, "user-email sync completed with errors",
+			"email", redaction.RedactEmail(email),
+			"username", redaction.Redact(username),
+			"total_seats", len(emailOnlySeats),
+			"failed_seats", len(syncErrors),
+		)
+	}
+
+	return stderrors.Join(syncErrors...)
+}
+
+// promoteEmailOnlyMemberUsername sets the username on an email-only committee member seat and
+// persists it via UpdateMember. It retries on revision conflicts (up to maxRetries), skips seats
+// that are already promoted or whose email no longer matches (index lag), and uses
+// contextWithSkipMemberUsernameEmailResolution so UpdateMember does not re-run the auth lookup.
+func (m *messageHandlerOrchestrator) promoteEmailOnlyMemberUsername(writeCtx context.Context, committeeUID, memberUID, username, email string) error {
+	const maxRetries = 3
+	normalizedEmail := strings.ToLower(strings.TrimSpace(email))
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		member, revision, err := m.committeeReader.GetMember(writeCtx, committeeUID, memberUID)
+		if err != nil {
+			slog.WarnContext(writeCtx, "failed to get member for username promotion",
+				"error", err,
+				"committee_uid", committeeUID,
+				"member_uid", memberUID,
+			)
+			return err
+		}
+
+		// Skip if already promoted or if the email no longer matches (index may lag an email change).
+		if member.Username != "" || strings.ToLower(strings.TrimSpace(member.Email)) != normalizedEmail {
+			return nil
+		}
+
+		member.Username = username
+
+		updated, writeErr := m.committeeWriterOrchestrator.UpdateMember(
+			contextWithSkipMemberUsernameEmailResolution(writeCtx),
+			member, revision, false,
+		)
+		if writeErr != nil {
+			var conflictErr errors.Conflict
+			if stderrors.As(writeErr, &conflictErr) && attempt < maxRetries-1 {
+				slog.DebugContext(writeCtx, "revision conflict promoting member username — retrying",
+					"attempt", attempt+1,
+					"committee_uid", committeeUID,
+					"member_uid", memberUID,
+				)
+				continue
+			}
+			slog.ErrorContext(writeCtx, "failed to promote email-only member to LFID",
+				"error", writeErr,
+				"committee_uid", committeeUID,
+				"member_uid", memberUID,
+			)
+			return writeErr
+		}
+
+		persistedUsername := username
+		if updated != nil {
+			persistedUsername = updated.Username
+		}
+		slog.DebugContext(writeCtx, "user-email sync — promoted email-only member to LFID",
+			"committee_uid", committeeUID,
+			"member_uid", memberUID,
+			"username", redaction.Redact(persistedUsername),
+		)
+		return nil
+	}
+
+	return nil
+}
+
 // Returns the first element if no known role is found.
 func highestRole(roles []string) string {
 	for _, r := range roles {

--- a/internal/service/message_handler_test.go
+++ b/internal/service/message_handler_test.go
@@ -2627,3 +2627,250 @@ func mustMarshalGetProjectJSON(t *testing.T, v interface{}) []byte {
 	require.NoError(t, err)
 	return b
 }
+
+// fakeUserReader is a configurable test double for port.UserReader.
+type fakeUserReader struct {
+	usernameByEmail func(ctx context.Context, email string) (string, error)
+}
+
+func (f *fakeUserReader) UsernameByEmail(ctx context.Context, email string) (string, error) {
+	if f.usernameByEmail != nil {
+		return f.usernameByEmail(ctx, email)
+	}
+	return "", nil
+}
+func (f *fakeUserReader) EmailsByAuthToken(_ context.Context, _ string) (*model.UserEmails, error) {
+	return nil, nil
+}
+func (f *fakeUserReader) UserMetadataByPrincipal(_ context.Context, _ string) (*model.UserMetadata, error) {
+	return nil, nil
+}
+
+// TestMessageHandlerOrchestrator_HandleUserEmailChanged covers the pre-dispatch path:
+// wrong subject, malformed JSON, missing email, and not-yet-handled event types all discard/ACK
+// without any wired collaborators. alternate_email_added is intentionally absent here because
+// it routes to reconcileUsernamesForEmail (tested separately below).
+func TestMessageHandlerOrchestrator_HandleUserEmailChanged(t *testing.T) {
+	ctx := context.Background()
+
+	validEvent := func(eventType model.UserEmailEventType) []byte {
+		b, _ := json.Marshal(model.UserEmailEvent{
+			Type:      eventType,
+			Email:     "user@example.com",
+			Timestamp: time.Now(),
+		})
+		return b
+	}
+
+	tests := []struct {
+		name        string
+		subject     string
+		messageData []byte
+		wantErr     bool
+	}{
+		{
+			name:        "alternate email removed — not yet handled, ACKs with no error",
+			subject:     constants.UserEmailChangedSubject,
+			messageData: validEvent(model.UserEmailEventAlternateEmailRemoved),
+		},
+		{
+			name:        "LFID user created — not yet handled, ACKs with no error",
+			subject:     constants.UserEmailChangedSubject,
+			messageData: validEvent(model.UserEmailEventLFIDUserCreated),
+		},
+		{
+			name:        "LFID user deleted — not yet handled, ACKs with no error",
+			subject:     constants.UserEmailChangedSubject,
+			messageData: validEvent(model.UserEmailEventLFIDUserDeleted),
+		},
+		{
+			name:        "wrong subject — skipped, no error",
+			subject:     "lfx.other-service.something",
+			messageData: validEvent(model.UserEmailEventAlternateEmailAdded),
+		},
+		{
+			name:        "malformed JSON — discarded, no error",
+			subject:     constants.UserEmailChangedSubject,
+			messageData: []byte(`not-json`),
+		},
+		{
+			name:    "missing email — discarded, no error",
+			subject: constants.UserEmailChangedSubject,
+			messageData: func() []byte {
+				b, _ := json.Marshal(model.UserEmailEvent{Type: model.UserEmailEventAlternateEmailAdded})
+				return b
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewMessageHandlerOrchestrator()
+
+			msg := &mockStreamMessenger{subject: tt.subject, data: tt.messageData}
+			err := handler.HandleUserEmailChanged(ctx, msg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestMessageHandlerOrchestrator_HandleUserEmailChanged_AlternateEmailAdded tests the full
+// alternate_email_added promotion flow: index lookup → auth resolution → UpdateMember per seat.
+func TestMessageHandlerOrchestrator_HandleUserEmailChanged_AlternateEmailAdded(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		targetEmail    = "alt@example.com"
+		resolvedUser   = "jane.doe"
+		committeeUID   = "committee-111"
+		emailOnlyUID   = "member-aaa"
+		alreadyLFIDUID = "member-bbb"
+	)
+
+	buildMsg := func(email string) *mockStreamMessenger {
+		b, _ := json.Marshal(model.UserEmailEvent{
+			Type:      model.UserEmailEventAlternateEmailAdded,
+			Email:     email,
+			Timestamp: time.Now(),
+		})
+		return &mockStreamMessenger{subject: constants.UserEmailChangedSubject, data: b}
+	}
+
+	// seedRepo returns a mock repo pre-loaded with one email-only seat and one already-LFID seat.
+	// The committee base is also seeded so the service-layer GetMember (which validates committee
+	// existence via GetBase first) can find the record.
+	seedRepo := func() *mock.MockRepository {
+		repo := mock.NewMockRepository()
+		repo.ClearAll()
+		repo.AddCommittee(&model.Committee{
+			CommitteeBase: model.CommitteeBase{UID: committeeUID},
+		})
+		repo.AddCommitteeMember(committeeUID, &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				UID:          emailOnlyUID,
+				CommitteeUID: committeeUID,
+				Email:        targetEmail,
+				Username:     "", // email-only
+			},
+		})
+		repo.AddCommitteeMember(committeeUID, &model.CommitteeMember{
+			CommitteeMemberBase: model.CommitteeMemberBase{
+				UID:          alreadyLFIDUID,
+				CommitteeUID: committeeUID,
+				Email:        targetEmail,
+				Username:     "existing.user", // already has LFID
+			},
+		})
+		return repo
+	}
+
+	buildHandler := func(repo *mock.MockRepository, userReader port.UserReader, spy *spyCommitteeWriterOrchestrator) port.MessageHandler {
+		return NewMessageHandlerOrchestrator(
+			WithCommitteeReaderForMessageHandler(
+				NewCommitteeReaderOrchestrator(WithCommitteeReader(repo)),
+			),
+			WithUserReaderForMessageHandler(userReader),
+			WithCommitteeWriterOrchestratorForMessageHandler(spy),
+		)
+	}
+
+	tests := []struct {
+		name            string
+		email           string
+		userReaderFn    func(context.Context, string) (string, error)
+		wantErr         bool
+		wantUpdateCalls int
+		validateUpdated func(t *testing.T, members []*model.CommitteeMember)
+	}{
+		{
+			name:  "email-only seat is promoted, LFID seat is skipped",
+			email: targetEmail,
+			userReaderFn: func(_ context.Context, _ string) (string, error) {
+				return resolvedUser, nil
+			},
+			wantUpdateCalls: 1,
+			validateUpdated: func(t *testing.T, members []*model.CommitteeMember) {
+				t.Helper()
+				require.Len(t, members, 1)
+				assert.Equal(t, emailOnlyUID, members[0].UID)
+				assert.Equal(t, resolvedUser, members[0].Username)
+			},
+		},
+		{
+			name:  "UsernameByEmail returns NotFound — ACK, no UpdateMember",
+			email: targetEmail,
+			userReaderFn: func(_ context.Context, _ string) (string, error) {
+				return "", errs.NewNotFound("email not found")
+			},
+			wantUpdateCalls: 0,
+		},
+		{
+			name:  "UsernameByEmail returns empty string — ACK, no UpdateMember",
+			email: targetEmail,
+			userReaderFn: func(_ context.Context, _ string) (string, error) {
+				return "", nil
+			},
+			wantUpdateCalls: 0,
+		},
+		{
+			name:  "UsernameByEmail returns transient error — NAK",
+			email: targetEmail,
+			userReaderFn: func(_ context.Context, _ string) (string, error) {
+				return "", fmt.Errorf("auth service unavailable")
+			},
+			wantErr:         true,
+			wantUpdateCalls: 0,
+		},
+		{
+			name:  "no email-only seats — auth not called, ACK",
+			email: "nobody@example.com", // no members have this email
+			userReaderFn: func(_ context.Context, _ string) (string, error) {
+				// Should not be called; panic to surface any accidental call.
+				panic("UsernameByEmail should not be called when no email-only seats exist")
+			},
+			wantUpdateCalls: 0,
+		},
+		{
+			name:  "no collaborators — returns validation error",
+			email: targetEmail,
+			// handler built without options (nil collaborators)
+			wantErr:         true,
+			wantUpdateCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spy := &spyCommitteeWriterOrchestrator{}
+
+			var handler port.MessageHandler
+			if tt.userReaderFn == nil {
+				// No-collaborator case
+				handler = NewMessageHandlerOrchestrator()
+			} else {
+				repo := seedRepo()
+				handler = buildHandler(repo, &fakeUserReader{usernameByEmail: tt.userReaderFn}, spy)
+			}
+
+			msg := buildMsg(tt.email)
+			err := handler.HandleUserEmailChanged(ctx, msg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantUpdateCalls, spy.updateMemberCalls, "UpdateMember call count mismatch")
+
+			if tt.validateUpdated != nil {
+				tt.validateUpdated(t, spy.updatedMembers)
+			}
+		})
+	}
+}

--- a/pkg/constants/storage.go
+++ b/pkg/constants/storage.go
@@ -112,6 +112,14 @@ const (
 	// the async weekly-brief generation (source gather → LLM → finalize).
 	ConsumerNameWeeklyBriefGenerate = "committee-service-weekly-brief-generate"
 
+	// StreamNameUserEmailEvents is the JetStream stream that captures upstream user-email change events
+	// (alternate email added/removed, LFID user created/deleted). Subject filter: lfx.user-email.*.
+	StreamNameUserEmailEvents = "user-email-events"
+
+	// ConsumerNameUserEmailSync is the durable JetStream consumer that reacts to user-email change
+	// events to trigger username re-resolution for affected committee members.
+	ConsumerNameUserEmailSync = "committee-service-user-email-sync"
+
 	// KVBucketNameGroupWeeklyBriefs is the KV bucket for working-group weekly briefs.
 	// Key: brief UID; Value: full brief JSON.
 	KVBucketNameGroupWeeklyBriefs = "group-weekly-briefs"

--- a/pkg/constants/subjects.go
+++ b/pkg/constants/subjects.go
@@ -79,6 +79,11 @@ const (
 	// MailingListCommitteeChangedSubject is consumed from mailing-list-api when
 	// committee-related mailing list state changes (e.g. has_mailing_list flag).
 	MailingListCommitteeChangedSubject = "lfx.mailing-list-api.committee_mailing_list.changed"
+
+	// UserEmailChangedSubject is consumed when a user's email or LFID identity changes upstream
+	// (alternate email added/removed, LFID user created/deleted). Payload: model.UserEmailEvent.
+	// Producers: lfx-v1-sync-helper and others. Drives username re-resolution for affected members.
+	UserEmailChangedSubject = "lfx.user-email.changed"
 )
 
 // Event subjects emitted by the committee service for general consumption by any service


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Introduces a durable JetStream consumer on a new `user-email-events` stream (`lfx.user-email.*`) to react to upstream identity changes published by `lfx-v1-sync-helper` and other producers.

- **`UserEmailEvent` model** — `{type, email, timestamp}` with event-type enum (`alternate_email_added`, `alternate_email_removed`, `lfid_user_created`, `lfid_user_deleted`)
- **New `user-email-events` JetStream stream** provisioned in the service Helm chart (`lfx.user-email.*`)
- **`StartUserEmailConsumer`** durable consumer wired into `QueueSubscriptions`
- **`HandleUserEmailChanged`** dispatches on event type; `alternate_email_added` is fully implemented, other types are logged no-ops pending defined semantics
- **`reconcileUsernamesForEmail`** — index lookup (by-email secondary index) → single `UsernameByEmail` auth call → promote each email-only seat via `UpdateMember` with conflict retry (mirrors `enrichInvitedCommitteeMember`)
- **`ListMembersByEmail`** exposed on the service-layer `CommitteeReader` interface (was port-only)
- 13-case table-driven tests covering: promotion happy path, LFID-seat skipped, `NotFound` ACK, empty-username ACK, transient auth error NAK, no-seats short-circuit, no-collaborators validation error

Jira: [LFXV2-2521](https://linuxfoundation.atlassian.net/browse/LFXV2-2521)
EOF
)

[LFXV2-2521]: https://linuxfoundation.atlassian.net/browse/LFXV2-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ