### PR TITLE
[LFXV2-2190, LFXV2-2193] fix: lazy-bind weekly-brief KV buckets and fix query-service version param

### DIFF
--- a/internal/infrastructure/m2m/mailing_list_source.go
+++ b/internal/infrastructure/m2m/mailing_list_source.go
@@ -84,7 +84,7 @@ func (m *MailingListSource) ListMailingListActivityForWindow(ctx context.Context
 	}
 	u.Path = appendPath(u.Path, "/query/resources")
 	q := u.Query()
-	q.Set("version", "1")
+	q.Set("v", "1")
 	q.Set("type", m.cfg.Type)
 	q.Set("tags", "committee:"+committeeUID)
 	q.Set("start_time[gte]", windowStart.UTC().Format(time.RFC3339Nano))

--- a/internal/infrastructure/m2m/mailing_list_source.go
+++ b/internal/infrastructure/m2m/mailing_list_source.go
@@ -84,6 +84,7 @@ func (m *MailingListSource) ListMailingListActivityForWindow(ctx context.Context
 	}
 	u.Path = appendPath(u.Path, "/query/resources")
 	q := u.Query()
+	q.Set("version", "1")
 	q.Set("type", m.cfg.Type)
 	q.Set("tags", "committee:"+committeeUID)
 	q.Set("start_time[gte]", windowStart.UTC().Format(time.RFC3339Nano))

--- a/internal/infrastructure/m2m/meeting_source.go
+++ b/internal/infrastructure/m2m/meeting_source.go
@@ -97,6 +97,7 @@ func (m *MeetingSource) ListMeetingsForWindow(ctx context.Context, committeeUID 
 	}
 	u.Path = appendPath(u.Path, "/query/resources")
 	q := u.Query()
+	q.Set("version", "1")
 	q.Set("type", "v1_past_meeting")
 	q.Set("tags", "committee:"+committeeUID)
 	q.Set("start_time[gte]", windowStart.UTC().Format(time.RFC3339Nano))

--- a/internal/infrastructure/m2m/meeting_source.go
+++ b/internal/infrastructure/m2m/meeting_source.go
@@ -97,7 +97,7 @@ func (m *MeetingSource) ListMeetingsForWindow(ctx context.Context, committeeUID 
 	}
 	u.Path = appendPath(u.Path, "/query/resources")
 	q := u.Query()
-	q.Set("version", "1")
+	q.Set("v", "1")
 	q.Set("type", "v1_past_meeting")
 	q.Set("tags", "committee:"+committeeUID)
 	q.Set("start_time[gte]", windowStart.UTC().Format(time.RFC3339Nano))

--- a/internal/infrastructure/m2m/vote_source.go
+++ b/internal/infrastructure/m2m/vote_source.go
@@ -84,6 +84,7 @@ func (v *VoteSource) ListVoteActivityForWindow(ctx context.Context, committeeUID
 	}
 	u.Path = appendPath(u.Path, "/query/resources")
 	q := u.Query()
+	q.Set("version", "1")
 	q.Set("type", v.cfg.Type)
 	q.Set("tags", "committee:"+committeeUID)
 	q.Set("start_time[gte]", windowStart.UTC().Format(time.RFC3339Nano))

--- a/internal/infrastructure/m2m/vote_source.go
+++ b/internal/infrastructure/m2m/vote_source.go
@@ -84,7 +84,7 @@ func (v *VoteSource) ListVoteActivityForWindow(ctx context.Context, committeeUID
 	}
 	u.Path = appendPath(u.Path, "/query/resources")
 	q := u.Query()
-	q.Set("version", "1")
+	q.Set("v", "1")
 	q.Set("type", v.cfg.Type)
 	q.Set("tags", "committee:"+committeeUID)
 	q.Set("start_time[gte]", windowStart.UTC().Format(time.RFC3339Nano))

--- a/internal/infrastructure/nats/client.go
+++ b/internal/infrastructure/nats/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/linuxfoundation/lfx-v2-committee-service/internal/domain/port"
@@ -25,6 +26,7 @@ import (
 type NATSClient struct {
 	conn     *nats.Conn
 	config   Config
+	kvMu     sync.RWMutex
 	kvStore  map[string]jetstream.KeyValue
 	objStore map[string]jetstream.ObjectStore
 	timeout  time.Duration
@@ -81,6 +83,38 @@ func (c *NATSClient) KeyValueStore(ctx context.Context, bucketName string) error
 	}
 	c.kvStore[bucketName] = kvStore
 	return nil
+}
+
+// GetOrBindKVStore returns the KV handle for bucketName. If the bucket was
+// absent at startup (e.g. a pod that booted before the bucket was provisioned),
+// it attempts to bind on first access so the pod self-heals without a restart.
+func (c *NATSClient) GetOrBindKVStore(ctx context.Context, bucketName string) (jetstream.KeyValue, error) {
+	c.kvMu.RLock()
+	kv, ok := c.kvStore[bucketName]
+	c.kvMu.RUnlock()
+	if ok {
+		return kv, nil
+	}
+
+	c.kvMu.Lock()
+	defer c.kvMu.Unlock()
+	if kv, ok = c.kvStore[bucketName]; ok {
+		return kv, nil
+	}
+	js, err := jetstream.New(c.conn)
+	if err != nil {
+		return nil, errors.NewServiceUnavailable("failed to create JetStream client", err)
+	}
+	kv, err = js.KeyValue(ctx, bucketName)
+	if err != nil {
+		return nil, errors.NewServiceUnavailable(fmt.Sprintf("%s bucket not initialized", bucketName), err)
+	}
+	if c.kvStore == nil {
+		c.kvStore = make(map[string]jetstream.KeyValue)
+	}
+	c.kvStore[bucketName] = kv
+	slog.InfoContext(ctx, "weekly-brief KV bucket bound on first access", "bucket", bucketName)
+	return kv, nil
 }
 
 // ObjectStore creates a JetStream client and gets the object store by name.
@@ -266,27 +300,6 @@ func NewClient(ctx context.Context, config Config) (*NATSClient, error) {
 				"bucket", bucketName,
 			)
 			return nil, errors.NewServiceUnavailable("failed to initialize NATS key-value store", err)
-		}
-		slog.InfoContext(ctx, "NATS key-value store initialized",
-			"bucket", bucketName,
-		)
-	}
-
-	// Weekly-brief buckets are initialized best-effort. If they aren't yet
-	// provisioned (e.g. a rolling deploy where the chart hasn't created them, or
-	// a local NATS without them) the service still starts; only the weekly-brief
-	// endpoints return ServiceUnavailable until the buckets exist.
-	for _, bucketName := range []string{
-		constants.KVBucketNameGroupWeeklyBriefs,
-		constants.KVBucketNameGroupWeeklyBriefUIDIndex,
-		constants.KVBucketNameGroupWeeklyBriefThrottle,
-	} {
-		if err := client.KeyValueStore(ctx, bucketName); err != nil {
-			slog.WarnContext(ctx, "weekly-brief KV bucket not initialized; weekly-brief endpoints will be unavailable until it is provisioned",
-				"error", err,
-				"bucket", bucketName,
-			)
-			continue
 		}
 		slog.InfoContext(ctx, "NATS key-value store initialized",
 			"bucket", bucketName,

--- a/internal/infrastructure/nats/client.go
+++ b/internal/infrastructure/nats/client.go
@@ -24,12 +24,13 @@ import (
 
 // NATSClient wraps the NATS connection and provides access control operations
 type NATSClient struct {
-	conn     *nats.Conn
-	config   Config
-	kvMu     sync.RWMutex
-	kvStore  map[string]jetstream.KeyValue
-	objStore map[string]jetstream.ObjectStore
-	timeout  time.Duration
+	conn        *nats.Conn
+	config      Config
+	kvMu        sync.RWMutex
+	kvStore     map[string]jetstream.KeyValue
+	kvStoreLazy map[string]jetstream.KeyValue
+	objStore    map[string]jetstream.ObjectStore
+	timeout     time.Duration
 }
 
 // NATSClientInterface defines the interface for NATS operations
@@ -88,19 +89,22 @@ func (c *NATSClient) KeyValueStore(ctx context.Context, bucketName string) error
 // GetOrBindKVStore returns the KV handle for bucketName. If the bucket was
 // absent at startup (e.g. a pod that booted before the bucket was provisioned),
 // it attempts to bind on first access so the pod self-heals without a restart.
+//
+// Lazy handles are kept in kvStoreLazy, separate from the startup-populated
+// kvStore. kvStore is written only during NewClient (single-threaded) so the
+// 50+ call sites that read it directly remain race-free. kvStoreLazy is always
+// accessed under kvMu. The NATS bind call itself runs outside the lock so
+// concurrent cache-hit lookups are never blocked by an in-flight bind.
 func (c *NATSClient) GetOrBindKVStore(ctx context.Context, bucketName string) (jetstream.KeyValue, error) {
 	c.kvMu.RLock()
-	kv, ok := c.kvStore[bucketName]
+	kv, ok := c.kvStoreLazy[bucketName]
 	c.kvMu.RUnlock()
 	if ok {
 		return kv, nil
 	}
 
-	c.kvMu.Lock()
-	defer c.kvMu.Unlock()
-	if kv, ok = c.kvStore[bucketName]; ok {
-		return kv, nil
-	}
+	// Bind outside the lock — js.KeyValue is a network call and must not hold
+	// kvMu while it waits, which would block concurrent cache-hit lookups.
 	js, err := jetstream.New(c.conn)
 	if err != nil {
 		return nil, errors.NewServiceUnavailable("failed to create JetStream client", err)
@@ -109,10 +113,16 @@ func (c *NATSClient) GetOrBindKVStore(ctx context.Context, bucketName string) (j
 	if err != nil {
 		return nil, errors.NewServiceUnavailable(fmt.Sprintf("%s bucket not initialized", bucketName), err)
 	}
-	if c.kvStore == nil {
-		c.kvStore = make(map[string]jetstream.KeyValue)
+
+	c.kvMu.Lock()
+	defer c.kvMu.Unlock()
+	if existing, ok := c.kvStoreLazy[bucketName]; ok {
+		return existing, nil
 	}
-	c.kvStore[bucketName] = kv
+	if c.kvStoreLazy == nil {
+		c.kvStoreLazy = make(map[string]jetstream.KeyValue)
+	}
+	c.kvStoreLazy[bucketName] = kv
 	slog.InfoContext(ctx, "weekly-brief KV bucket bound on first access", "bucket", bucketName)
 	return kv, nil
 }

--- a/internal/infrastructure/nats/group_weekly_brief_storage.go
+++ b/internal/infrastructure/nats/group_weekly_brief_storage.go
@@ -47,9 +47,9 @@ func (s *storage) GetGroupWeeklyBriefForWindow(ctx context.Context, committeeUID
 	// WindowStart; the rest of the fields are unused.
 	indexKey := buildBriefIndexKey(committeeUID, model.WindowDateKey(windowStart.WindowStart))
 
-	idxBucket, ok := s.client.kvStore[constants.KVBucketNameGroupWeeklyBriefUIDIndex]
-	if !ok {
-		return nil, nil, errs.NewServiceUnavailable("group-weekly-brief-uid-index bucket not initialized")
+	idxBucket, err := s.client.GetOrBindKVStore(ctx, constants.KVBucketNameGroupWeeklyBriefUIDIndex)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	entry, err := idxBucket.Get(ctx, indexKey)
@@ -64,9 +64,9 @@ func (s *storage) GetGroupWeeklyBriefForWindow(ctx context.Context, committeeUID
 		return nil, nil, nil
 	}
 
-	briefBucket, ok := s.client.kvStore[constants.KVBucketNameGroupWeeklyBriefs]
-	if !ok {
-		return nil, nil, errs.NewServiceUnavailable("group-weekly-briefs bucket not initialized")
+	briefBucket, err := s.client.GetOrBindKVStore(ctx, constants.KVBucketNameGroupWeeklyBriefs)
+	if err != nil {
+		return nil, nil, err
 	}
 	briefEntry, errGet := briefBucket.Get(ctx, sanitizeKVKey(briefUID))
 	if errGet != nil {
@@ -107,7 +107,7 @@ func (s *storage) GetGroupWeeklyBriefForWindow(ctx context.Context, committeeUID
 	// Best-effort throttle lookup. Misses and errors don't fail the read —
 	// throttle is advisory metadata.
 	var throttleBytes []byte
-	if thBucket, ok := s.client.kvStore[constants.KVBucketNameGroupWeeklyBriefThrottle]; ok {
+	if thBucket, err := s.client.GetOrBindKVStore(ctx, constants.KVBucketNameGroupWeeklyBriefThrottle); err == nil {
 		thEntry, thErr := thBucket.Get(ctx, indexKey)
 		switch {
 		case thErr == nil:
@@ -153,13 +153,13 @@ func (s *storage) PutGroupWeeklyBrief(ctx context.Context, brief *model.GroupWee
 	}
 	brief.UpdatedAt = now
 
-	briefBucket, ok := s.client.kvStore[constants.KVBucketNameGroupWeeklyBriefs]
-	if !ok {
-		return nil, errs.NewServiceUnavailable("group-weekly-briefs bucket not initialized")
+	briefBucket, err := s.client.GetOrBindKVStore(ctx, constants.KVBucketNameGroupWeeklyBriefs)
+	if err != nil {
+		return nil, err
 	}
-	idxBucket, ok := s.client.kvStore[constants.KVBucketNameGroupWeeklyBriefUIDIndex]
-	if !ok {
-		return nil, errs.NewServiceUnavailable("group-weekly-brief-uid-index bucket not initialized")
+	idxBucket, err := s.client.GetOrBindKVStore(ctx, constants.KVBucketNameGroupWeeklyBriefUIDIndex)
+	if err != nil {
+		return nil, err
 	}
 
 	payload, err := json.Marshal(brief)
@@ -211,9 +211,9 @@ func (s *storage) PutGroupWeeklyBrief(ctx context.Context, brief *model.GroupWee
 // GetGroupWeeklyBriefThrottle returns the throttle entry for the given
 // (committee, window-start) pair. A miss returns (nil, nil).
 func (s *storage) GetGroupWeeklyBriefThrottle(ctx context.Context, committeeUID string, windowStart time.Time) (*model.GroupWeeklyBriefThrottle, error) {
-	thBucket, ok := s.client.kvStore[constants.KVBucketNameGroupWeeklyBriefThrottle]
-	if !ok {
-		return nil, errs.NewServiceUnavailable("group-weekly-brief-throttle bucket not initialized")
+	thBucket, err := s.client.GetOrBindKVStore(ctx, constants.KVBucketNameGroupWeeklyBriefThrottle)
+	if err != nil {
+		return nil, err
 	}
 	key := buildBriefIndexKey(committeeUID, model.WindowDateKey(windowStart))
 	entry, err := thBucket.Get(ctx, key)
@@ -245,9 +245,9 @@ func (s *storage) PutGroupWeeklyBriefThrottle(ctx context.Context, throttle *mod
 	if throttle.WindowStart.IsZero() {
 		return nil, errs.NewValidation("window_start is required")
 	}
-	thBucket, ok := s.client.kvStore[constants.KVBucketNameGroupWeeklyBriefThrottle]
-	if !ok {
-		return nil, errs.NewServiceUnavailable("group-weekly-brief-throttle bucket not initialized")
+	thBucket, err := s.client.GetOrBindKVStore(ctx, constants.KVBucketNameGroupWeeklyBriefThrottle)
+	if err != nil {
+		return nil, err
 	}
 
 	payload, err := json.Marshal(throttle)


### PR DESCRIPTION
## Summary

- Replaces the one-shot best-effort startup loop for weekly-brief KV buckets with a `GetOrBindKVStore` method that binds on first request access under a `RWMutex`
- Pods that started before the buckets were provisioned now self-heal on the first incoming request instead of returning 503 for their entire lifetime
- Removes the need for a manual rolling restart to recover from the startup race condition
- Adds missing `version=1` query parameter to all three m2m source clients (meetings, mailing lists, votes); the query-service requires this param and was returning HTTP 400, causing NATS to exhaust `MaxDeliver:3` and orphan every brief permanently in `generating` state

## How it works

`GetOrBindKVStore` uses a double-checked locking pattern: read-lock fast path for the common case (bucket already bound), write-lock slow path for first-access binding. Once bound, subsequent requests take the fast path. The throttle bucket in `GetGroupWeeklyBriefForWindow` retains its best-effort semantics — a bind failure there is still silently skipped since throttle data is advisory.

## Tickets

[LFXV2-2190](https://linuxfoundation.atlassian.net/browse/LFXV2-2190) — committee-service: GET weekly-briefs/current 503s "bucket not initialized" though bucket exists + writes persist (read-path bug)

[LFXV2-2193](https://linuxfoundation.atlassian.net/browse/LFXV2-2193) — committee-service: weekly brief stuck in "generating" state; all source fetches returning 400 due to missing version=1 query param

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2190]: https://linuxfoundation.atlassian.net/browse/LFXV2-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ