### PR TITLE
feat(logging): upgrade email/invite send success logs to Info with full context

### DIFF
--- a/internal/infrastructure/nats/email_sender.go
+++ b/internal/infrastructure/nats/email_sender.go
@@ -38,7 +38,7 @@ func (e *emailSender) SendEmail(ctx context.Context, req emailapi.SendEmailReque
 	}
 
 	if len(msg.Data) == 0 {
-		slog.InfoContext(ctx, "email sent", "to", redaction.RedactEmail(req.To))
+		slog.InfoContext(ctx, "email sent", "recipient_email", redaction.RedactEmail(req.To))
 		return nil
 	}
 
@@ -47,7 +47,7 @@ func (e *emailSender) SendEmail(ctx context.Context, req emailapi.SendEmailReque
 		return errors.NewUnexpected("email service error: "+errResp.Error, nil)
 	}
 
-	slog.InfoContext(ctx, "email sent", "to", redaction.RedactEmail(req.To))
+	slog.InfoContext(ctx, "email sent", "recipient_email", redaction.RedactEmail(req.To))
 	return nil
 }
 

--- a/internal/infrastructure/nats/email_sender.go
+++ b/internal/infrastructure/nats/email_sender.go
@@ -6,9 +6,11 @@ package nats
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/port"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/redaction"
 	emailapi "github.com/linuxfoundation/lfx-v2-email-service/pkg/api"
 )
 
@@ -36,6 +38,9 @@ func (e *emailSender) SendEmail(ctx context.Context, req emailapi.SendEmailReque
 	}
 
 	if len(msg.Data) == 0 {
+		slog.InfoContext(ctx, "email sent",
+			"to", redaction.RedactEmail(req.To),
+			"subject", req.Subject)
 		return nil
 	}
 
@@ -44,6 +49,9 @@ func (e *emailSender) SendEmail(ctx context.Context, req emailapi.SendEmailReque
 		return errors.NewUnexpected("email service error: "+errResp.Error, nil)
 	}
 
+	slog.InfoContext(ctx, "email sent",
+		"to", redaction.RedactEmail(req.To),
+		"subject", req.Subject)
 	return nil
 }
 

--- a/internal/infrastructure/nats/email_sender.go
+++ b/internal/infrastructure/nats/email_sender.go
@@ -38,9 +38,7 @@ func (e *emailSender) SendEmail(ctx context.Context, req emailapi.SendEmailReque
 	}
 
 	if len(msg.Data) == 0 {
-		slog.InfoContext(ctx, "email sent",
-			"to", redaction.RedactEmail(req.To),
-			"subject", req.Subject)
+		slog.InfoContext(ctx, "email sent", "to", redaction.RedactEmail(req.To))
 		return nil
 	}
 
@@ -49,9 +47,7 @@ func (e *emailSender) SendEmail(ctx context.Context, req emailapi.SendEmailReque
 		return errors.NewUnexpected("email service error: "+errResp.Error, nil)
 	}
 
-	slog.InfoContext(ctx, "email sent",
-		"to", redaction.RedactEmail(req.To),
-		"subject", req.Subject)
+	slog.InfoContext(ctx, "email sent", "to", redaction.RedactEmail(req.To))
 	return nil
 }
 

--- a/internal/infrastructure/nats/invite_sender.go
+++ b/internal/infrastructure/nats/invite_sender.go
@@ -58,15 +58,15 @@ func (s *inviteSender) SendInvite(ctx context.Context, req inviteapi.SendInviteR
 		result.InviteUID = resp.UID
 		result.RecipientEmail = resp.Email
 		result.ExpiresAt = resp.ExpiresAt
+		var recipientEmail string
+		if req.Recipient != nil {
+			recipientEmail = req.Recipient.Email
+		}
+		slog.InfoContext(ctx, "invite sent",
+			"invite_uid", result.InviteUID,
+			"recipient_email", redaction.RedactEmail(recipientEmail),
+			"expires_at", result.ExpiresAt)
 	}
-	var recipientEmail string
-	if req.Recipient != nil {
-		recipientEmail = req.Recipient.Email
-	}
-	slog.InfoContext(ctx, "invite sent",
-		"invite_uid", result.InviteUID,
-		"recipient_email", redaction.RedactEmail(recipientEmail),
-		"expires_at", result.ExpiresAt)
 	return result, nil
 }
 

--- a/internal/infrastructure/nats/invite_sender.go
+++ b/internal/infrastructure/nats/invite_sender.go
@@ -58,15 +58,15 @@ func (s *inviteSender) SendInvite(ctx context.Context, req inviteapi.SendInviteR
 		result.InviteUID = resp.UID
 		result.RecipientEmail = resp.Email
 		result.ExpiresAt = resp.ExpiresAt
-		var recipientEmail string
-		if req.Recipient != nil {
-			recipientEmail = req.Recipient.Email
-		}
-		slog.InfoContext(ctx, "invite sent",
-			"invite_uid", result.InviteUID,
-			"recipient_email", redaction.RedactEmail(recipientEmail),
-			"expires_at", result.ExpiresAt)
 	}
+	var recipientEmail string
+	if req.Recipient != nil {
+		recipientEmail = req.Recipient.Email
+	}
+	slog.InfoContext(ctx, "invite sent",
+		"invite_uid", result.InviteUID,
+		"recipient_email", redaction.RedactEmail(recipientEmail),
+		"expires_at", result.ExpiresAt)
 	return result, nil
 }
 

--- a/internal/infrastructure/nats/invite_sender.go
+++ b/internal/infrastructure/nats/invite_sender.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/port"
 	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/errors"
+	"github.com/linuxfoundation/lfx-v2-committee-service/pkg/redaction"
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 )
 
@@ -58,7 +59,14 @@ func (s *inviteSender) SendInvite(ctx context.Context, req inviteapi.SendInviteR
 		result.RecipientEmail = resp.Email
 		result.ExpiresAt = resp.ExpiresAt
 	}
-	slog.DebugContext(ctx, "invite service replied", "invite_uid", result.InviteUID, "expires_at", result.ExpiresAt)
+	var recipientEmail string
+	if req.Recipient != nil {
+		recipientEmail = req.Recipient.Email
+	}
+	slog.InfoContext(ctx, "invite sent",
+		"invite_uid", result.InviteUID,
+		"recipient_email", redaction.RedactEmail(recipientEmail),
+		"expires_at", result.ExpiresAt)
 	return result, nil
 }
 

--- a/internal/service/application_notification_handler.go
+++ b/internal/service/application_notification_handler.go
@@ -113,8 +113,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeApplicationSubmitted(ctx con
 					"error", sendErr, "committee_uid", application.CommitteeUID,
 					"username", redaction.Redact(writer.username))
 			} else {
-				slog.DebugContext(gctx, "sent application submitted notification email",
-					"committee_uid", application.CommitteeUID)
+				slog.InfoContext(gctx, "sent application submitted notification email",
+					"committee_uid", application.CommitteeUID,
+					"application_uid", application.UID,
+					"recipient_email", redaction.RedactEmail(writer.email),
+					"username", redaction.Redact(writer.username))
 			}
 			return nil
 		})
@@ -223,8 +226,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeApplicationUpdated(ctx conte
 		slog.WarnContext(ctx, "failed to send application updated notification email",
 			"error", sendErr, "committee_uid", application.CommitteeUID, "status", application.Status)
 	} else {
-		slog.DebugContext(ctx, "sent application updated notification email",
-			"committee_uid", application.CommitteeUID, "status", application.Status)
+		slog.InfoContext(ctx, "sent application updated notification email",
+			"committee_uid", application.CommitteeUID,
+			"application_uid", application.UID,
+			"recipient_email", redaction.RedactEmail(application.ApplicantEmail),
+			"status", application.Status)
 	}
 
 	return nil, nil

--- a/internal/service/document_notification_handler.go
+++ b/internal/service/document_notification_handler.go
@@ -198,8 +198,11 @@ func (m *messageHandlerOrchestrator) handleContentCreated(ctx context.Context, i
 				slog.WarnContext(gctx, "failed to send content notification email",
 					"error", sendErr, "committee_uid", item.committeeUID)
 			} else {
-				slog.DebugContext(gctx, "sent content notification email",
-					"committee_uid", item.committeeUID, "document_type", item.documentType)
+				slog.InfoContext(gctx, "sent content notification email",
+					"committee_uid", item.committeeUID,
+					"recipient_email", redaction.RedactEmail(email),
+					"username", redaction.Redact(recipient.username),
+					"document_type", item.documentType)
 			}
 			return nil
 		})

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -929,7 +929,7 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 	if event.UID == "" || event.AcceptedBy == "" || strings.TrimSpace(event.Recipient.Email) == "" {
 		slog.WarnContext(ctx, "invite_accepted event missing required fields — discarding",
 			"invite_uid", event.UID, "accepted_by", redaction.Redact(event.AcceptedBy),
-			"recipient_email", event.Recipient.Email)
+			"recipient_email", redaction.RedactEmail(event.Recipient.Email))
 		return nil, nil
 	}
 

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -661,8 +661,10 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberCreated(ctx context.Co
 		slog.WarnContext(ctx, "failed to send member notification email",
 			"error", sendErr, "committee_uid", member.CommitteeUID)
 	} else {
-		slog.DebugContext(ctx, "sent member notification email",
-			"committee_uid", member.CommitteeUID)
+		slog.InfoContext(ctx, "sent member notification email",
+			"committee_uid", member.CommitteeUID,
+			"member_uid", member.UID,
+			"recipient_email", redaction.RedactEmail(member.Email))
 	}
 
 	return nil, nil
@@ -701,8 +703,11 @@ func (m *messageHandlerOrchestrator) sendMemberInvite(ctx context.Context, membe
 		return err
 	}
 
-	slog.DebugContext(ctx, "sent member invite request",
-		"committee_uid", member.CommitteeUID, "invite_uid", result.InviteUID)
+	slog.InfoContext(ctx, "sent member invite request",
+		"committee_uid", member.CommitteeUID,
+		"member_uid", member.UID,
+		"recipient_email", redaction.RedactEmail(member.Email),
+		"invite_uid", result.InviteUID)
 	return nil
 }
 
@@ -821,8 +826,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 					return nil
 				}
 
-				slog.DebugContext(gctx, "sent settings invite request",
-					"committee_uid", data.CommitteeUID, "invite_uid", result.InviteUID)
+				slog.InfoContext(gctx, "sent settings invite request",
+					"committee_uid", data.CommitteeUID,
+					"recipient_email", redaction.RedactEmail(u.Email),
+					"invite_uid", result.InviteUID,
+					"kind", kind)
 
 				return nil
 			}
@@ -890,8 +898,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeSettingsUpdated(ctx context.
 				slog.WarnContext(gctx, "failed to send settings notification email",
 					"error", sendErr, "committee_uid", data.CommitteeUID, "kind", kind)
 			} else {
-				slog.DebugContext(gctx, "sent settings notification email",
-					"committee_uid", data.CommitteeUID, "kind", kind)
+				slog.InfoContext(gctx, "sent settings notification email",
+					"committee_uid", data.CommitteeUID,
+					"recipient_email", redaction.RedactEmail(u.Email),
+					"username", redaction.Redact(u.Username),
+					"kind", kind)
 			}
 			return nil
 		})
@@ -1446,8 +1457,11 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberDeleted(ctx context.Co
 		slog.WarnContext(ctx, "failed to send member-deleted notification email",
 			"error", sendErr, "committee_uid", member.CommitteeUID)
 	} else {
-		slog.DebugContext(ctx, "sent member-deleted notification email",
-			"committee_uid", member.CommitteeUID)
+		slog.InfoContext(ctx, "sent member-deleted notification email",
+			"committee_uid", member.CommitteeUID,
+			"member_uid", member.UID,
+			"recipient_email", redaction.RedactEmail(member.Email),
+			"username", redaction.Redact(member.Username))
 	}
 
 	return nil, nil

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -664,7 +664,8 @@ func (m *messageHandlerOrchestrator) HandleCommitteeMemberCreated(ctx context.Co
 		slog.InfoContext(ctx, "sent member notification email",
 			"committee_uid", member.CommitteeUID,
 			"member_uid", member.UID,
-			"recipient_email", redaction.RedactEmail(member.Email))
+			"recipient_email", redaction.RedactEmail(member.Email),
+			"username", redaction.Redact(member.Username))
 	}
 
 	return nil, nil

--- a/internal/service/message_handler.go
+++ b/internal/service/message_handler.go
@@ -929,7 +929,7 @@ func (m *messageHandlerOrchestrator) HandleInviteAccepted(ctx context.Context, m
 	if event.UID == "" || event.AcceptedBy == "" || strings.TrimSpace(event.Recipient.Email) == "" {
 		slog.WarnContext(ctx, "invite_accepted event missing required fields — discarding",
 			"invite_uid", event.UID, "accepted_by", redaction.Redact(event.AcceptedBy),
-			"recipient_email", redaction.RedactEmail(event.Recipient.Email))
+			"recipient_email", event.Recipient.Email)
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary

- Adds an Info-level success log inside `nats/email_sender.go` and `nats/invite_sender.go` so every successful email or invite dispatch is always captured at the infra layer, regardless of which caller triggers it
- Upgrades all caller-side success logs from Debug → Info and enriches them with full domain context: `committee_uid`, `member_uid` or `application_uid` (where available), redacted `recipient_email`, redacted `username`, `invite_uid`, and event `kind`
- All PII (email addresses, usernames) is redacted via the existing `redaction.RedactEmail` / `redaction.Redact` utilities

## Ticket

No JIRA ticket — observability improvement.

🤖 Generated with [Claude Code](https://claude.ai/code)