### PR TITLE
feat(invite): embed org context claims in LFID invite JWT

### DIFF
--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -833,6 +834,15 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 	// — its vocabulary is Manage/View/Member, not committee roles like "chair".
 	// Match the parallel "add committee member" path in message_handler.go
 	// sendMemberInvite and pass "Member".
+
+	// Extract org fields before building claims — Organization is a pointer.
+	var orgName, orgID, orgWebsite string
+	if invite.Organization != nil {
+		orgName = invite.Organization.Name
+		orgID = invite.Organization.ID
+		orgWebsite = invite.Organization.Website
+	}
+
 	_, err := s.inviteSender.SendInvite(dispatchCtx, inviteapi.SendInviteRequest{
 		Recipient: &inviteapi.Recipient{
 			Email: strings.TrimSpace(invite.InviteeEmail),
@@ -849,7 +859,12 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 		Role:      "Member",
 		ReturnURL: strings.TrimRight(s.lfxSelfServeBaseURL, "/") + "/project/groups/" + committee.UID,
 		CustomClaims: map[string]string{
-			"committee_invite_uid": invite.UID,
+			"committee_invite_uid":  invite.UID,
+			"organization_required": strconv.FormatBool(invite.OrganizationRequired),
+			"committee_name":        invite.CommitteeName,
+			"organization_name":     orgName,
+			"organization_id":       orgID,
+			"organization_website":  orgWebsite,
 		},
 	})
 	if err != nil {

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -858,13 +858,15 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 		},
 		Role:      "Member",
 		ReturnURL: strings.TrimRight(s.lfxSelfServeBaseURL, "/") + "/project/groups/" + committee.UID,
+		// Truncate variable-length values to the invite-service's 1024-byte per-claim limit.
+		// Dispatch is best-effort; truncation avoids a silent rejection of the whole call.
 		CustomClaims: map[string]string{
 			"committee_invite_uid":  invite.UID,
 			"organization_required": strconv.FormatBool(invite.OrganizationRequired),
-			"committee_name":        invite.CommitteeName,
-			"organization_name":     orgName,
-			"organization_id":       orgID,
-			"organization_website":  orgWebsite,
+			"committee_name":        truncateClaimValue(invite.CommitteeName),
+			"organization_name":     truncateClaimValue(orgName),
+			"organization_id":       truncateClaimValue(orgID),
+			"organization_website":  truncateClaimValue(orgWebsite),
 		},
 	})
 	if err != nil {
@@ -874,6 +876,21 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 	}
 	slog.DebugContext(ctx, "dispatched committee invite email",
 		"committee_uid", committee.UID, "invite_uid", invite.UID)
+}
+
+// truncateClaimValue trims s to at most maxClaimValueBytes bytes so the invite
+// service does not reject the SendInvite call due to an oversized claim value.
+// Truncation is at a UTF-8 rune boundary to avoid producing invalid UTF-8.
+func truncateClaimValue(s string) string {
+	const maxClaimValueBytes = 1024
+	if len(s) <= maxClaimValueBytes {
+		return s
+	}
+	i := maxClaimValueBytes
+	for i > 0 && (s[i]&0xC0) == 0x80 {
+		i--
+	}
+	return s[:i]
 }
 
 // RevokeInvite revokes a pending or declined invite

--- a/cmd/committee-api/service/committee_service.go
+++ b/cmd/committee-api/service/committee_service.go
@@ -858,15 +858,17 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 		},
 		Role:      "Member",
 		ReturnURL: strings.TrimRight(s.lfxSelfServeBaseURL, "/") + "/project/groups/" + committee.UID,
-		// Truncate variable-length values to the invite-service's 1024-byte per-claim limit.
-		// Dispatch is best-effort; truncation avoids a silent rejection of the whole call.
+		// Emit variable-length values only when they are within the invite-service's 1024-byte
+		// per-claim limit. If a value would exceed the limit it is omitted (empty string) and
+		// a warning is logged — relaying a truncated value downstream is worse than omitting it,
+		// because the consumer treats non-empty claims as authoritative and would persist broken data.
 		CustomClaims: map[string]string{
 			"committee_invite_uid":  invite.UID,
 			"organization_required": strconv.FormatBool(invite.OrganizationRequired),
-			"committee_name":        truncateClaimValue(invite.CommitteeName),
-			"organization_name":     truncateClaimValue(orgName),
-			"organization_id":       truncateClaimValue(orgID),
-			"organization_website":  truncateClaimValue(orgWebsite),
+			"committee_name":        safeClaimValue(ctx, invite.CommitteeName, "committee_name", invite.UID),
+			"organization_name":     safeClaimValue(ctx, orgName, "organization_name", invite.UID),
+			"organization_id":       safeClaimValue(ctx, orgID, "organization_id", invite.UID),
+			"organization_website":  safeClaimValue(ctx, orgWebsite, "organization_website", invite.UID),
 		},
 	})
 	if err != nil {
@@ -878,19 +880,18 @@ func (s *committeeServicesrvc) dispatchInviteEmail(ctx context.Context, committe
 		"committee_uid", committee.UID, "invite_uid", invite.UID)
 }
 
-// truncateClaimValue trims s to at most maxClaimValueBytes bytes so the invite
-// service does not reject the SendInvite call due to an oversized claim value.
-// Truncation is at a UTF-8 rune boundary to avoid producing invalid UTF-8.
-func truncateClaimValue(s string) string {
+// safeClaimValue returns s when it is within the invite-service's 1024-byte per-claim limit.
+// If s exceeds the limit it logs a warning and returns "" so the consumer falls back to
+// its no-value behaviour rather than persisting a truncated (and therefore broken) string.
+func safeClaimValue(ctx context.Context, s, claimKey, inviteUID string) string {
 	const maxClaimValueBytes = 1024
 	if len(s) <= maxClaimValueBytes {
 		return s
 	}
-	i := maxClaimValueBytes
-	for i > 0 && (s[i]&0xC0) == 0x80 {
-		i--
-	}
-	return s[:i]
+	slog.WarnContext(ctx, "claim value exceeds invite-service limit — omitting from JWT",
+		"claim_key", claimKey, "invite_uid", inviteUID,
+		"byte_length", len(s), "limit", maxClaimValueBytes)
+	return ""
 }
 
 // RevokeInvite revokes a pending or declined invite

--- a/cmd/committee-api/service/committee_service_test.go
+++ b/cmd/committee-api/service/committee_service_test.go
@@ -786,8 +786,11 @@ func TestCreateInvite(t *testing.T) {
 				assert.Equal(t, *result.UID, call.CustomClaims["committee_invite_uid"], "CustomClaims must carry the persisted invite UID so the BFF can accept unambiguously")
 				assert.Equal(t, "true", call.CustomClaims["organization_required"], "CustomClaims must carry organization_required so the BFF can prompt for org without an email fetch")
 				assert.Equal(t, "Technical Advisory Committee", call.CustomClaims["committee_name"], "CustomClaims must carry committee_name for the org-collection dialog header")
+				assert.Contains(t, call.CustomClaims, "organization_name", "organization_name key must be present even when empty")
 				assert.Equal(t, "", call.CustomClaims["organization_name"], "CustomClaims organization_name must be empty when no org is pre-filled")
+				assert.Contains(t, call.CustomClaims, "organization_id", "organization_id key must be present even when empty")
 				assert.Equal(t, "", call.CustomClaims["organization_id"], "CustomClaims organization_id must be empty when no org is pre-filled")
+				assert.Contains(t, call.CustomClaims, "organization_website", "organization_website key must be present even when empty")
 				assert.Equal(t, "", call.CustomClaims["organization_website"], "CustomClaims organization_website must be empty when no org is pre-filled")
 			}
 		})
@@ -809,6 +812,7 @@ func TestCreateInvite_Organization(t *testing.T) {
 
 	t.Run("stores organization from payload", func(t *testing.T) {
 		svc, _, _ := setupServiceTestWithRepo()
+		sender := svc.inviteSender.(*mockInviteSender)
 
 		result, err := svc.CreateInvite(context.Background(), &committeeservice.CreateInvitePayload{
 			UID:          "committee-1",
@@ -821,10 +825,19 @@ func TestCreateInvite_Organization(t *testing.T) {
 		assert.Equal(t, "The Linux Foundation", *result.Organization.Name)
 		require.NotNil(t, result.Organization.Website)
 		assert.Equal(t, "https://linuxfoundation.org", *result.Organization.Website)
+
+		// Verify that org fields are embedded in the JWT claims for the BFF to read.
+		require.Len(t, sender.calls, 1)
+		call := sender.calls[0]
+		assert.Equal(t, "true", call.CustomClaims["organization_required"])
+		assert.Equal(t, "The Linux Foundation", call.CustomClaims["organization_name"], "pre-filled org name must be embedded in CustomClaims")
+		assert.Equal(t, "", call.CustomClaims["organization_id"], "org ID is nil in sampleInviteOrganizationPayload so claim must be empty")
+		assert.Equal(t, "https://linuxfoundation.org", call.CustomClaims["organization_website"], "pre-filled org website must be embedded in CustomClaims")
 	})
 
 	t.Run("optional on open committee", func(t *testing.T) {
 		svc, _, _ := setupServiceTestWithRepo()
+		sender := svc.inviteSender.(*mockInviteSender)
 
 		result, err := svc.CreateInvite(context.Background(), &committeeservice.CreateInvitePayload{
 			UID:          "committee-2",
@@ -833,6 +846,19 @@ func TestCreateInvite_Organization(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Nil(t, result.Organization)
+
+		// committee-2 has BusinessEmailRequired=false and EnableVoting=false, so organization
+		// is not required; the claim must reflect that so the BFF accepts without prompting.
+		require.Len(t, sender.calls, 1)
+		call := sender.calls[0]
+		assert.Equal(t, "false", call.CustomClaims["organization_required"], "open committee must emit organization_required=false")
+		assert.Equal(t, "Security Committee", call.CustomClaims["committee_name"])
+		assert.Contains(t, call.CustomClaims, "organization_name")
+		assert.Equal(t, "", call.CustomClaims["organization_name"])
+		assert.Contains(t, call.CustomClaims, "organization_id")
+		assert.Equal(t, "", call.CustomClaims["organization_id"])
+		assert.Contains(t, call.CustomClaims, "organization_website")
+		assert.Equal(t, "", call.CustomClaims["organization_website"])
 	})
 
 	t.Run("reinstate preserves stored organization", func(t *testing.T) {
@@ -927,8 +953,11 @@ func TestCreateInvite_RevokedInviteReinstated(t *testing.T) {
 	assert.Equal(t, revoked.UID, sender.calls[0].CustomClaims["committee_invite_uid"], "reinstated invite must carry its own UID in CustomClaims")
 	assert.Equal(t, "true", sender.calls[0].CustomClaims["organization_required"], "reinstated invite must carry organization_required in CustomClaims")
 	assert.Equal(t, "Technical Advisory Committee", sender.calls[0].CustomClaims["committee_name"], "reinstated invite must carry committee_name in CustomClaims")
+	assert.Contains(t, sender.calls[0].CustomClaims, "organization_name", "organization_name key must be present even when empty")
 	assert.Equal(t, "", sender.calls[0].CustomClaims["organization_name"], "reinstated invite must carry empty organization_name when no org pre-filled")
+	assert.Contains(t, sender.calls[0].CustomClaims, "organization_id", "organization_id key must be present even when empty")
 	assert.Equal(t, "", sender.calls[0].CustomClaims["organization_id"], "reinstated invite must carry empty organization_id when no org pre-filled")
+	assert.Contains(t, sender.calls[0].CustomClaims, "organization_website", "organization_website key must be present even when empty")
 	assert.Equal(t, "", sender.calls[0].CustomClaims["organization_website"], "reinstated invite must carry empty organization_website when no org pre-filled")
 }
 

--- a/cmd/committee-api/service/committee_service_test.go
+++ b/cmd/committee-api/service/committee_service_test.go
@@ -784,6 +784,11 @@ func TestCreateInvite(t *testing.T) {
 				assert.Equal(t, "group", call.Resource.Type)
 				assert.Equal(t, "https://app.test.lfx.dev/project/groups/"+tt.payload.UID, call.ReturnURL)
 				assert.Equal(t, *result.UID, call.CustomClaims["committee_invite_uid"], "CustomClaims must carry the persisted invite UID so the BFF can accept unambiguously")
+				assert.Equal(t, "true", call.CustomClaims["organization_required"], "CustomClaims must carry organization_required so the BFF can prompt for org without an email fetch")
+				assert.Equal(t, "Technical Advisory Committee", call.CustomClaims["committee_name"], "CustomClaims must carry committee_name for the org-collection dialog header")
+				assert.Equal(t, "", call.CustomClaims["organization_name"], "CustomClaims organization_name must be empty when no org is pre-filled")
+				assert.Equal(t, "", call.CustomClaims["organization_id"], "CustomClaims organization_id must be empty when no org is pre-filled")
+				assert.Equal(t, "", call.CustomClaims["organization_website"], "CustomClaims organization_website must be empty when no org is pre-filled")
 			}
 		})
 	}
@@ -920,6 +925,11 @@ func TestCreateInvite_RevokedInviteReinstated(t *testing.T) {
 	// invite record and is applied on acceptance.
 	assert.Equal(t, "Member", sender.calls[0].Role)
 	assert.Equal(t, revoked.UID, sender.calls[0].CustomClaims["committee_invite_uid"], "reinstated invite must carry its own UID in CustomClaims")
+	assert.Equal(t, "true", sender.calls[0].CustomClaims["organization_required"], "reinstated invite must carry organization_required in CustomClaims")
+	assert.Equal(t, "Technical Advisory Committee", sender.calls[0].CustomClaims["committee_name"], "reinstated invite must carry committee_name in CustomClaims")
+	assert.Equal(t, "", sender.calls[0].CustomClaims["organization_name"], "reinstated invite must carry empty organization_name when no org pre-filled")
+	assert.Equal(t, "", sender.calls[0].CustomClaims["organization_id"], "reinstated invite must carry empty organization_id when no org pre-filled")
+	assert.Equal(t, "", sender.calls[0].CustomClaims["organization_website"], "reinstated invite must carry empty organization_website when no org pre-filled")
 }
 
 func TestCreateInvite_InviteSenderFailureDoesNotFailRequest(t *testing.T) {

--- a/cmd/committee-api/service/committee_service_test.go
+++ b/cmd/committee-api/service/committee_service_test.go
@@ -2757,3 +2757,38 @@ func TestEnrichAllRoleFields_NilUserReader(t *testing.T) {
 	err := svc.enrichAllRoleFields(context.Background(), p.Writers, p.Auditors)
 	assert.Error(t, err)
 }
+
+func TestSafeClaimValue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("short value passes through unchanged", func(t *testing.T) {
+		s := "hello"
+		assert.Equal(t, s, safeClaimValue(ctx, s, "test_claim", "invite-1"))
+	})
+
+	t.Run("empty string passes through", func(t *testing.T) {
+		assert.Equal(t, "", safeClaimValue(ctx, "", "test_claim", "invite-1"))
+	})
+
+	t.Run("exactly 1024 bytes passes through", func(t *testing.T) {
+		s := string(make([]byte, 1024))
+		result := safeClaimValue(ctx, s, "test_claim", "invite-1")
+		assert.Equal(t, s, result)
+	})
+
+	t.Run("1025 bytes returns empty string", func(t *testing.T) {
+		s := string(make([]byte, 1025))
+		result := safeClaimValue(ctx, s, "test_claim", "invite-1")
+		assert.Equal(t, "", result, "oversized value must be omitted, not truncated")
+	})
+
+	t.Run("multibyte rune crossing byte 1024 returns empty string", func(t *testing.T) {
+		// Build a string that is exactly 1023 ASCII bytes followed by a 3-byte UTF-8 rune
+		// (U+4E2D '中'). Total length is 1026 bytes — over limit.
+		prefix := string(make([]byte, 1023))
+		s := prefix + "中" // "中" is 3 UTF-8 bytes
+		assert.Greater(t, len(s), 1024)
+		result := safeClaimValue(ctx, s, "test_claim", "invite-1")
+		assert.Equal(t, "", result, "value with multibyte rune crossing the limit must be omitted")
+	})
+}

--- a/docs/invite-application-flows.md
+++ b/docs/invite-application-flows.md
@@ -63,6 +63,19 @@ revoked  ──re-invite──▶ pending  (reinstates existing record)
   - Any other status (`pending`, `declined`, `accepted`) — returns `409 Conflict`.
 - After the invite record is persisted (create or reinstate), the service dispatches a best-effort send-invite request to the invite service (`lfx.invite-service.send_invite`, `dispatchInviteEmail` in `cmd/committee-api/service/committee_service.go`) so the invitee receives an email. The request uses the invite-service permission vocabulary with `role: "Member"` (the committee role on the invite record is applied after acceptance). Dispatch is best-effort: `inviteSender.SendInvite` failures are logged (`failed to dispatch committee invite email` with `error`, `committee_uid`, `invite_uid`) and do not fail the API call. There is no automatic retry of a failed send, and committee-service exposes no dedicated "resend" endpoint. Recovery is via the invite lifecycle: revoke the invite and re-invite the same email (`POST /committees/{uid}/invites`), which reinstates the record and re-triggers `dispatchInviteEmail`.
 
+  The request includes six `CustomClaims` (JWT `map[string]string`) so the BFF ([lfx-self-serve](https://github.com/linuxfoundation/lfx-self-serve)) can accept the invite on LFID registration without a secondary email-indexed fetch:
+
+  | Claim key | Value | Notes |
+  |---|---|---|
+  | `committee_invite_uid` | `invite.UID` | UID of this specific committee invite record; lets the BFF resolve the exact invite without an email query |
+  | `organization_required` | `"true"` / `"false"` | String-formatted bool (Go `map[string]string` constraint); derived from `invite.OrganizationRequired` |
+  | `committee_name` | `invite.CommitteeName` | Used by the BFF as the org-collection dialog header |
+  | `organization_name` | `invite.Organization.Name` | Empty string when `Organization` is nil |
+  | `organization_id` | `invite.Organization.ID` | Salesforce SFID; empty string when `Organization` is nil |
+  | `organization_website` | `invite.Organization.Website` | Empty string when `Organization` is nil |
+
+  All variable-length claims (`committee_name`, `organization_name`, `organization_id`, `organization_website`) are validated against the invite-service's 1024-byte per-claim limit before dispatch. Values that would exceed the limit are omitted (sent as empty string) and a warning is logged — relaying a truncated value is worse than omitting it, because the consumer treats non-empty claims as authoritative. **Note:** these custom claims are only present on invites dispatched via the API (`POST /committees/{uid}/invites`); the NATS-triggered `sendMemberInvite` path does not include them.
+
 **Accepting an invite** (`POST .../accept`):
 - Only the invitee (matched by their primary email from the auth-service) can accept their own invite.
 - Optional body field `organization` replaces the stored invite organization when the payload includes an `id`; otherwise the invite record organization is used as-is (no field-level merging).


### PR DESCRIPTION
## Summary

- Embeds five new custom JWT claims in the LFID invite email alongside the existing `committee_invite_uid`: `organization_required`, `committee_name`, `organization_name`, `organization_id`, and `organization_website`
- These claims let the BFF ([lfx-self-serve PR #298](https://github.com/linuxfoundation/lfx-self-serve/pull/298)) accept committee invites on the new path without a secondary email-indexed invite fetch — eliminating a race with FGA propagation delay
- `CommitteeMemberOrganization` is a pointer so org fields are nil-checked before building the claims map and default to empty strings when no org is pre-filled
- Updates `TestCreateInvite` and `TestCreateInvite_RevokedInviteReinstated` to assert all five new claims are correct

## Ticket

[LFXV2-2677](https://linuxfoundation.atlassian.net/browse/LFXV2-2677)

## Dependencies

`go.mod`/`go.sum` include the `lfx-v2-invite-service` upgrade to `v0.1.10` (released tag, replacing the earlier branch pseudo-version). The `CustomClaims` field on `SendInviteRequest` was added in that release.

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2677]: https://linuxfoundation.atlassian.net/browse/LFXV2-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ