### PR TITLE
[LFXV2-2690] feat(chart): use inviter relation for committee invite creation

### DIFF
--- a/charts/lfx-v2-committee-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-committee-service/templates/ruleset.yaml
@@ -469,7 +469,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: writer
+              relation: inviter
               object: "committee:{{ "{{- .Request.URL.Captures.uid -}}" }}"
         {{- else }}
         - authorizer: allow_all


### PR DESCRIPTION
## Summary

- Update the Heimdall ruleset for `POST /committees/:uid/invites` to check the `inviter` relation instead of `writer`
- The `inviter` relation (defined in the platform FGA model) covers members, auditors, and writers — allowing any committee member to send invites in invite-only join mode

## Ticket

[LFXV2-2690](https://linuxfoundation.atlassian.net/browse/LFXV2-2690)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-2690]: https://linuxfoundation.atlassian.net/browse/LFXV2-2690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ