### PR TITLE
[LFXV2-2677] fix(invites): use payload org when name or website present without SFID

### DIFF
--- a/cmd/committee-api/service/committee_service_test.go
+++ b/cmd/committee-api/service/committee_service_test.go
@@ -1387,12 +1387,12 @@ func TestAcceptInvite_Organization(t *testing.T) {
 		assert.Equal(t, "https://payload.org", member.Organization.Website)
 	})
 
-	t.Run("ignores partial payload without organization ID", func(t *testing.T) {
+	t.Run("uses payload name and website without organization ID", func(t *testing.T) {
 		svc, mockOrch, repo := setupServiceTestWithRepo()
 		svc.userReader = mockReaderForPrincipalEmail("accept@example.com", "accept@example.com")
 
 		repo.AddCommitteeInvite(&model.CommitteeInvite{
-			UID:          "invite-org-merge",
+			UID:          "invite-org-name-website",
 			CommitteeUID: "committee-1",
 			InviteeEmail: "accept@example.com",
 			Status:       "pending",
@@ -1411,25 +1411,28 @@ func TestAcceptInvite_Organization(t *testing.T) {
 			},
 		}
 
-		overrideName := "Payload Org"
+		payloadName := "Payload Org"
+		payloadWebsite := "https://payload.org"
 		_, err := svc.AcceptInvite(testCtx("accept@example.com"), &committeeservice.AcceptInvitePayload{
 			UID:       "committee-1",
-			InviteUID: "invite-org-merge",
+			InviteUID: "invite-org-name-website",
 			Body: &committeeservice.AcceptInviteOptionalBody{
 				Organization: &struct {
 					ID      *string
 					Name    *string
 					Website *string
 				}{
-					Name: &overrideName,
+					Name:    &payloadName,
+					Website: &payloadWebsite,
 				},
 			},
 		})
 		require.NoError(t, err)
 		require.Len(t, mockOrch.createMemberCalls, 1)
 		member := mockOrch.createMemberCalls[0]
-		assert.Equal(t, "Invite Org", member.Organization.Name)
-		assert.Equal(t, "https://invite.org", member.Organization.Website)
+		assert.Equal(t, "Payload Org", member.Organization.Name)
+		assert.Equal(t, "https://payload.org", member.Organization.Website)
+		assert.Empty(t, member.Organization.ID)
 	})
 
 	t.Run("falls back to invite organization", func(t *testing.T) {

--- a/cmd/committee-api/service/organization_helpers.go
+++ b/cmd/committee-api/service/organization_helpers.go
@@ -54,11 +54,12 @@ func normalizeMemberOrganization(org *model.CommitteeMemberOrganization) {
 }
 
 // acceptInviteOrganization selects the organization for member creation on invite accept.
-// When the accept payload includes an organization ID, the entire payload organization is
-// used. Otherwise the stored invite organization is used as-is (no field-level merging).
+// When the accept payload carries any organization data (ID, name, or website), it is used
+// as-is. The stored invite organization is only used when the payload supplies nothing at
+// all, preserving any pre-filled org on the invite as a fallback.
 func acceptInviteOrganization(invite *model.CommitteeInvite, id, name, website *string) model.CommitteeMemberOrganization {
 	payloadOrg := organizationFromOptionalFields(id, name, website)
-	if strings.TrimSpace(payloadOrg.ID) != "" {
+	if organizationHasData(payloadOrg) {
 		return payloadOrg
 	}
 	return inviteOrganizationValue(invite)

--- a/cmd/committee-api/service/organization_helpers_test.go
+++ b/cmd/committee-api/service/organization_helpers_test.go
@@ -29,15 +29,24 @@ func TestAcceptInviteOrganization(t *testing.T) {
 		assert.Equal(t, "https://payload.org", org.Website)
 	})
 
-	t.Run("ignores partial payload without ID", func(t *testing.T) {
+	t.Run("uses payload name and website without ID", func(t *testing.T) {
 		orgName := "Payload Org"
-		org := acceptInviteOrganization(invite, nil, &orgName, nil)
-		assert.Equal(t, "Invite Org", org.Name)
-		assert.Equal(t, "https://invite.org", org.Website)
+		orgWebsite := "https://payload.org"
+		org := acceptInviteOrganization(invite, nil, &orgName, &orgWebsite)
+		assert.Equal(t, "Payload Org", org.Name)
+		assert.Equal(t, "https://payload.org", org.Website)
 		assert.Empty(t, org.ID)
 	})
 
-	t.Run("falls back to invite when payload has no organization", func(t *testing.T) {
+	t.Run("uses payload name-only without ID", func(t *testing.T) {
+		orgName := "Payload Org"
+		org := acceptInviteOrganization(invite, nil, &orgName, nil)
+		assert.Equal(t, "Payload Org", org.Name)
+		assert.Empty(t, org.Website)
+		assert.Empty(t, org.ID)
+	})
+
+	t.Run("falls back to invite when payload has no organization data", func(t *testing.T) {
 		org := acceptInviteOrganization(invite, nil, nil, nil)
 		assert.Equal(t, "Invite Org", org.Name)
 		assert.Equal(t, "https://invite.org", org.Website)


### PR DESCRIPTION
## Summary

- Fixes a regression where accepting a voting-enabled committee invite with an org supplied as `name + website` (no Salesforce SFID) returned `BAD_REQUEST: organization id or organization name and domain are required when business email is required or voting is enabled`
- Root cause: `acceptInviteOrganization` only used the accept payload when it contained an SFID (`payloadOrg.ID != ""`). Self-serve never sends an SFID (only CDP UUIDs, which are intentionally stripped), so any `name + website` payload was silently discarded in favour of the invite's stored org — which was empty for the `pendingForOrg` case, causing `validateOrganizationFields` to reject the request
- Fix: change the fallback condition from `payloadOrg.ID != ""` to `organizationHasData(payloadOrg)` so any payload carrying a name, website, or SFID takes precedence; the invite fallback is only used when the payload supplies nothing at all
- Updated unit tests in `organization_helpers_test.go` and integration test in `committee_service_test.go` to assert the correct (fixed) behaviour

## Ticket

[LFXV2-2677](https://linuxfoundation.atlassian.net/browse/LFXV2-2677)

## Test Plan

- [x] `go test ./...` passes — all existing tests green, updated tests assert fixed behaviour
- [x] Unit tests cover: payload with ID, payload with name+website (no ID), payload with name-only (no ID), empty payload falls back to invite org

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2677]: https://linuxfoundation.atlassian.net/browse/LFXV2-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ