### PR TITLE
fix(chart): standardize tracesSamplerArg comment

### DIFF
--- a/charts/lfx-v2-committee-service/values.yaml
+++ b/charts/lfx-v2-committee-service/values.yaml
@@ -576,7 +576,7 @@ app:
     # When empty, the application defaults to parentbased_traceidratio.
     tracesSampler: ""
     # tracesSamplerArg specifies the OTEL_TRACES_SAMPLER_ARG (sampler ratio or parent_sampler_arg).
-    # Required for "traceidratio" and "parentbased_traceidratio" samplers.
+    # Used by "traceidratio" and "parentbased_traceidratio" samplers (defaults to 1.0 if empty).
     # (default: "")
     tracesSamplerArg: ""
     # metricsExporter specifies the metrics exporter: "otlp" or "none"


### PR DESCRIPTION
## Summary

- Standardizes the `tracesSamplerArg` Helm chart comment to match the canonical wording from `lfx-v2-email-service`
- Replaces "Required for" phrasing with "Used by...samplers (defaults to 1.0 if empty)" — the field is optional, not required

## Test plan
- [ ] Comment in `values.yaml` matches canonical format

🤖 Generated with [Claude Code](https://claude.com/claude-code)